### PR TITLE
Rendering rework

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -7,33 +7,6 @@
 #include "util/lock.h"
 #include "util/log.h"
 
-// Convert window coordinates (as provided by SDL_GetMouseState() to renderer
-// coordinates (as provided in SDL mouse events)
-//
-// See my question:
-// <https://stackoverflow.com/questions/49111054/how-to-get-mouse-position-on-mouse-wheel-event>
-static void
-convert_to_renderer_coordinates(SDL_Renderer *renderer, int *x, int *y) {
-    SDL_Rect viewport;
-    float scale_x, scale_y;
-    SDL_RenderGetViewport(renderer, &viewport);
-    SDL_RenderGetScale(renderer, &scale_x, &scale_y);
-    *x = (int) (*x / scale_x) - viewport.x;
-    *y = (int) (*y / scale_y) - viewport.y;
-}
-
-static struct point
-get_mouse_point(struct screen *screen) {
-    int x;
-    int y;
-    SDL_GetMouseState(&x, &y);
-    convert_to_renderer_coordinates(screen->renderer, &x, &y);
-    return (struct point) {
-        .x = x,
-        .y = y,
-    };
-}
-
 static const int ACTION_DOWN = 1;
 static const int ACTION_UP = 1 << 1;
 
@@ -487,11 +460,17 @@ convert_touch(const SDL_TouchFingerEvent *from, struct screen *screen,
 
     to->inject_touch_event.pointer_id = from->fingerId;
     to->inject_touch_event.position.screen_size = screen->frame_size;
+
+    int ww;
+    int wh;
+    SDL_GL_GetDrawableSize(screen->window, &ww, &wh);
+
     // SDL touch event coordinates are normalized in the range [0; 1]
-    float x = from->x * screen->content_size.width;
-    float y = from->y * screen->content_size.height;
+    int32_t x = from->x * ww;
+    int32_t y = from->y * wh;
     to->inject_touch_event.position.point =
         screen_convert_to_frame_coords(screen, x, y);
+
     to->inject_touch_event.pressure = from->pressure;
     to->inject_touch_event.buttons = 0;
     return true;
@@ -506,13 +485,6 @@ input_manager_process_touch(struct input_manager *im,
             LOGW("Could not request 'inject touch event'");
         }
     }
-}
-
-static bool
-is_outside_device_screen(struct input_manager *im, int x, int y)
-{
-    return x < 0 || x >= im->screen->content_size.width ||
-           y < 0 || y >= im->screen->content_size.height;
 }
 
 static bool
@@ -552,10 +524,15 @@ input_manager_process_mouse_button(struct input_manager *im,
             action_home(im->controller, ACTION_DOWN | ACTION_UP);
             return;
         }
