### PR TITLE
Compare server and client version at the start of scrcpy

### DIFF
--- a/app/src/server.c
+++ b/app/src/server.c
@@ -131,6 +131,7 @@ execute_server(struct server *server, const struct server_params *params) {
 #endif
         "/", // unused
         "com.genymobile.scrcpy.Server",
+        SCRCPY_VERSION,
         max_size_string,
         bit_rate_string,
         server->tunnel_forward ? "true" : "false",

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -67,29 +67,40 @@ public final class Server {
 
     @SuppressWarnings("checkstyle:MagicNumber")
     private static Options createOptions(String... args) {
-        if (args.length != 6) {
-            throw new IllegalArgumentException("Expecting 6 parameters");
+        if (args.length < 1) {
+            throw new IllegalArgumentException("At least client version should be specified");
+        }
+
+        String clientVersion = args[0];
+
+        if (!clientVersion.equals(BuildConfig.VERSION_NAME)) {
+            throw new java.lang.UnsupportedOperationException(
+                            "Difference version between client and server has not support yet");
+        }
+
+        if (args.length != 7) {
+            throw new IllegalArgumentException("Expecting 7 parameters");
         }
 
         Options options = new Options();
 
-        int maxSize = Integer.parseInt(args[0]) & ~7; // multiple of 8
+        int maxSize = Integer.parseInt(args[1]) & ~7; // multiple of 8
         options.setMaxSize(maxSize);
 
-        int bitRate = Integer.parseInt(args[1]);
+        int bitRate = Integer.parseInt(args[2]);
         options.setBitRate(bitRate);
 
         // use "adb forward" instead of "adb tunnel"? (so the server must listen)
-        boolean tunnelForward = Boolean.parseBoolean(args[2]);
+        boolean tunnelForward = Boolean.parseBoolean(args[3]);
         options.setTunnelForward(tunnelForward);
 
-        Rect crop = parseCrop(args[3]);
+        Rect crop = parseCrop(args[4]);
         options.setCrop(crop);
 
-        boolean sendFrameMeta = Boolean.parseBoolean(args[4]);
+        boolean sendFrameMeta = Boolean.parseBoolean(args[5]);
         options.setSendFrameMeta(sendFrameMeta);
 
-        boolean control = Boolean.parseBoolean(args[5]);
+        boolean control = Boolean.parseBoolean(args[6]);
         options.setControl(control);
 
         return options;


### PR DESCRIPTION
We found that some people wrong use older server with newer client. For example, #613 
To prevent this problem and let debug more easily. I add a patch to check this situation at the start of scrcpy.

It will show a warning when it finds version not matched.