### PR TITLE
Disable X11 compositor bypass

### DIFF
--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -43,4 +43,9 @@
 # define SCRCPY_SDL_HAS_WINDOW_ALWAYS_ON_TOP
 #endif
 
+#if SDL_VERSION_ATLEAST(2, 0, 8)
+// <https://hg.libsdl.org/SDL/rev/dfde5d3f9781>
+# define SCRCPY_SDL_HAS_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
+#endif
+
 #endif

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -9,6 +9,7 @@
 
 #include "command.h"
 #include "common.h"
+#include "compat.h"
 #include "controller.h"
 #include "decoder.h"
 #include "device.h"
@@ -65,6 +66,13 @@ sdl_init_and_configure(bool display) {
     // Handle a click to gain focus as any other click
     if (!SDL_SetHint(SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1")) {
         LOGW("Could not enable mouse focus clickthrough");
+    }
+#endif
+
+#ifdef SCRCPY_SDL_HAS_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
+    // Disable compositor bypassing on X11
+    if (!SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "0")) {
+        LOGW("Could not disable X11 compositor bypass");
     }
 #endif
 


### PR DESCRIPTION
Compositor bypass is meant for fullscreen games consuming lots of GPU resources. For a light app that will usually be windowed, this only causes unnecessary compositor suspends, especially visible (and annoying) with complying window manager like KWin.

As an added bonus, mouse focus clickthrough is fixed as it didn't work due to compat.h header not being included in scrcpy.c