### PR TITLE
BUILD docs: add a command to go back to the parent directory, so that…

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -197,6 +197,7 @@ Then, build:
 meson x --buildtype release --strip -Db_lto=true
 cd x
 ninja
+cd ..
 ```
 
 _Note: `ninja` [must][ninja-user] be run as a non-root user (only `ninja


### PR DESCRIPTION
… the next command on the page ("./run") works (for absent-minded people like me who will try "run" from within "x")