### PR TITLE
Add option to set the window title with the serial number

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -28,6 +28,7 @@ struct args {
     uint16_t max_size;
     uint32_t bit_rate;
     bool always_on_top;
+    bool window_serial;
 };
 
 static void usage(const char *arg0) {
@@ -91,6 +92,9 @@ static void usage(const char *arg0) {
         "\n"
         "    -v, --version\n"
         "        Print the version of scrcpy.\n"
+        "\n"
+        "    -w, --window-serial\n"
+        "        Set the Window Title with the serial number.\n"
         "\n"
         "Shortcuts:\n"
         "\n"
@@ -291,10 +295,11 @@ parse_args(struct args *args, int argc, char *argv[]) {
         {"serial",        required_argument, NULL, 's'},
         {"show-touches",  no_argument,       NULL, 't'},
         {"version",       no_argument,       NULL, 'v'},
+        {"window-serial", no_argument,       NULL, 'w'},
         {NULL,            0,                 NULL, 0  },
     };
     int c;
-    while ((c = getopt_long(argc, argv, "b:c:fF:hm:nNp:r:s:tTv", long_options,
+    while ((c = getopt_long(argc, argv, "b:c:fF:hm:nNp:r:s:tTv:w", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 'b':
@@ -346,6 +351,9 @@ parse_args(struct args *args, int argc, char *argv[]) {
                 break;
             case 'v':
                 args->version = true;
+                break;
+            case 'w':
+                args->window_serial = true;
                 break;
             default:
                 // getopt prints the error message on stderr
@@ -448,6 +456,7 @@ main(int argc, char *argv[]) {
         .always_on_top = args.always_on_top,
         .no_control = args.no_control,
         .no_display = args.no_display,
+        .window_serial = args.window_serial,
     };
     int res = scrcpy(&options) ? 0 : 1;
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -365,8 +365,8 @@ scrcpy(const struct scrcpy_options *options) {
             }
         }
 
-        if (!screen_init_rendering(&screen, device_name, frame_size,
-                                   options->always_on_top)) {
+        if (!screen_init_rendering(&screen, ((options->serial && options->window_serial) ? options->serial : device_name),
+                                   frame_size, options->always_on_top)) {
             ret = false;
             goto finally_stop_and_join_controller;
         }

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -18,6 +18,7 @@ struct scrcpy_options {
     bool always_on_top;
     bool no_control;
     bool no_display;
+    bool window_serial;
 };
 
 bool


### PR DESCRIPTION
I have multiple devices with the same model name.  Setting this window title with a different name is really useful.

Fixes #120 