### PR TITLE
prepare-dep: use variable for better readability

### DIFF
--- a/prebuilt-deps/prepare-dep
+++ b/prebuilt-deps/prepare-dep
@@ -55,4 +55,4 @@ get_dep() {
     fi
 }
 
-get_dep "$1" "$2" "$3"
+get_dep "$url" "$sum" "$dir"


### PR DESCRIPTION
The arguments are saved to variable when script started. Instead of
using $1, $2 and $3, we can use these variables.

Signed-off-by: yuchenlin <npes87184@gmail.com>