### PR TITLE
fix for resizing HIDPI MacOS windows

### DIFF
--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -144,8 +144,13 @@ handle_event(SDL_Event *event, bool control) {
             break;
         case SDL_WINDOWEVENT:
             switch (event->window.event) {
-                case SDL_WINDOWEVENT_EXPOSED:
                 case SDL_WINDOWEVENT_SIZE_CHANGED:
+#ifdef HIDPI_SUPPORT
+                    LOGD("Reinitializing renderer");
+                    screen_init_renderer_and_texture(&screen);
+#endif
+                    // fall-through no break
+                case SDL_WINDOWEVENT_EXPOSED:
                     screen_render(&screen);
                     break;
             }

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -146,8 +146,10 @@ handle_event(SDL_Event *event, bool control) {
             switch (event->window.event) {
                 case SDL_WINDOWEVENT_SIZE_CHANGED:
 #ifdef HIDPI_SUPPORT
-                    LOGD("Reinitializing renderer");
-                    screen_init_renderer_and_texture(&screen);
+                    if (!screen_test_correct_hidpi_ratio(&screen)) {
+                      LOGW("Reinitializing renderer due to incorrect hidpi ratio");
+                      screen_init_renderer_and_texture(&screen);
+                    }
 #endif
                     // fall-through no break
                 case SDL_WINDOWEVENT_EXPOSED:

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -20,6 +20,15 @@ struct screen {
     bool has_frame;
     bool fullscreen;
     bool no_window;
+#ifdef HIDPI_SUPPORT
+    // these values store the ratio between renderer pixel size and window size
+    // in most configurations these ratios would be 1.0 (1000), but on MacOS with
+    // a Retina/HIDPI monitor connected they are 2.0 (2000) because that's how
+    // Apple chose to maintain compatibility with legacy apps, by pretending that
+    // that the screen has half of its real resolution.
+    int expected_hidpi_w_factor; // multiplied by 1000 to avoid float
+    int expected_hidpi_h_factor; // multiplied by 1000 to avoid float
+#endif
 };
 
 #define SCREEN_INITIALIZER {  \
@@ -47,6 +56,15 @@ screen_init(struct screen *screen);
 bool
 screen_init_rendering(struct screen *screen, const char *window_title,
                       struct size frame_size, bool always_on_top);
+
+#ifdef HIDPI_SUPPORT
+// test if the expected renderer to window ratio is correct
+// used to work around SDL bugs
+// returns true if correct.
+// If it returns false the renderer state needs to be fixed
+bool
+screen_test_correct_hidpi_ratio(struct screen *screen);
+#endif
 
 // reinitialize the renderer (only used in some configurations
 // if necessary to workaround SDL bugs)

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -48,6 +48,11 @@ bool
 screen_init_rendering(struct screen *screen, const char *window_title,
                       struct size frame_size, bool always_on_top);
 
+// reinitialize the renderer (only used in some configurations
+// if necessary to workaround SDL bugs)
+bool
+screen_init_renderer_and_texture(struct screen *screen);
+
 // show the window
 void
 screen_show_window(struct screen *screen);


### PR DESCRIPTION
Workaround for https://github.com/Genymobile/scrcpy/issues/15

The bug manifests in multi-monitor configurations mixing HiDPI and non-HiDPI monitors.

This fix is a little brute force - it reinitializes the SDL_Renderer context after each resize.  But it seems to work in every combination of resizing, fullscreening, window dragging, etc I could think of.

Testing in an ASAN debugging build too just to check the initialization isn't leaking stuff.