### PR TITLE
input_manager: don't ignore double click event when clicking inside device

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -295,8 +295,8 @@ void input_manager_process_mouse_button(struct input_manager *input_manager,
                                                        event->y);
             if (outside) {
                 screen_resize_to_fit(input_manager->screen);
+                return;
             }
-            return;
         }
         // otherwise, send the click event to the device
     }


### PR DESCRIPTION
Fix the regression from [fefb9816a99e](https://github.com/Genymobile/scrcpy/commit/fefb9816a99e6f8fa59befcfb70ba87112f90a8d).

Thanks

