### PR TITLE
Return specific error for missing adb binary on Windows

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -319,5 +319,10 @@ int main(int argc, char *argv[]) {
 
     avformat_network_deinit(); // ignore failure
 
+#if defined (__WINDOWS__) && ! defined (WINDOWS_NOCONSOLE)
+    if (res != 0) {
+        system("pause");
+    }
+#endif
     return res;
 }

--- a/app/src/sys/win/command.c
+++ b/app/src/sys/win/command.c
@@ -29,7 +29,11 @@ enum process_result cmd_execute(const char *path, const char *const argv[], HAND
 #endif
     if (!CreateProcess(NULL, cmd, NULL, NULL, FALSE, flags, NULL, NULL, &si, &pi)) {
         *handle = NULL;
-        return PROCESS_ERROR_GENERIC;
+        if (GetLastError() == ERROR_FILE_NOT_FOUND) {
+            return PROCESS_ERROR_MISSING_BINARY;
+        } else {
+            return PROCESS_ERROR_GENERIC;
+        }
     }
 
     *handle = pi.hProcess;


### PR DESCRIPTION
Hi, @rom1v 

Windows has `GetLastError()` to show what happen when `CreateProcess()` failed.

Reference:
* [CreateProcess](https://docs.microsoft.com/en-us/windows/desktop/api/processthreadsapi/nf-processthreadsapi-createprocessa)
* [GetLastError](https://msdn.microsoft.com/zh-tw/library/windows/desktop/ms679360(v=vs.85).aspx)
* [Error code](https://docs.microsoft.com/zh-tw/windows/desktop/Debug/system-error-codes--0-499-)

In this series, I also prevent console closing immediately when error occurs by adding `pause` in windows console mode. It helps to show error message to user.

Related pr: #236.

Thanks.