### PR TITLE
Fix some minor things

### DIFF
--- a/app/src/command.h
+++ b/app/src/command.h
@@ -74,6 +74,6 @@ adb_install(const char *serial, const char *local);
 // convenience function to wait for a successful process execution
 // automatically log process errors with the provided process name
 bool
-process_check_success(process_t process, const char *name);
+process_check_success(process_t proc, const char *name);
 
 #endif

--- a/app/src/device.h
+++ b/app/src/device.h
@@ -11,6 +11,6 @@
 
 // name must be at least DEVICE_NAME_FIELD_LENGTH bytes
 bool
-device_read_info(socket_t device_socket, char *name, struct size *frame_size);
+device_read_info(socket_t device_socket, char *device_name, struct size *size);
 
 #endif

--- a/app/src/net.c
+++ b/app/src/net.c
@@ -33,6 +33,7 @@ net_connect(uint32_t addr, uint16_t port) {
 
     if (connect(sock, (SOCKADDR *) &sin, sizeof(sin)) == SOCKET_ERROR) {
         perror("connect");
+        close(sock);
         return INVALID_SOCKET;
     }
 
@@ -60,11 +61,13 @@ net_listen(uint32_t addr, uint16_t port, int backlog) {
 
     if (bind(sock, (SOCKADDR *) &sin, sizeof(sin)) == SOCKET_ERROR) {
         perror("bind");
+        close(sock);
         return INVALID_SOCKET;
     }
 
     if (listen(sock, backlog) == SOCKET_ERROR) {
         perror("listen");
+        close(sock);
         return INVALID_SOCKET;
     }
 

--- a/app/src/recorder.h
+++ b/app/src/recorder.h
@@ -20,7 +20,7 @@ struct recorder {
 };
 
 bool
-recorder_init(struct recorder *recoder, const char *filename,
+recorder_init(struct recorder *recorder, const char *filename,
               enum recorder_format format, struct size declared_frame_size);
 
 void


### PR DESCRIPTION
1. I make the variable name the same in implementation and definition. One of it is typo. 
2. Prevent socket opening when failed.