+
         // double-click on black borders resize to fit the device screen
         if (event->button == SDL_BUTTON_LEFT && event->clicks == 2) {
-            bool outside =
-                is_outside_device_screen(im, event->x, event->y);
+            int32_t x = event->x;
+            int32_t y = event->y;
+            screen_hidpi_scale_coords(im->screen, &x, &y);
+            SDL_Rect *r = &im->screen->rect;
+            bool outside = x < r->x || x >= r->x + r->w
+                        || y < r->y || y >= r->y + r->h;
             if (outside) {
                 screen_resize_to_fit(im->screen);
                 return;
@@ -579,9 +556,15 @@ input_manager_process_mouse_button(struct input_manager *im,
 static bool
 convert_mouse_wheel(const SDL_MouseWheelEvent *from, struct screen *screen,
                     struct control_msg *to) {
+
+    // mouse_x and mouse_y are expressed in pixels relative to the window
+    int mouse_x;
+    int mouse_y;
+    SDL_GetMouseState(&mouse_x, &mouse_y);
+
     struct position position = {
         .screen_size = screen->frame_size,
-        .point = get_mouse_point(screen),
+        .point = screen_convert_to_frame_coords(screen, mouse_x, mouse_y),
     };
 
     to->type = CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -136,7 +136,7 @@ event_watcher(void *data, SDL_Event *event) {
             && event->window.event == SDL_WINDOWEVENT_RESIZED) {
         // In practice, it seems to always be called from the same thread in
         // that specific case. Anyway, it's just a workaround.
-        screen_render(&screen);
+        screen_render(&screen, true);
     }
     return 0;
 }

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -531,6 +531,13 @@ screen_handle_window_event(struct screen *screen,
             screen->maximized = true;
             break;
         case SDL_WINDOWEVENT_RESTORED:
+            if (screen->fullscreen) {
+                // On Windows, in maximized+fullscreen, disabling fullscreen
+                // mode unexpectedly triggers the "restored" then "maximized"
+                // events, leaving the window in a weird state (maximized
+                // according to the events, but not maximized visually).
+                break;
+            }
             screen->maximized = false;
             apply_pending_resize(screen);
             break;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -484,13 +484,8 @@ screen_switch_fullscreen(struct screen *screen) {
 
 void
 screen_resize_to_fit(struct screen *screen) {
-    if (screen->fullscreen) {
+    if (screen->fullscreen || screen->maximized) {
         return;
-    }
-
-    if (screen->maximized) {
-        SDL_RestoreWindow(screen->window);
-        screen->maximized = false;
     }
 
     struct size optimal_size =

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -325,6 +325,11 @@ screen_init_rendering(struct screen *screen, const char *window_title,
         return false;
     }
 
+    // Reset the window size to trigger a SIZE_CHANGED event, to workaround
+    // HiDPI issues with some SDL renderers when several displays having
+    // different HiDPI scaling are connected
+    SDL_SetWindowSize(screen->window, window_size.width, window_size.height);
+
     screen_update_content_rect(screen);
 
     return true;

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -21,11 +21,12 @@ struct screen {
     struct sc_opengl gl;
     struct size frame_size;
     struct size content_size; // rotated frame_size
-    // The window size the last time it was not maximized or fullscreen.
-    struct size windowed_window_size;
-    // Since we receive the event SIZE_CHANGED before MAXIMIZED, we must be
-    // able to revert the size to its non-maximized value.
-    struct size windowed_window_size_backup;
+
+    bool resize_pending; // resize requested while fullscreen or maximized
+    // The content size the last time the window was not maximized or
+    // fullscreen (meaningful only when resize_pending is true)
+    struct size windowed_content_size;
+
     // client rotation: 0, 1, 2 or 3 (x90 degrees counterclockwise)
     unsigned rotation;
     bool has_frame;
@@ -49,11 +50,8 @@ struct screen {
         .width = 0, \
         .height = 0, \
     }, \
-    .windowed_window_size = { \
-        .width = 0, \
-        .height = 0, \
-    }, \
-    .windowed_window_size_backup = { \
+    .resize_pending = false, \
+    .windowed_content_size = { \
         .width = 0, \
         .height = 0, \
     }, \

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -29,6 +29,8 @@ struct screen {
 
     // client rotation: 0, 1, 2 or 3 (x90 degrees counterclockwise)
     unsigned rotation;
+    // rectangle of the content (excluding black borders)
+    struct SDL_Rect rect;
     bool has_frame;
     bool fullscreen;
     bool maximized;
@@ -56,6 +58,12 @@ struct screen {
         .height = 0, \
     }, \
     .rotation = 0, \
+    .rect = { \
+        .x = 0, \
+        .y = 0, \
+        .w = 0, \
+        .h = 0, \
+    }, \
     .has_frame = false, \
     .fullscreen = false, \
     .maximized = false, \
@@ -89,8 +97,11 @@ bool
 screen_update_frame(struct screen *screen, struct video_buffer *vb);
 
 // render the texture to the renderer
+//
+// Set the update_content_rect flag if the window or content size may have
+// changed, so that the content rectangle is recomputed
 void
-screen_render(struct screen *screen);
+screen_render(struct screen *screen, bool update_content_rect);
 
 // switch the fullscreen mode
 void
@@ -116,5 +127,12 @@ screen_handle_window_event(struct screen *screen, const SDL_WindowEvent *event);
 // x and y are expressed in pixels
 struct point
 screen_convert_to_frame_coords(struct screen *screen, int32_t x, int32_t y);
+
+// Convert coordinates from window to drawable.
+// Events are expressed in window coordinates, but content is expressed in
+// drawable coordinates. They are the same if HiDPI scaling is 1, but differ
+// otherwise.
+void
+screen_hidpi_scale_coords(struct screen *screen, int32_t *x, int32_t *y);
 
 #endif


### PR DESCRIPTION
I reworked many things related to the window/rendering.

Firstly, I improved the maximized/fullscreen handling to avoid weird behaviors on some platforms (see commit messages 6dc113e67b4484fa402daeeb6e6ccacb021a9eb2 and eb189ceaab80433f682e847ab5d297edde3c52a6).

Then, (as a followup of #1307 that I closed because it was not ready) I reworked the rendering to position and scale the content (and the events) manually (i.e. without using the SDL "logical size" feature). (commit a6dcbf34bade4d8d71bdac15c04ff1cd12ce9450)

It has several benefits:
 - it allows to avoid rounding inconsistencies between internal SDL logical size and the window size (causing 1 unexpected row/column of pixels blacks in the "optimal size")
 - it will make possible to draw visual feedback at the expected size (for #24 for example) in the future
 - above all, it fixes #15 :tada:

I am now quite confident that it works correctly.

But since it impacts heavily the rendering and the event forwarding (which must NOT be broken at all), more tests from users are welcome:
 - if you can, also test with a secondary screen
 - check that clicks are correctly applied at the right position
   - even if you resize so that there are black borders
   - both in fullscreen or maximized or normal state
   - with or without content rotation (`Ctrl`+`←` / `Ctrl`+`→`)
 - try to maximize, then fullscreen (both `Ctrl`+`f` and "expand to fullscreen", which behaves differently), rotate device, then unfullscreen (check that the window is correctly restored in maximized state), then unmaximize (check that the window is correctly restored at the correct size).
 - use the app normally, you could find other edge cases :)

## Binaries

To simplify testing, here are binaries.

For windows users, take both `scrcpy.exe` and `scrcpy-server`, and replace them in your scrcpy v1.13 release.

For other platforms, take `scrcpy-server` and [build](https://github.com/Genymobile/scrcpy/blob/master/BUILD.md#prebuilt-server) only the client.


 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/pr1408/scrcpy.exe)
  _SHA256: 7d61f31c8e33aa1b70a43b38b7c40c7e5289683a959e8426b34c3a488a385186_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/pr1408/scrcpy-server)
  _SHA256: 6d124307e081b8bbccc478dcf82731aad3cc994e7502197c9bae3847d3169dc7_

Thank you for your feedbacks :wink: