### PR TITLE
please surpport send input event to extented display on smartisan nut pro3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+ - [ ] I have read the [FAQ](https://github.com/Genymobile/scrcpy/blob/master/FAQ.md).
+ - [ ] I have searched in existing [issues](https://github.com/Genymobile/scrcpy/issues).
+
+**Environment**
+ - OS: [e.g. Debian, Windows, macOS...]
+ - scrcpy version: [e.g. 1.12.1]
+ - installation method: [e.g. manual build, apt, snap, brew, Windows release...]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+On errors, please provide the output of the console (and `adb logcat` if relevant).
+Format them between code blocks (delimited by ```).
+Please do not post screenshots of your terminal, just post the content as text instead.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+ - [ ] I have checked that a similar [feature request](https://github.com/Genymobile/scrcpy/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature+request%22) does not already exist.
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
adb shell input --ext-display tap/swipe... This commend can sending event to extented display,
so it is very useful for scrcpy --display 2 .
it also can solve the issue "Input events are not supported for secondary displays before Android 10".
Because "adb shell input --ext-display keyevent " can send input to secondary displays on android 9.
it is very useful  for  samrtisan   tnt.
Thank you very much.