### PR TITLE
[Request for tests] Refactor rendering and events position/scaling

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -7,33 +7,6 @@
 #include "util/lock.h"
 #include "util/log.h"
 
-// Convert window coordinates (as provided by SDL_GetMouseState() to renderer
-// coordinates (as provided in SDL mouse events)
-//
-// See my question:
-// <https://stackoverflow.com/questions/49111054/how-to-get-mouse-position-on-mouse-wheel-event>
-static void
-convert_to_renderer_coordinates(SDL_Renderer *renderer, int *x, int *y) {
-    SDL_Rect viewport;
-    float scale_x, scale_y;
-    SDL_RenderGetViewport(renderer, &viewport);
-    SDL_RenderGetScale(renderer, &scale_x, &scale_y);
-    *x = (int) (*x / scale_x) - viewport.x;
-    *y = (int) (*y / scale_y) - viewport.y;
-}
-
-static struct point
-get_mouse_point(struct screen *screen) {
-    int x;
-    int y;
-    SDL_GetMouseState(&x, &y);
-    convert_to_renderer_coordinates(screen->renderer, &x, &y);
-    return (struct point) {
-        .x = x,
-        .y = y,
-    };
-}
-
 static const int ACTION_DOWN = 1;
 static const int ACTION_UP = 1 << 1;
 
@@ -487,11 +460,17 @@ convert_touch(const SDL_TouchFingerEvent *from, struct screen *screen,
 
     to->inject_touch_event.pointer_id = from->fingerId;
     to->inject_touch_event.position.screen_size = screen->frame_size;
+
+    int ww;
+    int wh;
+    SDL_GL_GetDrawableSize(screen->window, &ww, &wh);
+
     // SDL touch event coordinates are normalized in the range [0; 1]
-    float x = from->x * screen->content_size.width;
-    float y = from->y * screen->content_size.height;
+    int32_t x = from->x * ww;
+    int32_t y = from->y * wh;
     to->inject_touch_event.position.point =
         screen_convert_to_frame_coords(screen, x, y);
+
     to->inject_touch_event.pressure = from->pressure;
     to->inject_touch_event.buttons = 0;
     return true;
@@ -506,13 +485,6 @@ input_manager_process_touch(struct input_manager *im,
             LOGW("Could not request 'inject touch event'");
         }
     }
-}
-
-static bool
-is_outside_device_screen(struct input_manager *im, int x, int y)
-{
-    return x < 0 || x >= im->screen->content_size.width ||
-           y < 0 || y >= im->screen->content_size.height;
 }
 
 static bool
@@ -552,10 +524,14 @@ input_manager_process_mouse_button(struct input_manager *im,
             action_home(im->controller, ACTION_DOWN | ACTION_UP);
             return;
         }
