### PR TITLE
Enable trilinear filtering on OpenGL

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -134,18 +134,27 @@ that's all. See [#37].
 
 ### The quality is low
 
-On Windows, you may need to configure the [scaling behavior].
+If the definition of your client window is smaller than that of your device
+screen, then you might get poor quality, especially visible on text (see [#40]).
+
+[#40]: https://github.com/Genymobile/scrcpy/issues/40
+
+To improve downscaling quality, trilinear filtering is enabled automatically
+if the renderer is OpenGL and if it supports mipmapping.
+
+On Windows or macOS, you might need to force OpenGL:
+
+```
+scrcpy --render-driver=opengl
+```
+
+On Windows, you may also need to configure the [scaling behavior].
 
 > `scrcpy.exe` > Properties > Compatibility > Change high DPI settings >
 > Override high DPI scaling behavior > Scaling performed by: _Application_.
 
 [scaling behavior]: https://github.com/Genymobile/scrcpy/issues/40#issuecomment-424466723
 
-If the definition of your client window is far smaller than that of your device
-screen, then you'll get poor quality. This is especially visible on text. See
-[#40].
-
-[#40]: https://github.com/Genymobile/scrcpy/issues/40
 
 
 ### KWin compositor crashes

--- a/app/meson.build
+++ b/app/meson.build
@@ -11,6 +11,7 @@ src = [
     'src/file_handler.c',
     'src/fps_counter.c',
     'src/input_manager.c',
+    'src/opengl.c',
     'src/receiver.c',
     'src/recorder.c',
     'src/scrcpy.c',

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -75,6 +75,10 @@ Disable device control (mirror the device in read\-only).
 Do not display device (only when screen recording is enabled).
 
 .TP
+.B \-\-no\-mipmaps
+If the renderer is OpenGL 3.0+ or OpenGL ES 2.0+, then mipmaps are automatically generated to improve downscaling quality. This option disables the generation of mipmaps.
+
+.TP
 .BI "\-p, \-\-port " port[:port]
 Set the TCP port (range) used by the client to listen.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -107,6 +107,14 @@ option if set, or by the file extension (.mp4 or .mkv).
 Force recording format (either mp4 or mkv).
 
 .TP
+.BI "\-\-render\-driver " name
+Request SDL to use the given render driver (this is just a hint).
+
+Supported names are currently "direct3d", "opengl", "opengles2", "opengles", "metal" and "software".
+.UR https://wiki.libsdl.org/SDL_HINT_RENDER_DRIVER
+.UE
+
+.TP
 .B \-\-render\-expired\-frames
 By default, to minimize latency, scrcpy always renders the last available decoded frame, and drops any previous ones. This flag forces to render all frames, at a cost of a possible increased latency.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -75,6 +75,11 @@ scrcpy_print_usage(const char *arg0) {
         "        Do not display device (only when screen recording is\n"
         "        enabled).\n"
         "\n"
+        "    --no-mipmaps\n"
+        "        If the renderer is OpenGL 3.0+ or OpenGL ES 2.0+, then\n"
+        "        mipmaps are automatically generated to improve downscaling\n"
+        "        quality. This option disables the generation of mipmaps.\n"
+        "\n"
         "    -p, --port port[:port]\n"
         "        Set the TCP port (range) used by the client to listen.\n"
         "        Default is %d:%d.\n"
@@ -462,6 +467,7 @@ guess_record_format(const char *filename) {
 #define OPT_DISPLAY_ID             1014
 #define OPT_ROTATION               1015
 #define OPT_RENDER_DRIVER          1016
+#define OPT_NO_MIPMAPS             1017
 
 bool
 scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
@@ -478,6 +484,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"max-size",               required_argument, NULL, 'm'},
         {"no-control",             no_argument,       NULL, 'n'},
         {"no-display",             no_argument,       NULL, 'N'},
+        {"no-mipmaps",             no_argument,       NULL, OPT_NO_MIPMAPS},
         {"port",                   required_argument, NULL, 'p'},
         {"push-target",            required_argument, NULL, OPT_PUSH_TARGET},
         {"record",                 required_argument, NULL, 'r'},
@@ -628,6 +635,9 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
                 break;
             case OPT_RENDER_DRIVER:
                 opts->render_driver = optarg;
+                break;
+            case OPT_NO_MIPMAPS:
+                opts->mipmaps = false;
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -99,6 +99,13 @@ scrcpy_print_usage(const char *arg0) {
         "    --record-format format\n"
         "        Force recording format (either mp4 or mkv).\n"
         "\n"
+        "    --render-driver name\n"
+        "        Request SDL to use the given render driver (this is just a\n"
+        "        hint).\n"
+        "        Supported names are currently \"direct3d\", \"opengl\",\n"
+        "        \"opengles2\", \"opengles\", \"metal\" and \"software\".\n"
+        "        <https://wiki.libsdl.org/SDL_HINT_RENDER_DRIVER>\n"
+        "\n"
         "    --render-expired-frames\n"
         "        By default, to minimize latency, scrcpy always renders the\n"
         "        last available decoded frame, and drops any previous ones.\n"
@@ -454,6 +461,7 @@ guess_record_format(const char *filename) {
 #define OPT_LOCK_VIDEO_ORIENTATION 1013
 #define OPT_DISPLAY_ID             1014
 #define OPT_ROTATION               1015
+#define OPT_RENDER_DRIVER          1016
 
 bool
 scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
@@ -474,6 +482,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"push-target",            required_argument, NULL, OPT_PUSH_TARGET},
         {"record",                 required_argument, NULL, 'r'},
         {"record-format",          required_argument, NULL, OPT_RECORD_FORMAT},
+        {"render-driver",          required_argument, NULL, OPT_RENDER_DRIVER},
         {"render-expired-frames",  no_argument,       NULL,
                                                   OPT_RENDER_EXPIRED_FRAMES},
         {"rotation",               required_argument, NULL, OPT_ROTATION},
@@ -616,6 +625,9 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
                 if (!parse_rotation(optarg, &opts->rotation)) {
                     return false;
                 }
+                break;
+            case OPT_RENDER_DRIVER:
+                opts->render_driver = optarg;
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -463,12 +463,11 @@ rotate_position(struct screen *screen, int32_t x, int32_t y) {
             result.x = w - x;
             result.y = h - y;
             break;
-        case 3:
+        default:
+            assert(rotation == 3);
             result.x = y;
             result.y = w - x;
             break;
-        default:
-            assert(!"Unreachable");
     }
     return result;
 }

--- a/app/src/opengl.c
+++ b/app/src/opengl.c
@@ -1,0 +1,56 @@
+#include "opengl.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include "SDL2/SDL.h"
+
+void
+sc_opengl_init(struct sc_opengl *gl) {
+    gl->GetString = SDL_GL_GetProcAddress("glGetString");
+    assert(gl->GetString);
+
+    gl->TexParameterf = SDL_GL_GetProcAddress("glTexParameterf");
+    assert(gl->TexParameterf);
+
+    gl->TexParameteri = SDL_GL_GetProcAddress("glTexParameteri");
+    assert(gl->TexParameteri);
+
+    // optional
+    gl->GenerateMipmap = SDL_GL_GetProcAddress("glGenerateMipmap");
+
+    const char *version = (const char *) gl->GetString(GL_VERSION);
+    assert(version);
+    gl->version = version;
+
+#define OPENGL_ES_PREFIX "OpenGL ES "
+    /* starts with "OpenGL ES " */
+    gl->is_opengles = !strncmp(gl->version, OPENGL_ES_PREFIX,
+                               sizeof(OPENGL_ES_PREFIX) - 1);
+    if (gl->is_opengles) {
+        /* skip the prefix */
+        version += sizeof(PREFIX) - 1;
+    }
+
+    int r = sscanf(version, "%d.%d", &gl->version_major, &gl->version_minor);
+    if (r != 2) {
+        // failed to parse the version
+        gl->version_major = 0;
+        gl->version_minor = 0;
+    }
+}
+
+bool
+sc_opengl_version_at_least(struct sc_opengl *gl,
+                           int minver_major, int minver_minor,
+                           int minver_es_major, int minver_es_minor)
+{
+    if (gl->is_opengles) {
+        return gl->version_major > minver_es_major
+            || (gl->version_major == minver_es_major
+             && gl->version_minor >= minver_es_minor);
+    }
+
+    return gl->version_major > minver_major
+        || (gl->version_major == minver_major
+         && gl->version_minor >= minver_minor);
+}

--- a/app/src/opengl.h
+++ b/app/src/opengl.h
@@ -1,0 +1,36 @@
+#ifndef SC_OPENGL_H
+#define SC_OPENGL_H
+
+#include <stdbool.h>
+#include <SDL2/SDL_opengl.h>
+
+#include "config.h"
+
+struct sc_opengl {
+    const char *version;
+    bool is_opengles;
+    int version_major;
+    int version_minor;
+
+    const GLubyte *
+    (*GetString)(GLenum name);
+
+    void
+    (*TexParameterf)(GLenum target, GLenum pname, GLfloat param);
+
+    void
+    (*TexParameteri)(GLenum target, GLenum pname, GLint param);
+
+    void
+    (*GenerateMipmap)(GLenum target);
+};
+
+void
+sc_opengl_init(struct sc_opengl *gl);
+
+bool
+sc_opengl_version_at_least(struct sc_opengl *gl,
+                           int minver_major, int minver_minor,
+                           int minver_es_major, int minver_es_minor);
+
+#endif

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -401,7 +401,7 @@ scrcpy(const struct scrcpy_options *options) {
                                    options->window_y, options->window_width,
                                    options->window_height,
                                    options->window_borderless,
-                                   options->rotation)) {
+                                   options->rotation, options-> mipmaps)) {
             goto end;
         }
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -47,7 +47,7 @@ static struct input_manager input_manager = {
 
 // init SDL and set appropriate hints
 static bool
-sdl_init_and_configure(bool display) {
+sdl_init_and_configure(bool display, const char *render_driver) {
     uint32_t flags = display ? SDL_INIT_VIDEO : SDL_INIT_EVENTS;
     if (SDL_Init(flags)) {
         LOGC("Could not initialize SDL: %s", SDL_GetError());
@@ -58,6 +58,10 @@ sdl_init_and_configure(bool display) {
 
     if (!display) {
         return true;
+    }
+
+    if (render_driver && !SDL_SetHint(SDL_HINT_RENDER_DRIVER, render_driver)) {
+        LOGW("Could not set render driver");
     }
 
     // Linear filtering
@@ -310,7 +314,7 @@ scrcpy(const struct scrcpy_options *options) {
     bool controller_initialized = false;
     bool controller_started = false;
 
-    if (!sdl_init_and_configure(options->display)) {
+    if (!sdl_init_and_configure(options->display, options->render_driver)) {
         goto end;
     }
 

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -37,6 +37,7 @@ struct scrcpy_options {
     bool render_expired_frames;
     bool prefer_text;
     bool window_borderless;
+    bool mipmaps;
 };
 
 #define SCRCPY_OPTIONS_DEFAULT { \
@@ -70,6 +71,7 @@ struct scrcpy_options {
     .render_expired_frames = false, \
     .prefer_text = false, \
     .window_borderless = false, \
+    .mipmaps = true, \
 }
 
 bool

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -15,6 +15,7 @@ struct scrcpy_options {
     const char *record_filename;
     const char *window_title;
     const char *push_target;
+    const char *render_driver;
     enum recorder_format record_format;
     struct port_range port_range;
     uint16_t max_size;
@@ -44,6 +45,7 @@ struct scrcpy_options {
     .record_filename = NULL, \
     .window_title = NULL, \
     .push_target = NULL, \
+    .render_driver = NULL, \
     .record_format = RECORDER_FORMAT_AUTO, \
     .port_range = { \
         .first = DEFAULT_LOCAL_PORT_RANGE_FIRST, \

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -226,6 +226,11 @@ screen_init_rendering(struct screen *screen, const char *window_title,
         return false;
     }
 
+    SDL_RendererInfo renderer_info;
+    int r = SDL_GetRendererInfo(screen->renderer, &renderer_info);
+    const char *renderer_name = r ? NULL : renderer_info.name;
+    LOGI("Renderer: %s", renderer_name ? renderer_name : "(unknown)");
+
     if (SDL_RenderSetLogicalSize(screen->renderer, content_size.width,
                                  content_size.height)) {
         LOGE("Could not set renderer logical size: %s", SDL_GetError());

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -199,7 +199,7 @@ screen_init_rendering(struct screen *screen, const char *window_title,
                       struct size frame_size, bool always_on_top,
                       int16_t window_x, int16_t window_y, uint16_t window_width,
                       uint16_t window_height, bool window_borderless,
-                      uint8_t rotation) {
+                      uint8_t rotation, bool mipmaps) {
     screen->frame_size = frame_size;
     screen->rotation = rotation;
     if (rotation) {
@@ -266,15 +266,19 @@ screen_init_rendering(struct screen *screen, const char *window_title,
 
         LOGI("OpenGL version: %s", gl->version);
 
-        bool supports_mipmaps =
-            sc_opengl_version_at_least(gl, 3, 0, /* OpenGL 3.0+ */
-                                           2, 0  /* OpenGL ES 2.0+ */);
-        if (supports_mipmaps) {
-            LOGI("Trilinear filtering enabled");
-            screen->mipmaps = true;
+        if (mipmaps) {
+            bool supports_mipmaps =
+                sc_opengl_version_at_least(gl, 3, 0, /* OpenGL 3.0+ */
+                                               2, 0  /* OpenGL ES 2.0+ */);
+            if (supports_mipmaps) {
+                LOGI("Trilinear filtering enabled");
+                screen->mipmaps = true;
+            } else {
+                LOGW("Trilinear filtering disabled "
+                     "(OpenGL 3.0+ or ES 2.0+ required)");
+            }
         } else {
-            LOGW("Trilinear filtering disabled "
-                 "(OpenGL 3.0+ or ES 2.0+ required)");
+            LOGI("Trilinear filtering disabled");
         }
     } else {
         LOGW("Trilinear filtering disabled (not an OpenGL renderer)");

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -7,6 +7,7 @@
 
 #include "config.h"
 #include "common.h"
+#include "opengl.h"
 
 #define WINDOW_POSITION_UNDEFINED (-0x8000)
 
@@ -16,6 +17,8 @@ struct screen {
     SDL_Window *window;
     SDL_Renderer *renderer;
     SDL_Texture *texture;
+    bool use_opengl;
+    struct sc_opengl gl;
     struct size frame_size;
     struct size content_size; // rotated frame_size
     // The window size the last time it was not maximized or fullscreen.
@@ -29,12 +32,15 @@ struct screen {
     bool fullscreen;
     bool maximized;
     bool no_window;
+    bool mipmaps;
 };
 
 #define SCREEN_INITIALIZER { \
     .window = NULL, \
     .renderer = NULL, \
     .texture = NULL, \
+    .use_opengl = false, \
+    .gl = {0}, \
     .frame_size = { \
         .width = 0, \
         .height = 0, \
@@ -56,6 +62,7 @@ struct screen {
     .fullscreen = false, \
     .maximized = false, \
     .no_window = false, \
+    .mipmaps = false, \
 }
 
 // initialize default values

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -76,7 +76,7 @@ screen_init_rendering(struct screen *screen, const char *window_title,
                       struct size frame_size, bool always_on_top,
                       int16_t window_x, int16_t window_y, uint16_t window_width,
                       uint16_t window_height, bool window_borderless,
-                      uint8_t rotation);
+                      uint8_t rotation, bool mipmaps);
 
 // show the window
 void

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -172,7 +172,7 @@ enable_tunnel_reverse_any_port(struct server *server,
         // check before incrementing to avoid overflow on port 65535
         if (port < port_range.last) {
             LOGW("Could not listen on port %" PRIu16", retrying on %" PRIu16,
-                 port, port + 1);
+                 port, (uint16_t) (port + 1));
             port++;
             continue;
         }

--- a/app/src/sys/unix/command.c
+++ b/app/src/sys/unix/command.c
@@ -14,6 +14,7 @@
 #include <limits.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This PR aims to improve downscaling quality. See https://github.com/Genymobile/scrcpy/issues/40#issuecomment-591917787 for more details.

- add an option `--render-driver` to force a renderer
- enable trilinear filtering if the renderer is OpenGL and if it supports mipmapping
- add an option `--no-mipmaps` to force-disable trilinear filtering

![mipmaps](https://user-images.githubusercontent.com/543275/79056440-f05ed580-7c56-11ea-9e8e-5355dfb41e7b.png)

```
scrcpy --window-height=500 --window-title=BEFORE --no-mipmaps
scrcpy --window-height=500 --window-title=AFTER
```

cc @cjxgm

I'm hesitant to set `opengl` as the default render driver on Windows and macOS. I'm afraid that it could cause problems. What do you think?

Please test with `--render-driver=opengl` on these platforms, and report any problems :)

Note that this improves quality only for client downscaling (the device sends the video at full definition, and the client resizes the window).
The quality is still bad if the content is resized before encoding (`scrcpy -m 500` for example).