### PR TITLE
Encoding profile option

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -145,6 +145,10 @@ Set the initial window height.
 
 Default is 0 (automatic).\n
 
+.TP
+.BI "\-P, \-\-\codec\-profile " value
+Request specific encoding codec profile, see AVC profiles at: https://developer.android.com/reference/android/media/MediaCodecInfo.CodecProfileLevel for valid codec profile values. Default is 0 (automatic).
+
 .SH SHORTCUTS
 
 .TP

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -371,6 +371,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"window-height",         required_argument, NULL, OPT_WINDOW_HEIGHT},
         {"window-borderless",     no_argument,       NULL,
                                                      OPT_WINDOW_BORDERLESS},
+        {"codec-profile",         required_argument, NULL, 'P'},
         {NULL,                    0,                 NULL, 0  },
     };
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -124,6 +124,12 @@ scrcpy_print_usage(const char *arg0) {
         "        Set the initial window width.\n"
         "        Default is 0 (automatic).\n"
         "\n"
+        "    -P, --codec-profile value\n"
+        "        Request specific encoding codec profile, see AVC profiles at:\n"
+        "        https://developer.android.com/reference/android/media/MediaCodecInfo.CodecProfileLevel\n"
+        "        for valid codec profile values.\n"
+        "        Default is 0 (automatic).\n"
+        "\n"
         "Shortcuts:\n"
         "\n"
         "    " CTRL_OR_CMD "+f\n"
@@ -311,6 +317,35 @@ parse_record_format(const char *optarg, enum recorder_format *format) {
     return false;
 }
 
+static bool
+parse_codec_profile(const char *optarg, uint32_t *codec_profile) {
+    long value;
+    // long may be 32 bits (it is the case on mingw), so do not use more than
+    // 31 bits (long is signed)
+    bool ok = parse_integer_arg(optarg, &value, true, 0, 0x7FFFFFFF, "codec-profile");
+    if (!ok) {
+        return false;
+    }
+
+    switch (value) {
+        case 0:         // Automatic
+        case 0x01:      // AVCProfileBaseline
+        case 0x02:      // AVCProfileMain
+        case 0x04:      // AVCProfileExtended
+        case 0x08:      // AVCProfileHigh
+        case 0x10:      // AVCProfileHigh10
+        case 0x20:      // AVCProfileHigh422
+        case 0x40:      // AVCProfileHigh444
+        case 0x10000:   // AVCProfileConstrainedBaseline
+        case 0x80000:   // AVCProfileConstrainedHigh
+            *codec_profile = (uint32_t) value;
+            return true;
+        default:
+            LOGE("Invalid codec-profile, Use -h for help");
+            return false;
+    }
+}
+
 static enum recorder_format
 guess_record_format(const char *filename) {
     size_t len = strlen(filename);
@@ -380,7 +415,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
     optind = 0; // reset to start from the first argument in tests
 
     int c;
-    while ((c = getopt_long(argc, argv, "b:c:fF:hm:nNp:r:s:StTv", long_options,
+    while ((c = getopt_long(argc, argv, "b:c:fF:hm:nNp:r:s:StTv:P:", long_options,
                             NULL)) != -1) {
         switch (c) {
             case 'b':
@@ -484,6 +519,11 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
                 break;
             case OPT_PREFER_TEXT:
                 opts->prefer_text = true;
+                break;
+            case 'P':
+                if (!parse_codec_profile(optarg, &opts->codec_profile)) {
+                    return false;
+                }
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -285,6 +285,7 @@ scrcpy(const struct scrcpy_options *options) {
         .bit_rate = options->bit_rate,
         .max_fps = options->max_fps,
         .control = options->control,
+        .codec_profile = options->codec_profile,
     };
     if (!server_start(&server, options->serial, &params)) {
         return false;

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -32,6 +32,7 @@ struct scrcpy_options {
     bool render_expired_frames;
     bool prefer_text;
     bool window_borderless;
+    uint32_t codec_profile;
 };
 
 #define SCRCPY_OPTIONS_DEFAULT { \
@@ -58,6 +59,7 @@ struct scrcpy_options {
     .render_expired_frames = false, \
     .prefer_text = false, \
     .window_borderless = false, \
+    .codec_profile = 0, \
 }
 
 bool

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -124,9 +124,11 @@ execute_server(struct server *server, const struct server_params *params) {
     char max_size_string[6];
     char bit_rate_string[11];
     char max_fps_string[6];
+    char codec_profile_string[11];
     sprintf(max_size_string, "%"PRIu16, params->max_size);
     sprintf(bit_rate_string, "%"PRIu32, params->bit_rate);
     sprintf(max_fps_string, "%"PRIu16, params->max_fps);
+    sprintf(codec_profile_string, "%"PRIu32, params->codec_profile);
     const char *const cmd[] = {
         "shell",
         "CLASSPATH=" DEVICE_SERVER_PATH,
@@ -146,6 +148,7 @@ execute_server(struct server *server, const struct server_params *params) {
         params->crop ? params->crop : "-",
         "true", // always send frame meta (packet boundaries + timestamp)
         params->control ? "true" : "false",
+        codec_profile_string,
     };
 #ifdef SERVER_DEBUGGER
     LOGI("Server debugger waiting for a client on device port "
@@ -222,6 +225,7 @@ bool
 server_start(struct server *server, const char *serial,
              const struct server_params *params) {
     server->local_port = params->local_port;
+    server->codec_profile = params->codec_profile;
 
     if (serial) {
         server->serial = SDL_strdup(serial);

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -17,6 +17,7 @@ struct server {
     uint16_t local_port;
     bool tunnel_enabled;
     bool tunnel_forward; // use "adb forward" instead of "adb reverse"
+    uint32_t codec_profile;
 };
 
 #define SERVER_INITIALIZER {          \
@@ -28,6 +29,7 @@ struct server {
     .local_port = 0,                  \
     .tunnel_enabled = false,          \
     .tunnel_forward = false,          \
+    .codec_profile = 0,               \
 }
 
 struct server_params {

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -37,6 +37,7 @@ struct server_params {
     uint32_t bit_rate;
     uint16_t max_fps;
     bool control;
+    uint32_t codec_profile;
 };
 
 // init default values

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -10,6 +10,7 @@ public class Options {
     private Rect crop;
     private boolean sendFrameMeta; // send PTS so that the client may record properly
     private boolean control;
+    private int codecProfile;
 
     public int getMaxSize() {
         return maxSize;
@@ -65,5 +66,13 @@ public class Options {
 
     public void setControl(boolean control) {
         this.control = control;
+    }
+
+    public int getCodecProfile() {
+        return codecProfile;
+    }
+
+    public void setCodecProfile(int codecProfile) {
+        this.codecProfile = codecProfile;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -76,7 +76,7 @@ public final class Server {
         String clientVersion = args[0];
         if (!clientVersion.equals(BuildConfig.VERSION_NAME)) {
             throw new IllegalArgumentException(
-                    "The server version (" + clientVersion + ") does not match the client " + "(" + BuildConfig.VERSION_NAME + ")");
+                    "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "(" + clientVersion + ")");
         }
 
         if (args.length != 9) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -19,7 +19,7 @@ public final class Server {
         final Device device = new Device(options);
         boolean tunnelForward = options.isTunnelForward();
         try (DesktopConnection connection = DesktopConnection.open(device, tunnelForward)) {
-            ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps());
+            ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps(), options.getCodecProfile());
 
             if (options.getControl()) {
                 Controller controller = new Controller(device, connection);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -79,8 +79,8 @@ public final class Server {
                     "The server version (" + clientVersion + ") does not match the client " + "(" + BuildConfig.VERSION_NAME + ")");
         }
 
-        if (args.length != 8) {
-            throw new IllegalArgumentException("Expecting 8 parameters");
+        if (args.length != 9) {
+            throw new IllegalArgumentException("Expecting 9 parameters");
         }
 
         Options options = new Options();
@@ -106,6 +106,9 @@ public final class Server {
 
         boolean control = Boolean.parseBoolean(args[7]);
         options.setControl(control);
+
+        int codecProfile = Integer.parseInt(args[8]);
+        options.setCodecProfile(codecProfile);
 
         return options;
     }


### PR DESCRIPTION
There are some decoders like [Broadway](https://github.com/emersion/Broadway) that can accept only H.264 Baseline profile streams.
This profile is considered the most generic and is available on most Android devices.
To allow selecting a profile new option has been added to client and server.