### PR TITLE
Remove deprecated Arch Linux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,7 @@ control it using keyboard and mouse.
 On Linux, you typically need to [build the app manually][BUILD]. Don't worry,
 it's not that hard.
 
-For Arch Linux, two [AUR] packages have been created by users:
-
- - [`scrcpy`](https://aur.archlinux.org/packages/scrcpy/)
- - [`scrcpy-prebuiltserver`](https://aur.archlinux.org/packages/scrcpy-prebuiltserver/)
+For Arch Linux, an [AUR] package is available: [`scrcpy`](https://aur.archlinux.org/packages/scrcpy/)
 
 [AUR]: https://wiki.archlinux.org/index.php/Arch_User_Repository
 


### PR DESCRIPTION
The `scrcpy-prebuiltserver` has been deprecated in favor of the `scrcpy` package.

https://aur.archlinux.org/cgit/aur.git/commit/?h=scrcpy-prebuiltserver&id=2ef4359b2e45fc278a191fae014d381b486ffcfe
