### PR TITLE
server/meson.build: Prevent using input field for directory

### DIFF
--- a/server/meson.build
+++ b/server/meson.build
@@ -4,9 +4,8 @@ prebuilt_server = get_option('prebuilt_server')
 if prebuilt_server == ''
     custom_target('scrcpy-server',
                   build_always: true,  # gradle is responsible for tracking source changes
-                  input: '.',
                   output: 'scrcpy-server.jar',
-                  command: [find_program('./scripts/build-wrapper.sh'), '@INPUT@', '@OUTPUT@', get_option('buildtype')],
+                  command: [find_program('./scripts/build-wrapper.sh'), meson.current_source_dir(), '@OUTPUT@', get_option('buildtype')],
                   install: true,
                   install_dir: 'share/scrcpy')
 else


### PR DESCRIPTION
This will fix build warning in newer meson.
Fix #540.

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>