### PR TITLE
Inject UTF-8 text

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -1,10 +1,7 @@
 package com.genymobile.scrcpy;
 
-import com.genymobile.scrcpy.wrappers.InputManager;
-
 import android.os.SystemClock;
 import android.view.InputDevice;
-import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -50,7 +47,7 @@ public class Controller {
     public void control() throws IOException {
         // on start, power on the device
         if (!device.isScreenOn()) {
-            injectKeycode(KeyEvent.KEYCODE_POWER);
+            device.injectKeycode(KeyEvent.KEYCODE_POWER);
 
             // dirty hack
             // After POWER is injected, the device is powered on asynchronously.
@@ -133,7 +130,7 @@ public class Controller {
     }
 
     private boolean injectKeycode(int action, int keycode, int metaState) {
-        return injectKeyEvent(action, keycode, 0, metaState);
+        return device.injectKeyEvent(action, keycode, 0, metaState);
     }
 
     private boolean injectChar(char c) {
@@ -144,7 +141,7 @@ public class Controller {
             return false;
         }
         for (KeyEvent event : events) {
-            if (!injectEvent(event)) {
+            if (!device.injectEvent(event)) {
                 return false;
             }
         }
@@ -200,7 +197,7 @@ public class Controller {
         MotionEvent event = MotionEvent
                 .obtain(lastTouchDown, now, action, pointerCount, pointerProperties, pointerCoords, 0, buttons, 1f, 1f, DEVICE_ID_VIRTUAL, 0,
                         InputDevice.SOURCE_TOUCHSCREEN, 0);
-        return injectEvent(event);
+        return device.injectEvent(event);
     }
 
     private boolean injectScroll(Position position, int hScroll, int vScroll) {
@@ -223,26 +220,11 @@ public class Controller {
         MotionEvent event = MotionEvent
                 .obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, 0, 1f, 1f, DEVICE_ID_VIRTUAL, 0,
                         InputDevice.SOURCE_TOUCHSCREEN, 0);
-        return injectEvent(event);
-    }
-
-    private boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState) {
-        long now = SystemClock.uptimeMillis();
-        KeyEvent event = new KeyEvent(now, now, action, keyCode, repeat, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
-                InputDevice.SOURCE_KEYBOARD);
-        return injectEvent(event);
-    }
-
-    private boolean injectKeycode(int keyCode) {
-        return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0) && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0);
-    }
-
-    private boolean injectEvent(InputEvent event) {
-        return device.injectInputEvent(event, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+        return device.injectEvent(event);
     }
 
     private boolean pressBackOrTurnScreenOn() {
         int keycode = device.isScreenOn() ? KeyEvent.KEYCODE_BACK : KeyEvent.KEYCODE_POWER;
-        return injectKeycode(keycode);
+        return device.injectKeycode(keycode);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -149,6 +149,10 @@ public class Controller {
     }
 
     private int injectText(String text) {
+        if (device.injectTextPaste(text)) {
+            // The best method (fastest and UTF-8) worked!
+            return text.length();
+        }
         int successCount = 0;
         for (char c : text.toCharArray()) {
             if (!injectChar(c)) {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -10,8 +10,12 @@ import android.content.IOnPrimaryClipChangedListener;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
+import android.os.SystemClock;
 import android.view.IRotationWatcher;
+import android.view.InputDevice;
 import android.view.InputEvent;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -147,7 +151,7 @@ public final class Device {
         return supportsInputEvents;
     }
 
-    public boolean injectInputEvent(InputEvent inputEvent, int mode) {
+    public boolean injectEvent(InputEvent inputEvent, int mode) {
         if (!supportsInputEvents()) {
             throw new AssertionError("Could not inject input event if !supportsInputEvents()");
         }
@@ -157,6 +161,21 @@ public final class Device {
         }
 
         return serviceManager.getInputManager().injectInputEvent(inputEvent, mode);
+    }
+
+    public boolean injectEvent(InputEvent event) {
+        return injectEvent(event, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+    }
+
+    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState) {
+        long now = SystemClock.uptimeMillis();
+        KeyEvent event = new KeyEvent(now, now, action, keyCode, repeat, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
+                InputDevice.SOURCE_KEYBOARD);
+        return injectEvent(event);
+    }
+
+    public boolean injectKeycode(int keyCode) {
+        return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0) && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0);
     }
 
     public boolean isScreenOn() {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -167,15 +167,23 @@ public final class Device {
         return injectEvent(event, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
     }
 
-    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState) {
+    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int mode) {
         long now = SystemClock.uptimeMillis();
         KeyEvent event = new KeyEvent(now, now, action, keyCode, repeat, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
                 InputDevice.SOURCE_KEYBOARD);
-        return injectEvent(event);
+        return injectEvent(event, mode);
+    }
+
+    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState) {
+        return injectKeyEvent(action, keyCode, repeat, metaState, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+    }
+
+    public boolean injectKeycode(int keyCode, int mode) {
+        return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0) && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0, mode);
     }
 
     public boolean injectKeycode(int keyCode) {
-        return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0) && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0);
+        return injectKeycode(keyCode, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
     }
 
     public boolean isScreenOn() {


### PR DESCRIPTION
Since Android 7, we could use the PASTE keycode to inject UTF-8 text, instead of injecting every ASCII char sequentially. (ref: https://github.com/Genymobile/scrcpy/issues/786#issuecomment-528308353)

So I just implemented it.

If the device runs Android >= 7:
 - backup the clipboard
 - set the text to inject into the clipboard
 - inject the PASTE key code
 - restore the clipboard

It is very fast and allows to inject UTF-8 text, which is awesome for non-ASCII languages like Chinese.

Please test and report any problem.

Thank you for your feedbacks.

---

Here are binaries so that you can test even if you don't know how to build:

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/pr1426/1/scrcpy.exe)
  _SHA256: 4481d854630aaba9f31e4f3a19b46c4843c1918da03e1a486089bae3a3ebb09a_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/pr1426/1/scrcpy-server)
  _SHA256: 64cd4d4277040430c48d35677ad8472a6315337651fb9cfc5f62cf5abf2021b7_

_(on Windows, replace both files in the v1.13 release; on other platforms, use `scrcpy-server` and follow [§Prebuilt server](https://github.com/Genymobile/scrcpy/blob/master/BUILD.md#prebuilt-server))_