### PR TITLE
Use getPhysicalDisplayToken if getBuiltInDisplay is not found

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/SurfaceControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/SurfaceControl.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy.wrappers;
 
 import android.annotation.SuppressLint;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.IBinder;
 import android.view.Surface;
 
@@ -77,7 +78,13 @@ public final class SurfaceControl {
 
     public static IBinder getBuiltInDisplay(int builtInDisplayId) {
         try {
-            return (IBinder) CLASS.getMethod("getBuiltInDisplay", int.class).invoke(null, builtInDisplayId);
+            // Android Q does not have this method anymore but has a
+            // replacement.
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                return (IBinder) CLASS.getMethod("getBuiltInDisplay", int.class).invoke(null, builtInDisplayId);
+            } else {
+                return (IBinder) CLASS.getMethod("getPhysicalDisplayToken", long.class).invoke(null, builtInDisplayId);
+            }
         } catch (Exception e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
This makes the -S (screen off) parameter work on Android Q beta 4

Closes #586