### PR TITLE
Implement seamless copy-paste from Android to computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ both directions:
  - `Ctrl`+`v` _pastes_ the computer clipboard as a sequence of text events (but
    breaks non-ASCII characters).
 
+Moreover, any time the Android clipboard changes, it is automatically
+synchronized to the computer clipboard.
+
 #### Text injection preference
 
 There are two kinds of [events][textevents] generated when typing text:

--- a/server/src/main/aidl/android/content/IOnPrimaryClipChangedListener.aidl
+++ b/server/src/main/aidl/android/content/IOnPrimaryClipChangedListener.aidl
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2008, The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package android.content;
+
+/**
+ * {@hide}
+ */
+oneway interface IOnPrimaryClipChangedListener {
+    void dispatchPrimaryClipChanged();
+}

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -53,11 +53,18 @@ public final class Server {
             ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps());
 
             if (options.getControl()) {
-                Controller controller = new Controller(device, connection);
+                final Controller controller = new Controller(device, connection);
 
                 // asynchronous
                 startController(controller);
                 startDeviceMessageSender(controller.getSender());
+
+                device.setClipboardListener(new Device.ClipboardListener() {
+                    @Override
+                    public void onClipboardTextChanged(String text) {
+                        controller.getSender().pushClipboardText(text);
+                    }
+                });
             }
 
             try {


### PR DESCRIPTION
Automatically synchronize the device clipboard to the computer any time it changes.

Refs https://github.com/Genymobile/scrcpy/issues/1056#issuecomment-631261693

---

To test, just copy some text on the Android device while scrcpy is running, then Ctrl+v in some text area on the computer.

The other direction is not synchronized automatically, because:
 - [SDL](https://wiki.libsdl.org/CategoryClipboard) does not provide a notification mechanism to listen to clipboard changes
 - it could leak data unexpectedly (if I copy from my password manager on the computer while scrcpy is running, I don't expect my password to be copied to the device, the other direction is less problematic IMO, because it is expected that the computer can access the device)

Here are binaries so that you can test even if you don't know how to build:

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/pr1423/1/scrcpy.exe)
  _SHA256: a89ce793ee5d1e9177288f5b3756986015c76d0200521ad1cb227f782bfda095_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/pr1423/1/scrcpy-server)
  _SHA256: e076176b01a70554188b9728f06b3d65dab63245be19c6b33ded2939008265eb_

_(on Windows, replace both files in the v1.13 release; on other platforms, use `scrcpy-server` and follow [§Prebuilt server](https://github.com/Genymobile/scrcpy/blob/master/BUILD.md#prebuilt-server))_