### PR TITLE
Return success count in injectText

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/EventController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/EventController.java
@@ -104,13 +104,15 @@ public class EventController {
         return true;
     }
 
-    private boolean injectText(String text) {
+    private int injectText(String text) {
+        int successCount = 0;
         for (char c : text.toCharArray()) {
             if (!injectChar(c)) {
-                return false;
+                continue;
             }
+            successCount++;
         }
-        return true;
+        return successCount;
     }
 
     private boolean injectMouse(int action, int buttons, Position position) {


### PR DESCRIPTION
It will insert as many text as possible now.
Fix #509, tested on Windows 10 and Arch Linux.

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>