### PR TITLE
Fix utf-8 char path in windows

### DIFF
--- a/app/src/command.c
+++ b/app/src/command.c
@@ -4,9 +4,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 #include "config.h"
 #include "common.h"
@@ -204,15 +201,4 @@ process_check_success(process_t proc, const char *name) {
         return false;
     }
     return true;
-}
-
-bool
-is_regular_file(const char *path) {
-    struct stat path_stat;
-    int r = stat(path, &path_stat);
-    if (r) {
-        perror("stat");
-        return false;
-    }
-    return S_ISREG(path_stat.st_mode);
 }

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -11,6 +11,7 @@
 #include "command.h"
 #include "util/log.h"
 #include "util/net.h"
+#include "util/str_util.h"
 
 #define SOCKET_NAME "scrcpy"
 #define SERVER_FILENAME "scrcpy-server"
@@ -20,7 +21,12 @@
 
 static const char *
 get_server_path(void) {
+#ifndef _WIN32
     const char *server_path_env = getenv("SCRCPY_SERVER_PATH");
+#else
+    const wchar_t *wide_server_path_env = _wgetenv(L"SCRCPY_SERVER_PATH");
+    char *server_path_env = utf8_from_wide_char(wide_server_path_env);
+#endif
     if (server_path_env) {
         LOGD("Using SCRCPY_SERVER_PATH: %s", server_path_env);
         // if the envvar is set, use it

--- a/app/src/sys/unix/command.c
+++ b/app/src/sys/unix/command.c
@@ -15,6 +15,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -126,4 +127,15 @@ get_executable_path(void) {
     // (it's useful to have a working version on Linux for debugging though)
     return NULL;
 #endif
+}
+
+bool
+is_regular_file(const char *path) {
+    struct stat path_stat;
+
+    if (stat(path, &path_stat)) {
+        perror("stat");
+        return false;
+    }
+    return S_ISREG(path_stat.st_mode);
 }

--- a/app/src/sys/win/command.c
+++ b/app/src/sys/win/command.c
@@ -4,6 +4,8 @@
 #include "util/log.h"
 #include "util/str_util.h"
 
+#include <sys/stat.h>
+
 static int
 build_cmd(char *cmd, size_t len, const char *const argv[]) {
     // Windows command-line parsing is WTF:
@@ -89,4 +91,25 @@ get_executable_path(void) {
     }
     buf[len] = '\0';
     return utf8_from_wide_char(buf);
+}
+
+bool
+is_regular_file(const char *path) {
+    struct _stat path_stat;
+    int r;
+    wchar_t *wide_path = utf8_to_wide_char(path);
+
+    if (!wide_path) {
+        LOGE("Failed to allocate memory");
+        return false;
+    }
+
+    r = _wstat(wide_path, &path_stat);
+    SDL_free(wide_path);
+
+    if (r) {
+        perror("stat");
+        return false;
+    }
+    return S_ISREG(path_stat.st_mode);
 }


### PR DESCRIPTION
The file 'E:\安安\scrcpy-win64-v1.12.1-1-g31bd950\scrcpy-server'
exists, however, it will show msg as follow:

INFO: scrcpy 1.12.1 <https://github.com/Genymobile/scrcpy>
stat: No such file or directory
ERROR: 'E:\安安\scrcpy-win64-v1.12.1-1-g31bd950\scrcpy-server' does not
exist or is not a regular file
Press any key to continue...

This patch fixes it.

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>