### PR TITLE
fix text memory leak

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -144,6 +144,7 @@ void input_manager_process_text_input(struct input_manager *input_manager,
         return;
     }
     if (!controller_push_event(input_manager->controller, &control_event)) {
+        SDL_free(control_event.text_event.text);
         LOGW("Cannot send text event");
     }
 }


### PR DESCRIPTION
In this time, the text will be freed only when queue is destroyed.
However, the queue is rotated very quickly. The text event may be
rotated out. It causes memory leak on text. Simply free text when
we used.

In additional, fix a potential memory leak when controller_push_event
failed.

Signed-off-by: yuchenlin <npes87184@gmail.com>