### PR TITLE
The Java JDK is needed to build the server

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -70,7 +70,7 @@ sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-rele
 sudo dnf install SDL2-devel ffms2-devel meson gcc make
 
 # server build dependencies
-sudo dnf install java
+sudo dnf install java-devel
 ```
 
 


### PR DESCRIPTION
The relevant Fedora package is java-devel and not java