### PR TITLE
server/meson.build: support relative path for prebuilt_server

### DIFF
--- a/server/meson.build
+++ b/server/meson.build
@@ -10,6 +10,10 @@ if prebuilt_server == ''
                   install: true,
                   install_dir: 'share/scrcpy')
 else
+    if not prebuilt_server.startswith('/')
+        # relative path needs some trick
+        prebuilt_server = meson.source_root() + '/' + prebuilt_server
+    endif
     custom_target('scrcpy-server-prebuilt',
                   input: prebuilt_server,
                   output: 'scrcpy-server.jar',


### PR DESCRIPTION
If we don't do this trick, the prebuilt_server will be
../server/[the_user_defined_path]. In general, we will not give an relative path
based on build directory, which leads to wrong prebuilt_server path.

The building error:

ninja: error: '../scrcpy-server-v1.7.jar', needed by
'server/scrcpy-server.jar', missing and no known rule to make it

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>