### PR TITLE
app: add always_on_top

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,16 @@ scrcpy -f  # short version
 Fullscreen can then be toggled dynamically with `Ctrl`+`f`.
 
 
+### Always on top
+
+The window of app can always be above others by:
+
+```bash
+scrcpy --always-on-top
+scrcpy -T  # short version
+```
+
+
 ### Show touches
 
 For presentations, it may be useful to show physical touches (on the physical

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -19,6 +19,7 @@ struct args {
     Uint16 port;
     Uint16 max_size;
     Uint32 bit_rate;
+    SDL_bool always_on_top;
 };
 
 static void usage(const char *arg0) {
@@ -64,6 +65,9 @@ static void usage(const char *arg0) {
         "    -t, --show-touches\n"
         "        Enable \"show touches\" on start, disable on quit.\n"
         "        It only shows physical touches (not clicks from scrcpy).\n"
+        "\n"
+        "    -T, --always-on-top\n"
+        "        Make scrcpy window always on top (above other windows).\n"
         "\n"
         "    -v, --version\n"
         "        Print the version of scrcpy.\n"
@@ -206,20 +210,21 @@ static SDL_bool parse_port(char *optarg, Uint16 *port) {
 
 static SDL_bool parse_args(struct args *args, int argc, char *argv[]) {
     static const struct option long_options[] = {
-        {"bit-rate",     required_argument, NULL, 'b'},
-        {"crop",         required_argument, NULL, 'c'},
-        {"fullscreen",   no_argument,       NULL, 'f'},
-        {"help",         no_argument,       NULL, 'h'},
-        {"max-size",     required_argument, NULL, 'm'},
-        {"port",         required_argument, NULL, 'p'},
-        {"record",       required_argument, NULL, 'r'},
-        {"serial",       required_argument, NULL, 's'},
-        {"show-touches", no_argument,       NULL, 't'},
-        {"version",      no_argument,       NULL, 'v'},
-        {NULL,           0,                 NULL, 0  },
+        {"always-on-top", no_argument,       NULL, 'T'},
+        {"bit-rate",      required_argument, NULL, 'b'},
+        {"crop",          required_argument, NULL, 'c'},
+        {"fullscreen",    no_argument,       NULL, 'f'},
+        {"help",          no_argument,       NULL, 'h'},
+        {"max-size",      required_argument, NULL, 'm'},
+        {"port",          required_argument, NULL, 'p'},
+        {"record",        required_argument, NULL, 'r'},
+        {"serial",        required_argument, NULL, 's'},
+        {"show-touches",  no_argument,       NULL, 't'},
+        {"version",       no_argument,       NULL, 'v'},
+        {NULL,            0,                 NULL, 0  },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "b:c:fhm:p:r:s:tv", long_options, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "b:c:fhm:p:r:s:tTv", long_options, NULL)) != -1) {
         switch (c) {
             case 'b':
                 if (!parse_bit_rate(optarg, &args->bit_rate)) {
@@ -253,6 +258,9 @@ static SDL_bool parse_args(struct args *args, int argc, char *argv[]) {
                 break;
             case 't':
                 args->show_touches = SDL_TRUE;
+                break;
+            case 'T':
+                args->always_on_top = SDL_TRUE;
                 break;
             case 'v':
                 args->version = SDL_TRUE;
@@ -288,6 +296,7 @@ int main(int argc, char *argv[]) {
         .port = DEFAULT_LOCAL_PORT,
         .max_size = DEFAULT_MAX_SIZE,
         .bit_rate = DEFAULT_BIT_RATE,
+        .always_on_top = SDL_FALSE,
     };
     if (!parse_args(&args, argc, argv)) {
         return 1;
@@ -324,6 +333,7 @@ int main(int argc, char *argv[]) {
         .bit_rate = args.bit_rate,
         .show_touches = args.show_touches,
         .fullscreen = args.fullscreen,
+        .always_on_top = args.always_on_top,
     };
     int res = scrcpy(&options) ? 0 : 1;
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -223,7 +223,7 @@ SDL_bool scrcpy(const struct scrcpy_options *options) {
         goto finally_destroy_controller;
     }
 
-    if (!screen_init_rendering(&screen, device_name, frame_size)) {
+    if (!screen_init_rendering(&screen, device_name, frame_size, options->always_on_top)) {
         ret = SDL_FALSE;
         goto finally_stop_and_join_controller;
     }

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -12,6 +12,7 @@ struct scrcpy_options {
     Uint32 bit_rate;
     SDL_bool show_touches;
     SDL_bool fullscreen;
+    SDL_bool always_on_top;
 };
 
 SDL_bool scrcpy(const struct scrcpy_options *options);

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -144,7 +144,10 @@ static inline SDL_Texture *create_texture(SDL_Renderer *renderer, struct size fr
                              frame_size.width, frame_size.height);
 }
 
-SDL_bool screen_init_rendering(struct screen *screen, const char *device_name, struct size frame_size) {
+SDL_bool screen_init_rendering(struct screen *screen,
+                               const char *device_name,
+                               struct size frame_size,
+                               SDL_bool always_on_top) {
     screen->frame_size = frame_size;
 
     struct size window_size = get_initial_optimal_size(frame_size);
@@ -152,6 +155,10 @@ SDL_bool screen_init_rendering(struct screen *screen, const char *device_name, s
 #ifdef HIDPI_SUPPORT
     window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 #endif
+    if (always_on_top) {
+        window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
+    }
+
     screen->window = SDL_CreateWindow(device_name, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED,
                                       window_size.width, window_size.height, window_flags);
     if (!screen->window) {

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -43,7 +43,8 @@ void screen_init(struct screen *screen);
 // initialize screen, create window, renderer and texture (window is hidden)
 SDL_bool screen_init_rendering(struct screen *screen,
                                const char *device_name,
-                               struct size frame_size);
+                               struct size frame_size,
+                               SDL_bool always_on_top);
 
 // show the window
 void screen_show_window(struct screen *screen);


### PR DESCRIPTION
Fix #391 

It is very convenient when I play mobile game and watch video at the
same time.

Tested on Linux mint Cinnamon as well as Windows 10.

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>