+
         // double-click on black borders resize to fit the device screen
         if (event->button == SDL_BUTTON_LEFT && event->clicks == 2) {
-            bool outside =
-                is_outside_device_screen(im, event->x, event->y);
+            int x = event->x;
+            int y = event->y;
+            SDL_Rect *r = &im->screen->rect;
+            bool outside = x < r->x || x >= r->x + r->w
+                        || y < r->y || y >= r->y + r->h;
             if (outside) {
                 screen_resize_to_fit(im->screen);
                 return;
@@ -579,9 +555,15 @@ input_manager_process_mouse_button(struct input_manager *im,
 static bool
 convert_mouse_wheel(const SDL_MouseWheelEvent *from, struct screen *screen,
                     struct control_msg *to) {
+
+    // mouse_x and mouse_y are expressed in pixels relative to the window
+    int mouse_x;
+    int mouse_y;
+    SDL_GetMouseState(&mouse_x, &mouse_y);
+
     struct position position = {
         .screen_size = screen->frame_size,
-        .point = get_mouse_point(screen),
+        .point = screen_convert_to_frame_coords(screen, mouse_x, mouse_y),
     };
 
     to->type = CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -601,9 +601,14 @@ screen_convert_to_frame_coords(struct screen *screen, int32_t x, int32_t y) {
     int32_t w = screen->content_size.width;
     int32_t h = screen->content_size.height;
 
-    // scale
-    x = (x - screen->rect.x) * w / screen->rect.w;
-    y = (y - screen->rect.y) * h / screen->rect.h;
+    // take the HiDPI scaling (dw/ww and dh/wh) into account
+    int ww, wh, dw, dh;
+    SDL_GetWindowSize(screen->window, &ww, &wh);
+    SDL_GL_GetDrawableSize(screen->window, &dw, &dh);
+
+    // scale (64 bits for intermediate multiplications)
+    x = (int64_t) (x - screen->rect.x) * w * dw / (screen->rect.w * ww);
+    y = (int64_t) (y - screen->rect.y) * h * dh / (screen->rect.h * wh);
 
     // rotate
     struct point result;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -435,6 +435,11 @@ screen_update_frame(struct screen *screen, struct video_buffer *vb) {
 }
 
 void
+screen_window_resized(struct screen *screen) {
+    screen_render(screen);
+}
+
+void
 screen_render(struct screen *screen) {
     SDL_RenderClear(screen->renderer);
     if (screen->rotation == 0) {
@@ -532,7 +537,7 @@ screen_handle_window_event(struct screen *screen,
                 // window is maximized or fullscreen is enabled.
                 screen->windowed_window_size = get_window_size(screen->window);
             }
-            screen_render(screen);
+            screen_window_resized(screen);
             break;
         case SDL_WINDOWEVENT_MAXIMIZED:
             // The backup size must be non-nul.

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -162,6 +162,32 @@ get_initial_optimal_size(struct size content_size, uint16_t req_width,
     return window_size;
 }
 
+static void
+update_content_rect(struct screen *screen) {
+    int ww;
+    int wh;
+    SDL_GL_GetDrawableSize(screen->window, &ww, &wh);
+
+    // 32 bits because we need to multiply two 16 bits values
+    uint32_t cw = screen->content_size.width;
+    uint32_t ch = screen->content_size.height;
+
+    SDL_Rect *rect = &screen->rect;
+
+    bool keep_width = cw * wh > ch * ww;
+    if (keep_width) {
+        rect->x = 0;
+        rect->w = ww;
+        rect->h = ww * ch / cw;
+        rect->y = (wh - rect->h) / 2;
+    } else {
+        rect->y = 0;
+        rect->h = wh;
+        rect->w = wh * cw / ch;
+        rect->x = (ww - rect->w) / 2;
+    }
+}
+
 void
 screen_init(struct screen *screen) {
     *screen = (struct screen) SCREEN_INITIALIZER;
@@ -251,13 +277,6 @@ screen_init_rendering(struct screen *screen, const char *window_title,
     const char *renderer_name = r ? NULL : renderer_info.name;
     LOGI("Renderer: %s", renderer_name ? renderer_name : "(unknown)");
 
-    if (SDL_RenderSetLogicalSize(screen->renderer, content_size.width,
-                                 content_size.height)) {
-        LOGE("Could not set renderer logical size: %s", SDL_GetError());
-        screen_destroy(screen);
-        return false;
-    }
-
     // stats with "opengl"
     screen->use_opengl = renderer_name && !strncmp(renderer_name, "opengl", 6);
     if (screen->use_opengl) {
@@ -301,6 +320,8 @@ screen_init_rendering(struct screen *screen, const char *window_title,
         return false;
     }
 
+    update_content_rect(screen);
+
     screen->windowed_window_size = window_size;
 
     return true;
@@ -335,13 +356,6 @@ screen_set_rotation(struct screen *screen, unsigned rotation) {
     struct size new_content_size =
         get_rotated_size(screen->frame_size, rotation);
 
-    if (SDL_RenderSetLogicalSize(screen->renderer,
-                                 new_content_size.width,
-                                 new_content_size.height)) {
-        LOGE("Could not set renderer logical size: %s", SDL_GetError());
-        return;
-    }
-
     struct size windowed_size = get_windowed_window_size(screen);
     struct size target_size = {
         .width = (uint32_t) windowed_size.width * new_content_size.width
@@ -356,6 +370,7 @@ screen_set_rotation(struct screen *screen, unsigned rotation) {
     screen->rotation = rotation;
     LOGI("Display rotation set to %u", rotation);
 
+    update_content_rect(screen);
     screen_render(screen);
 }
 
@@ -364,18 +379,11 @@ static bool
 prepare_for_frame(struct screen *screen, struct size new_frame_size) {
     if (screen->frame_size.width != new_frame_size.width
             || screen->frame_size.height != new_frame_size.height) {
-        struct size new_content_size =
-            get_rotated_size(new_frame_size, screen->rotation);
-        if (SDL_RenderSetLogicalSize(screen->renderer,
-                                     new_content_size.width,
-                                     new_content_size.height)) {
-            LOGE("Could not set renderer logical size: %s", SDL_GetError());
-            return false;
-        }
-
         // frame dimension changed, destroy texture
         SDL_DestroyTexture(screen->texture);
 
+        struct size new_content_size =
+            get_rotated_size(new_frame_size, screen->rotation);
         struct size content_size = screen->content_size;
         struct size windowed_size = get_windowed_window_size(screen);
         struct size target_size = {
@@ -389,6 +397,7 @@ prepare_for_frame(struct screen *screen, struct size new_frame_size) {
 
         screen->frame_size = new_frame_size;
         screen->content_size = new_content_size;
+        update_content_rect(screen);
 
         LOGI("New texture: %" PRIu16 "x%" PRIu16,
                      screen->frame_size.width, screen->frame_size.height);
@@ -436,6 +445,7 @@ screen_update_frame(struct screen *screen, struct video_buffer *vb) {
 
 void
 screen_window_resized(struct screen *screen) {
+    update_content_rect(screen);
     screen_render(screen);
 }
 
@@ -443,7 +453,7 @@ void
 screen_render(struct screen *screen) {
     SDL_RenderClear(screen->renderer);
     if (screen->rotation == 0) {
-        SDL_RenderCopy(screen->renderer, screen->texture, NULL, NULL);
+        SDL_RenderCopy(screen->renderer, screen->texture, NULL, &screen->rect);
     } else {
         // rotation in RenderCopyEx() is clockwise, while screen->rotation is
         // counterclockwise (to be consistent with --lock-video-orientation)
@@ -453,12 +463,14 @@ screen_render(struct screen *screen) {
         SDL_Rect *dstrect = NULL;
         SDL_Rect rect;
         if (screen->rotation & 1) {
-            struct size size = screen->content_size;
-            rect.x = (size.width - size.height) / 2;
-            rect.y = (size.height - size.width) / 2;
-            rect.w = size.height;
-            rect.h = size.width;
+            rect.x = screen->rect.x + (screen->rect.w - screen->rect.h) / 2;
+            rect.y = screen->rect.y + (screen->rect.h - screen->rect.w) / 2;
+            rect.w = screen->rect.h;
+            rect.h = screen->rect.w;
             dstrect = &rect;
+        } else {
+            assert(screen->rotation == 2);
+            dstrect = &screen->rect;
         }
 
         SDL_RenderCopyEx(screen->renderer, screen->texture, NULL, dstrect,
@@ -566,6 +578,12 @@ screen_convert_to_frame_coords(struct screen *screen, int32_t x, int32_t y) {
 
     int32_t w = screen->content_size.width;
     int32_t h = screen->content_size.height;
+
+    // scale
+    x = (x - screen->rect.x) * w / screen->rect.w;
+    y = (y - screen->rect.y) * h / screen->rect.h;
+
+    // rotate
     struct point result;
     switch (rotation) {
         case 0:

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -90,6 +90,10 @@ screen_destroy(struct screen *screen);
 bool
 screen_update_frame(struct screen *screen, struct video_buffer *vb);
 
+// update content after window resizing
+void
+screen_window_resized(struct screen *screen);
+
 // render the texture to the renderer
 void
 screen_render(struct screen *screen);

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -28,6 +28,8 @@ struct screen {
     struct size windowed_window_size_backup;
     // client rotation: 0, 1, 2 or 3 (x90 degrees counterclockwise)
     unsigned rotation;
+    // rectangle of the content (excluding black borders)
+    struct SDL_Rect rect;
     bool has_frame;
     bool fullscreen;
     bool maximized;
@@ -58,6 +60,12 @@ struct screen {
         .height = 0, \
     }, \
     .rotation = 0, \
+    .rect = { \
+        .x = 0, \
+        .y = 0, \
+        .w = 0, \
+        .h = 0, \
+    }, \
     .has_frame = false, \
     .fullscreen = false, \
     .maximized = false, \


### PR DESCRIPTION
This patchset removes calls to `SDL_RenderSetLogicalSize()` and position and scale the content (and the events) manually.

This has several benefits:
 - it allows to avoid rounding inconsistencies between internal SDL logical size and the window size (causing 1 unexpected row/column of pixels blacks in the "optimal size")
 - it will make possible to draw visual feedback for #24 in the future
 - it can possibly help to fix #15

It's been a long time since I want to do this change, but it is quite "dangerous" as it impacts heavily the rendering and the event forwarding.

Therefore, I'm very interested in testing from users. Especially on macOS (but not only) (because I don't have any macOS to test), especially with HiDPI (but not only), especially with a secondary monitor (#15) (but not only).

Please also test clicks after window rotation (Ctrl+Left and Ctrl+Right, a new feature in the next release).

In theory, this is the last remaining change I would like to merge before a new release.

Thank you for your feedbacks.

EDIT: please test `logical_size.8` instead