### PR TITLE
Encoding options

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -153,7 +153,7 @@ Default is 0 (automatic).\n
 
 .TP
 .BI "\-\-\codec\-options " 'options'
-'options' is a list of key=value pairs seperated by comma\n
+options is a list of key=value pairs seperated by comma\n
 for the device encoder.\n
 For a list of possible codec options:\n
 https://developer.android.com/reference/android/media/MediaCodecInfo\n

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -151,6 +151,14 @@ Set the initial window height.
 
 Default is 0 (automatic).\n
 
+.TP
+.BI "\-\-\codec\-options " 'options'
+'options' is a list of key=value pairs seperated by comma\n
+for the device encoder.\n
+For a list of possible codec options:\n
+https://developer.android.com/reference/android/media/MediaCodecInfo\n
+Currently supported keys: [profile, level].\n
+
 .SH SHORTCUTS
 
 .TP

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -431,6 +431,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"window-height",          required_argument, NULL, OPT_WINDOW_HEIGHT},
         {"window-borderless",      no_argument,       NULL,
                                                   OPT_WINDOW_BORDERLESS},
+        {"codec-profile",          required_argument, NULL, 'P'},
         {NULL,                     0,                 NULL, 0  },
     };
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -130,6 +130,12 @@ scrcpy_print_usage(const char *arg0) {
         "        Set the initial window width.\n"
         "        Default is 0 (automatic).\n"
         "\n"
+        "    -P, --codec-profile value\n"
+        "        Request specific encoding codec profile, see AVC profiles at:\n"
+        "        https://developer.android.com/reference/android/media/MediaCodecInfo.CodecProfileLevel\n"
+        "        for valid codec profile values.\n"
+        "        Default is 0 (automatic).\n"
+        "\n"
         "Shortcuts:\n"
         "\n"
         "    " CTRL_OR_CMD "+f\n"
@@ -368,6 +374,35 @@ parse_record_format(const char *optarg, enum recorder_format *format) {
     return false;
 }
 
+static bool
+parse_codec_profile(const char *optarg, uint32_t *codec_profile) {
+    long value;
+    // long may be 32 bits (it is the case on mingw), so do not use more than
+    // 31 bits (long is signed)
+    bool ok = parse_integer_arg(optarg, &value, true, 0, 0x7FFFFFFF, "codec-profile");
+    if (!ok) {
+        return false;
+    }
+
+    switch (value) {
+        case 0:         // Automatic
+        case 0x01:      // AVCProfileBaseline
+        case 0x02:      // AVCProfileMain
+        case 0x04:      // AVCProfileExtended
+        case 0x08:      // AVCProfileHigh
+        case 0x10:      // AVCProfileHigh10
+        case 0x20:      // AVCProfileHigh422
+        case 0x40:      // AVCProfileHigh444
+        case 0x10000:   // AVCProfileConstrainedBaseline
+        case 0x80000:   // AVCProfileConstrainedHigh
+            *codec_profile = (uint32_t) value;
+            return true;
+        default:
+            LOGE("Invalid codec-profile, Use -h for help");
+            return false;
+    }
+}
+
 static enum recorder_format
 guess_record_format(const char *filename) {
     size_t len = strlen(filename);
@@ -440,7 +475,11 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
     optind = 0; // reset to start from the first argument in tests
 
     int c;
+<<<<<<< HEAD
+    while ((c = getopt_long(argc, argv, "b:c:fF:hm:nNp:r:s:StTv:P:", long_options,
+=======
     while ((c = getopt_long(argc, argv, "b:c:fF:hm:nNp:r:s:StTv", long_options,
+>>>>>>> 1b12204... fixup! Added help and parsing of the codec-profile option
                             NULL)) != -1) {
         switch (c) {
             case 'b':
@@ -549,6 +588,11 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
                 break;
             case OPT_PREFER_TEXT:
                 opts->prefer_text = true;
+                break;
+            case 'P':
+                if (!parse_codec_profile(optarg, &opts->codec_profile)) {
+                    return false;
+                }
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -286,6 +286,7 @@ scrcpy(const struct scrcpy_options *options) {
         .max_fps = options->max_fps,
         .lock_video_orientation = options->lock_video_orientation,
         .control = options->control,
+        .codec_profile = options->codec_profile,
     };
     if (!server_start(&server, options->serial, &params)) {
         return false;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -286,7 +286,7 @@ scrcpy(const struct scrcpy_options *options) {
         .max_fps = options->max_fps,
         .lock_video_orientation = options->lock_video_orientation,
         .control = options->control,
-        .codec_profile = options->codec_profile,
+        .codec_options = options->codec_options,
     };
     if (!server_start(&server, options->serial, &params)) {
         return false;

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -34,6 +34,7 @@ struct scrcpy_options {
     bool render_expired_frames;
     bool prefer_text;
     bool window_borderless;
+    uint32_t codec_profile;
 };
 
 #define SCRCPY_OPTIONS_DEFAULT { \
@@ -64,6 +65,7 @@ struct scrcpy_options {
     .render_expired_frames = false, \
     .prefer_text = false, \
     .window_borderless = false, \
+    .codec_profile = 0, \
 }
 
 bool

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -15,6 +15,7 @@ struct scrcpy_options {
     const char *record_filename;
     const char *window_title;
     const char *push_target;
+    const char *codec_options;
     enum recorder_format record_format;
     struct port_range port_range;
     uint16_t max_size;
@@ -34,7 +35,6 @@ struct scrcpy_options {
     bool render_expired_frames;
     bool prefer_text;
     bool window_borderless;
-    uint32_t codec_profile;
 };
 
 #define SCRCPY_OPTIONS_DEFAULT { \
@@ -43,6 +43,7 @@ struct scrcpy_options {
     .record_filename = NULL, \
     .window_title = NULL, \
     .push_target = NULL, \
+    .codec_options = NULL, \
     .record_format = RECORDER_FORMAT_AUTO, \
     .port_range = { \
         .first = DEFAULT_LOCAL_PORT_RANGE_FIRST, \
@@ -65,7 +66,6 @@ struct scrcpy_options {
     .render_expired_frames = false, \
     .prefer_text = false, \
     .window_borderless = false, \
-    .codec_profile = 0, \
 }
 
 bool

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -234,12 +234,10 @@ execute_server(struct server *server, const struct server_params *params) {
     char bit_rate_string[11];
     char max_fps_string[6];
     char lock_video_orientation_string[3];
-    char codec_profile_string[11];
     sprintf(max_size_string, "%"PRIu16, params->max_size);
     sprintf(bit_rate_string, "%"PRIu32, params->bit_rate);
     sprintf(max_fps_string, "%"PRIu16, params->max_fps);
     sprintf(lock_video_orientation_string, "%"PRIi8, params->lock_video_orientation);
-    sprintf(codec_profile_string, "%"PRIu32, params->codec_profile);
     const char *const cmd[] = {
         "shell",
         "CLASSPATH=" DEVICE_SERVER_PATH,
@@ -256,7 +254,7 @@ execute_server(struct server *server, const struct server_params *params) {
         bit_rate_string,
         max_fps_string,
         lock_video_orientation_string,
-        codec_profile_string,
+        params->codec_options ? params->codec_options : "-",
         server->tunnel_forward ? "true" : "false",
         params->crop ? params->crop : "-",
         "true", // always send frame meta (packet boundaries + timestamp)
@@ -330,7 +328,6 @@ bool
 server_start(struct server *server, const char *serial,
              const struct server_params *params) {
     server->port_range = params->port_range;
-    server->codec_profile = params->codec_profile;
 
     if (serial) {
         server->serial = SDL_strdup(serial);

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -234,10 +234,12 @@ execute_server(struct server *server, const struct server_params *params) {
     char bit_rate_string[11];
     char max_fps_string[6];
     char lock_video_orientation_string[3];
+    char codec_profile_string[11];
     sprintf(max_size_string, "%"PRIu16, params->max_size);
     sprintf(bit_rate_string, "%"PRIu32, params->bit_rate);
     sprintf(max_fps_string, "%"PRIu16, params->max_fps);
     sprintf(lock_video_orientation_string, "%"PRIi8, params->lock_video_orientation);
+    sprintf(codec_profile_string, "%"PRIu32, params->codec_profile);
     const char *const cmd[] = {
         "shell",
         "CLASSPATH=" DEVICE_SERVER_PATH,
@@ -254,6 +256,7 @@ execute_server(struct server *server, const struct server_params *params) {
         bit_rate_string,
         max_fps_string,
         lock_video_orientation_string,
+        codec_profile_string,
         server->tunnel_forward ? "true" : "false",
         params->crop ? params->crop : "-",
         "true", // always send frame meta (packet boundaries + timestamp)
@@ -327,6 +330,7 @@ bool
 server_start(struct server *server, const char *serial,
              const struct server_params *params) {
     server->port_range = params->port_range;
+    server->codec_profile = params->codec_profile;
 
     if (serial) {
         server->serial = SDL_strdup(serial);

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -19,7 +19,6 @@ struct server {
     uint16_t local_port; // selected from port_range
     bool tunnel_enabled;
     bool tunnel_forward; // use "adb forward" instead of "adb reverse"
-    uint32_t codec_profile;
 };
 
 #define SERVER_INITIALIZER { \
@@ -35,7 +34,6 @@ struct server {
     .local_port = 0, \
     .tunnel_enabled = false, \
     .tunnel_forward = false, \
-    .codec_profile = 0, \
 }
 
 struct server_params {
@@ -46,7 +44,7 @@ struct server_params {
     uint16_t max_fps;
     int8_t lock_video_orientation;
     bool control;
-    uint32_t codec_profile;
+    char *codec_options;
 };
 
 // init default values

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -44,6 +44,7 @@ struct server_params {
     uint16_t max_fps;
     int8_t lock_video_orientation;
     bool control;
+    uint32_t codec_profile;
 };
 
 // init default values

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -19,6 +19,7 @@ struct server {
     uint16_t local_port; // selected from port_range
     bool tunnel_enabled;
     bool tunnel_forward; // use "adb forward" instead of "adb reverse"
+    uint32_t codec_profile;
 };
 
 #define SERVER_INITIALIZER { \
@@ -34,6 +35,7 @@ struct server {
     .local_port = 0, \
     .tunnel_enabled = false, \
     .tunnel_forward = false, \
+    .codec_profile = 0, \
 }
 
 struct server_params {

--- a/server/src/main/java/com/genymobile/scrcpy/CodecOptions.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CodecOptions.java
@@ -1,0 +1,25 @@
+package com.genymobile.scrcpy;
+
+import java.util.HashMap;
+
+public class CodecOptions {
+    static final String PROFILE_OPTION = "profile";
+    static final String LEVEL_OPTION = "level";
+
+    private HashMap<String, String> options;
+
+    CodecOptions(HashMap<String, String> options) {
+        this.options = options;
+    }
+
+    Object parseValue(String profileOption) {
+        String value = options.get(profileOption);
+        switch (profileOption) {
+            case PROFILE_OPTION:
+            case LEVEL_OPTION:
+                return NumberUtils.tryParseInt(value);
+            default:
+                return null;
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/CodecOptions.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CodecOptions.java
@@ -1,10 +1,46 @@
 package com.genymobile.scrcpy;
 
+import android.media.MediaCodecInfo;
+import android.os.Build;
+
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 public class CodecOptions {
-    static final String PROFILE_OPTION = "profile";
-    static final String LEVEL_OPTION = "level";
+
+    public static final String PROFILE_OPTION = "profile";
+    public static final String LEVEL_OPTION = "level";
+
+    private static final LinkedHashMap<Integer, String> levelsTable = new LinkedHashMap<Integer, String>() {
+        {
+            // Adding all possible level and their properties
+            // 3rd property, bitrate was added but not sure if needed for now.
+            // Source: https://en.wikipedia.org/wiki/Advanced_Video_Coding#Levels
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel1, "485,99,64");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel1b, "485,99,128");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel11, "3000,396,192");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel12, "6000,396,384");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel13, "11880,396,768");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel2, "11880,396,2000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel21, "19800,792,4000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel22, "20250,1620,4000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel3, "40500,1620,10000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel31, "108000,3600,14000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel32, "216000,5120,20000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel4, "245760,8192,20000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel41, "245760,8192,50000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel42, "522240,8704,50000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel5, "589824,22080,135000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel51, "983040,36864,240000");
+            put(MediaCodecInfo.CodecProfileLevel.AVCLevel52, "2073600,36864,240000");
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaCodecInfo.CodecProfileLevel.AVCLevel6, "4177920,139264,240000");
+                put(MediaCodecInfo.CodecProfileLevel.AVCLevel61, "8355840,139264,480000");
+                put(MediaCodecInfo.CodecProfileLevel.AVCLevel62, "16711680,139264,800000");
+            }
+        }
+    };
 
     private HashMap<String, String> options;
 
@@ -12,7 +48,31 @@ public class CodecOptions {
         this.options = options;
     }
 
-    Object parseValue(String profileOption) {
+    /**
+     * The purpose of this function is to return the lowest possible codec profile level
+     * that supports the given width/height/bitrate of the stream
+     * @param width of the device
+     * @param height of the device
+     * @param bitRate at which we stream
+     * @return the lowest possible level that should support the given properties.
+     */
+    public static int calculateLevel(int width, int height, int bitRate) {
+        // Calculations source: https://stackoverflow.com/questions/32100635/vlc-2-2-and-levels
+        int macroblocks = (int)( Math.ceil(width/16.0) * Math.ceil(height/16.0) );
+        int macroblocks_s = macroblocks * 60;
+        for (Map.Entry<Integer, String> entry : levelsTable.entrySet()) {
+            String[] levelProperties = entry.getValue().split(",");
+            int levelMacroblocks_s = Integer.parseInt(levelProperties[0]);
+            int levelMacroblocks = Integer.parseInt(levelProperties[1]);
+            if(macroblocks_s > levelMacroblocks_s) continue;
+            if(macroblocks > levelMacroblocks) continue;
+            Ln.i("Level selected based on screen size calculation: " + entry.getKey());
+            return entry.getKey();
+        }
+        return 0;
+    }
+
+    public Object parseValue(String profileOption) {
         String value = options.get(profileOption);
         switch (profileOption) {
             case PROFILE_OPTION:

--- a/server/src/main/java/com/genymobile/scrcpy/NumberUtils.java
+++ b/server/src/main/java/com/genymobile/scrcpy/NumberUtils.java
@@ -1,0 +1,16 @@
+package com.genymobile.scrcpy;
+
+public class NumberUtils {
+
+    public static int tryParseInt(final String str) {
+        return tryParseInt(str, 0);
+    }
+
+    public static int tryParseInt(final String str, int defaultValue) {
+        try {
+            return Integer.parseInt(str);
+        } catch (NumberFormatException e) {
+            return defaultValue;
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -11,7 +11,7 @@ public class Options {
     private Rect crop;
     private boolean sendFrameMeta; // send PTS so that the client may record properly
     private boolean control;
-    private int codecProfile;
+    private CodecOptions codecOptions;
 
     public int getMaxSize() {
         return maxSize;
@@ -77,11 +77,11 @@ public class Options {
         this.control = control;
     }
 
-    public int getCodecProfile() {
-        return codecProfile;
+    public CodecOptions getCodecOptions() {
+        return codecOptions;
     }
 
-    public void setCodecProfile(int codecProfile) {
-        this.codecProfile = codecProfile;
+    public void setCodecOptions(CodecOptions codecOptions) {
+        this.codecOptions = codecOptions;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -11,6 +11,7 @@ public class Options {
     private Rect crop;
     private boolean sendFrameMeta; // send PTS so that the client may record properly
     private boolean control;
+    private int codecProfile;
 
     public int getMaxSize() {
         return maxSize;
@@ -74,5 +75,13 @@ public class Options {
 
     public void setControl(boolean control) {
         this.control = control;
+    }
+
+    public int getCodecProfile() {
+        return codecProfile;
+    }
+
+    public void setCodecProfile(int codecProfile) {
+        this.codecProfile = codecProfile;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -30,19 +30,21 @@ public class ScreenEncoder implements Device.RotationListener {
     private int maxFps;
     private int lockedVideoOrientation;
     private int iFrameInterval;
+    private int codecProfile;
     private boolean sendFrameMeta;
     private long ptsOrigin;
 
-    public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, int lockedVideoOrientation, int iFrameInterval) {
+    public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, int lockedVideoOrientation, int codecProfile, int iFrameInterval) {
         this.sendFrameMeta = sendFrameMeta;
         this.bitRate = bitRate;
         this.maxFps = maxFps;
         this.lockedVideoOrientation = lockedVideoOrientation;
+        this.codecProfile = codecProfile;
         this.iFrameInterval = iFrameInterval;
     }
 
-    public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, int lockedVideoOrientation) {
-        this(sendFrameMeta, bitRate, maxFps, lockedVideoOrientation, DEFAULT_I_FRAME_INTERVAL);
+    public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, int lockedVideoOrientation, int codecProfile) {
+        this(sendFrameMeta, bitRate, maxFps, lockedVideoOrientation, codecProfile, DEFAULT_I_FRAME_INTERVAL);
     }
 
     @Override
@@ -64,6 +66,7 @@ public class ScreenEncoder implements Device.RotationListener {
         try {
             do {
                 MediaCodec codec = createCodec();
+                setCodecProfile(codec, format);
                 IBinder display = createDisplay();
                 ScreenInfo screenInfo = device.getScreenInfo();
                 Rect contentRect = screenInfo.getContentRect();
@@ -137,6 +140,22 @@ public class ScreenEncoder implements Device.RotationListener {
         headerBuffer.putInt(packetSize);
         headerBuffer.flip();
         IO.writeFully(fd, headerBuffer);
+    }
+
+    private void setCodecProfile(MediaCodec codec, MediaFormat format) throws IOException {
+        if(codecProfile == 0) return;
+        int level = 0;
+        for (MediaCodecInfo.CodecProfileLevel profileLevel : codec.getCodecInfo().getCapabilitiesForType("video/avc").profileLevels) {
+            if(profileLevel.profile == codecProfile) {
+                level = Math.max(level, profileLevel.level);
+            }
+        }
+        if(level == 0) throw new IOException("Device doesn't support the requested codec profile.");
+        // Profile (SDK Level 21) and Level (SDK Level 23).
+        format.setInteger(MediaFormat.KEY_PROFILE, codecProfile);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            format.setInteger(MediaFormat.KEY_LEVEL, level);
+        }
     }
 
     private static MediaCodec createCodec() throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -20,7 +20,7 @@ public final class Server {
         boolean tunnelForward = options.isTunnelForward();
         try (DesktopConnection connection = DesktopConnection.open(device, tunnelForward)) {
             ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps(),
-                    options.getLockedVideoOrientation());
+                    options.getLockedVideoOrientation(), options.getCodecProfile());
 
             if (options.getControl()) {
                 Controller controller = new Controller(device, connection);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -80,8 +80,8 @@ public final class Server {
                     "The server version (" + clientVersion + ") does not match the client " + "(" + BuildConfig.VERSION_NAME + ")");
         }
 
-        if (args.length != 9) {
-            throw new IllegalArgumentException("Expecting 9 parameters");
+        if (args.length != 10) {
+            throw new IllegalArgumentException("Expecting 10 parameters");
         }
 
         Options options = new Options();
@@ -98,17 +98,20 @@ public final class Server {
         int lockedVideoOrientation = Integer.parseInt(args[4]);
         options.setLockedVideoOrientation(lockedVideoOrientation);
 
+        int codecProfile = Integer.parseInt(args[5]);
+        options.setCodecProfile(codecProfile);
+
         // use "adb forward" instead of "adb tunnel"? (so the server must listen)
-        boolean tunnelForward = Boolean.parseBoolean(args[5]);
+        boolean tunnelForward = Boolean.parseBoolean(args[6]);
         options.setTunnelForward(tunnelForward);
 
-        Rect crop = parseCrop(args[6]);
+        Rect crop = parseCrop(args[7]);
         options.setCrop(crop);
 
-        boolean sendFrameMeta = Boolean.parseBoolean(args[7]);
+        boolean sendFrameMeta = Boolean.parseBoolean(args[8]);
         options.setSendFrameMeta(sendFrameMeta);
 
-        boolean control = Boolean.parseBoolean(args[8]);
+        boolean control = Boolean.parseBoolean(args[9]);
         options.setControl(control);
 
         return options;

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -77,7 +77,7 @@ public final class Server {
         String clientVersion = args[0];
         if (!clientVersion.equals(BuildConfig.VERSION_NAME)) {
             throw new IllegalArgumentException(
-                    "The server version (" + clientVersion + ") does not match the client " + "(" + BuildConfig.VERSION_NAME + ")");
+                    "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "(" + clientVersion + ")");
         }
 
         if (args.length != 10) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -6,6 +6,7 @@ import android.os.Build;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 
 public final class Server {
 
@@ -20,7 +21,7 @@ public final class Server {
         boolean tunnelForward = options.isTunnelForward();
         try (DesktopConnection connection = DesktopConnection.open(device, tunnelForward)) {
             ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps(),
-                    options.getLockedVideoOrientation(), options.getCodecProfile());
+                    options.getLockedVideoOrientation(), options.getCodecOptions());
 
             if (options.getControl()) {
                 Controller controller = new Controller(device, connection);
@@ -98,8 +99,8 @@ public final class Server {
         int lockedVideoOrientation = Integer.parseInt(args[4]);
         options.setLockedVideoOrientation(lockedVideoOrientation);
 
-        int codecProfile = Integer.parseInt(args[5]);
-        options.setCodecProfile(codecProfile);
+        CodecOptions codecOptions = parseCodecOptions(args[5]);
+        options.setCodecOptions(codecOptions);
 
         // use "adb forward" instead of "adb tunnel"? (so the server must listen)
         boolean tunnelForward = Boolean.parseBoolean(args[6]);
@@ -132,6 +133,18 @@ public final class Server {
         int x = Integer.parseInt(tokens[2]);
         int y = Integer.parseInt(tokens[3]);
         return new Rect(x, y, x + width, y + height);
+    }
+
+    private static CodecOptions parseCodecOptions(String codecOptions) {
+        HashMap<String, String> codecOptionsMap = new HashMap<>();
+        if (!"-".equals(codecOptions)) {
+            String[] pairs = codecOptions.split(",");
+            for (String pair : pairs) {
+                String[] option = pair.split("=");
+                codecOptionsMap.put(option[0], option.length > 1 ? option[1] : null);
+            }
+        }
+        return new CodecOptions(codecOptionsMap);
     }
 
     private static void unlinkSelf() {


### PR DESCRIPTION
Introduced options arguments for the Android MediaCodec library.

There are some decoders like Broadway that can accept only H.264 Baseline profile streams.
This profile is considered the most generic and is available on most Android devices.
To allow selecting a profile new option has been added to client and server.