### PR TITLE
a spell mistake

### DIFF
--- a/app/src/server.c
+++ b/app/src/server.c
@@ -15,7 +15,7 @@
 #define SOCKET_NAME "scrcpy"
 #define SERVER_FILENAME "scrcpy-server.jar"
 
-#define DEFAULT_SERVER_PATH PREFIX "/share/scrcpy/" SERVER_FLENAME
+#define DEFAULT_SERVER_PATH PREFIX "/share/scrcpy/" SERVER_FILENAME
 #define DEVICE_SERVER_PATH "/data/local/tmp/" SERVER_FILENAME
 
 static const char *


### PR DESCRIPTION
after commented default portable option in `app/meson.build` get some error and then find this. : )