### PR TITLE
Fix meson error: ‘for’ loop initial declarations are only allowed in …

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('scrcpy', 'c', meson_version: '>= 0.37')
+project('scrcpy', 'c', meson_version: '>= 0.37', default_options : 'c_std=c99')
 
 if get_option('build_app')
     subdir('app')


### PR DESCRIPTION
…C99 mode.