### PR TITLE
Desktop entry file for Linux app launchers (resolves #295)

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -143,6 +143,12 @@ endif
 
 executable('scrcpy', src, dependencies: dependencies, include_directories: src_dir, install: true, c_args: c_args, link_args: link_args)
 
+# Desktop entry file for application launchers
+if host_machine.system() == 'linux'
+    # -> /usr/share/applications/scrcpy.desktop
+    install_data('scrcpy.desktop', install_dir : join_paths(get_option('datadir'), 'applications'))
+endif
+
 
 ### TESTS
 

--- a/app/scrcpy.desktop
+++ b/app/scrcpy.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=scrcpy
+GenericName=Android Remote Control
+Comment=Display and control your Android device
+Exec=scrcpy
+Icon=gparted
+Terminal=false
+Type=Application
+Categories=Utility;RemoteAccess;
+StartupNotify=false


### PR DESCRIPTION
Adds the ability to launch scrcpy using your preferred application launcher on Linux.

See: https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html