### PR TITLE
Fix building on OS X (missing NULL in queue.h)

### DIFF
--- a/app/src/queue.h
+++ b/app/src/queue.h
@@ -3,6 +3,7 @@
 #define QUEUE_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <SDL2/SDL_assert.h>
 
 // To define a queue type of "struct foo":


### PR DESCRIPTION
Headers seem to be a bit different in Apple land and you need to include
stddef.h explicitly to the NULL declaration.

This also makes the code a bit more correct, as stddef.h is the header
in the C standard that defines NULL
(https://en.cppreference.com/w/cpp/header/cstddef).