### PR TITLE
Correct return value type in handle_event

### DIFF
--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -132,7 +132,7 @@ handle_event(SDL_Event *event, bool control) {
                 screen_show_window(&screen);
             }
             if (!screen_update_frame(&screen, &video_buffer)) {
-                return false;
+                return EVENT_RESULT_CONTINUE;
             }
             break;
         case SDL_WINDOWEVENT:


### PR DESCRIPTION
handle_event return the type enum event_result not bool

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>