### PR TITLE
Fix for issue #316 - failed build on LWS (Linux Windows Subsystem)

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <libavformat/avformat.h>
+#define SDL_MAIN_HANDLED
 #include <SDL2/SDL.h>
 
 #include "compat.h"

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -71,8 +71,9 @@ public class ScreenEncoder implements Device.RotationListener {
                 codec.start();
                 try {
                     alive = encode(codec, fd);
-                } finally {
+                    // do not call stop() on exception, it would trigger an IllegalStateException
                     codec.stop();
+                } finally {
                     destroyDisplay(display);
                     codec.release();
                     surface.release();


### PR DESCRIPTION
Fix for issue #316 - failed build on LWS (Linux Windows Subsystem) because of lack of reference to WinMain@16 during linking