### PR TITLE
Forward RCtrl to the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,30 +560,33 @@ Also see [issue #14].
 
 ## Shortcuts
 
+`LCtrl` is the left `Ctrl` key (the right `Ctrl` key is forwarded to the
+device).
+
  | Action                                      |   Shortcut                    |   Shortcut (macOS)
  | ------------------------------------------- |:----------------------------- |:-----------------------------
- | Switch fullscreen mode                      | `Ctrl`+`f`                    | `Cmd`+`f`
- | Rotate display left                         | `Ctrl`+`←` _(left)_           | `Cmd`+`←` _(left)_
- | Rotate display right                        | `Ctrl`+`→` _(right)_          | `Cmd`+`→` _(right)_
- | Resize window to 1:1 (pixel-perfect)        | `Ctrl`+`g`                    | `Cmd`+`g`
- | Resize window to remove black borders       | `Ctrl`+`x` \| _Double-click¹_ | `Cmd`+`x`  \| _Double-click¹_
- | Click on `HOME`                             | `Ctrl`+`h` \| _Middle-click_  | `Ctrl`+`h` \| _Middle-click_
- | Click on `BACK`                             | `Ctrl`+`b` \| _Right-click²_  | `Cmd`+`b`  \| _Right-click²_
- | Click on `APP_SWITCH`                       | `Ctrl`+`s`                    | `Cmd`+`s`
- | Click on `MENU`                             | `Ctrl`+`m`                    | `Ctrl`+`m`
- | Click on `VOLUME_UP`                        | `Ctrl`+`↑` _(up)_             | `Cmd`+`↑` _(up)_
- | Click on `VOLUME_DOWN`                      | `Ctrl`+`↓` _(down)_           | `Cmd`+`↓` _(down)_
- | Click on `POWER`                            | `Ctrl`+`p`                    | `Cmd`+`p`
- | Power on                                    | _Right-click²_                | _Right-click²_
- | Turn device screen off (keep mirroring)     | `Ctrl`+`o`                    | `Cmd`+`o`
- | Turn device screen on                       | `Ctrl`+`Shift`+`o`            | `Cmd`+`Shift`+`o`
- | Rotate device screen                        | `Ctrl`+`r`                    | `Cmd`+`r`
- | Expand notification panel                   | `Ctrl`+`n`                    | `Cmd`+`n`
- | Collapse notification panel                 | `Ctrl`+`Shift`+`n`            | `Cmd`+`Shift`+`n`
- | Copy device clipboard to computer           | `Ctrl`+`c`                    | `Cmd`+`c`
- | Paste computer clipboard to device          | `Ctrl`+`v`                    | `Cmd`+`v`
- | Copy computer clipboard to device and paste | `Ctrl`+`Shift`+`v`            | `Cmd`+`Shift`+`v`
- | Enable/disable FPS counter (on stdout)      | `Ctrl`+`i`                    | `Cmd`+`i`
+ | Switch fullscreen mode                      | `LCtrl`+`f`                    | `Cmd`+`f`
+ | Rotate display left                         | `LCtrl`+`←` _(left)_           | `Cmd`+`←` _(left)_
+ | Rotate display right                        | `LCtrl`+`→` _(right)_          | `Cmd`+`→` _(right)_
+ | Resize window to 1:1 (pixel-perfect)        | `LCtrl`+`g`                    | `Cmd`+`g`
+ | Resize window to remove black borders       | `LCtrl`+`x` \| _Double-click¹_ | `Cmd`+`x`  \| _Double-click¹_
+ | Click on `HOME`                             | `LCtrl`+`h` \| _Middle-click_  | `Ctrl`+`h` \| _Middle-click_
+ | Click on `BACK`                             | `LCtrl`+`b` \| _Right-click²_  | `Cmd`+`b`  \| _Right-click²_
+ | Click on `APP_SWITCH`                       | `LCtrl`+`s`                    | `Cmd`+`s`
+ | Click on `MENU`                             | `LCtrl`+`m`                    | `Ctrl`+`m`
+ | Click on `VOLUME_UP`                        | `LCtrl`+`↑` _(up)_             | `Cmd`+`↑` _(up)_
+ | Click on `VOLUME_DOWN`                      | `LCtrl`+`↓` _(down)_           | `Cmd`+`↓` _(down)_
+ | Click on `POWER`                            | `LCtrl`+`p`                    | `Cmd`+`p`
+ | Power on                                    | _Right-click²_                 | _Right-click²_
+ | Turn device screen off (keep mirroring)     | `LCtrl`+`o`                    | `Cmd`+`o`
+ | Turn device screen on                       | `LCtrl`+`Shift`+`o`            | `Cmd`+`Shift`+`o`
+ | Rotate device screen                        | `LCtrl`+`r`                    | `Cmd`+`r`
+ | Expand notification panel                   | `LCtrl`+`n`                    | `Cmd`+`n`
+ | Collapse notification panel                 | `LCtrl`+`Shift`+`n`            | `Cmd`+`Shift`+`n`
+ | Copy device clipboard to computer           | `LCtrl`+`c`                    | `Cmd`+`c`
+ | Paste computer clipboard to device          | `LCtrl`+`v`                    | `Cmd`+`v`
+ | Copy computer clipboard to device and paste | `LCtrl`+`Shift`+`v`            | `Cmd`+`Shift`+`v`
+ | Enable/disable FPS counter (on stdout)      | `LCtrl`+`i`                    | `Cmd`+`i`
 
 _¹Double-click on black borders to remove them._  
 _²Right-click turns the screen on if it was off, presses BACK otherwise._

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -203,52 +203,54 @@ Default is 0 (automatic).\n
 
 .SH SHORTCUTS
 
+\fBLCtrl\fR is the left Ctrl key (the right Ctrl key is forwarded to the device).
+
 .TP
-.B Ctrl+f
+.B LCtrl+f
 Switch fullscreen mode
 
 .TP
-.B Ctrl+Left
+.B LCtrl+Left
 Rotate display left
 
 .TP
-.B Ctrl+Right
+.B LCtrl+Right
 Rotate display right
 
 .TP
-.B Ctrl+g
+.B LCtrl+g
 Resize window to 1:1 (pixel\-perfect)
 
 .TP
-.B Ctrl+x, Double\-click on black borders
+.B LCtrl+x, Double\-click on black borders
 Resize window to remove black borders
 
 .TP
-.B Ctrl+h, Home, Middle\-click
+.B LCtrl+h, Home, Middle\-click
 Click on HOME
 
 .TP
-.B Ctrl+b, Ctrl+Backspace, Right\-click (when screen is on)
+.B LCtrl+b, Ctrl+Backspace, Right\-click (when screen is on)
 Click on BACK
 
 .TP
-.B Ctrl+s
+.B LCtrl+s
 Click on APP_SWITCH
 
 .TP
-.B Ctrl+m
+.B LCtrl+m
 Click on MENU
 
 .TP
-.B Ctrl+Up
+.B LCtrl+Up
 Click on VOLUME_UP
 
 .TP
-.B Ctrl+Down
+.B LCtrl+Down
 Click on VOLUME_DOWN
 
 .TP
-.B Ctrl+p
+.B LCtrl+p
 Click on POWER (turn screen on/off)
 
 .TP
@@ -256,39 +258,39 @@ Click on POWER (turn screen on/off)
 Turn screen on
 
 .TP
-.B Ctrl+o
+.B LCtrl+o
 Turn device screen off (keep mirroring)
 
 .TP
-.B Ctrl+Shift+o
+.B LCtrl+Shift+o
 Turn device screen on
 
 .TP
-.B Ctrl+r
+.B LCtrl+r
 Rotate device screen
 
 .TP
-.B Ctrl+n
+.B LCtrl+n
 Expand notification panel
 
 .TP
-.B Ctrl+Shift+n
+.B LCtrl+Shift+n
 Collapse notification panel
 
 .TP
-.B Ctrl+c
+.B LCtrl+c
 Copy device clipboard to computer
 
 .TP
-.B Ctrl+v
+.B LCtrl+v
 Paste computer clipboard to device
 
 .TP
-.B Ctrl+Shift+v
+.B LCtrl+Shift+v
 Copy computer clipboard to device (and paste if the device runs Android >= 7)
 
 .TP
-.B Ctrl+i
+.B LCtrl+i
 Enable/disable FPS counter (print frames/second in logs)
 
 .TP

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -15,7 +15,7 @@ scrcpy_print_usage(const char *arg0) {
 #ifdef __APPLE__
 # define CTRL_OR_CMD "Cmd"
 #else
-# define CTRL_OR_CMD "Ctrl"
+# define CTRL_OR_CMD "LCtrl"
 #endif
     fprintf(stderr,
         "Usage: %s [options]\n"
@@ -186,6 +186,9 @@ scrcpy_print_usage(const char *arg0) {
         "\n"
         "Shortcuts:\n"
         "\n"
+        "    LCtrl is the left Ctrl key (the right Ctrl key is forwarded to\n"
+        "    the device).\n"
+        "\n"
         "    " CTRL_OR_CMD "+f\n"
         "        Switch fullscreen mode\n"
         "\n"
@@ -202,7 +205,7 @@ scrcpy_print_usage(const char *arg0) {
         "    Double-click on black borders\n"
         "        Resize window to remove black borders\n"
         "\n"
-        "    Ctrl+h\n"
+        "    LCtrl+h\n"
         "    Middle-click\n"
         "        Click on HOME\n"
         "\n"
@@ -214,7 +217,7 @@ scrcpy_print_usage(const char *arg0) {
         "    " CTRL_OR_CMD "+s\n"
         "        Click on APP_SWITCH\n"
         "\n"
-        "    Ctrl+m\n"
+        "    LCtrl+m\n"
         "        Click on MENU\n"
         "\n"
         "    " CTRL_OR_CMD "+Up\n"

--- a/app/src/event_converter.c
+++ b/app/src/event_converter.c
@@ -92,6 +92,7 @@ convert_keycode(SDL_Keycode from, enum android_keycode *to, uint16_t mod,
         MAP(SDLK_LEFT,         AKEYCODE_DPAD_LEFT);
         MAP(SDLK_DOWN,         AKEYCODE_DPAD_DOWN);
         MAP(SDLK_UP,           AKEYCODE_DPAD_UP);
+        MAP(SDLK_RCTRL,        AKEYCODE_CTRL_RIGHT);
     }
 
     if (!(mod & (KMOD_NUM | KMOD_SHIFT))) {

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -259,7 +259,8 @@ input_manager_process_key(struct input_manager *im,
     // control: indicates the state of the command-line option --no-control
     // ctrl: the Ctrl key
 
-    bool ctrl = event->keysym.mod & (KMOD_LCTRL | KMOD_RCTRL);
+    // Only capture Left-Ctrl, Right-Ctrl is forwarded to the device
+    bool ctrl = event->keysym.mod & KMOD_LCTRL;
     bool alt = event->keysym.mod & (KMOD_LALT | KMOD_RALT);
     bool meta = event->keysym.mod & (KMOD_LGUI | KMOD_RGUI);
 


### PR DESCRIPTION
Only capture Left-Ctrl for scrcpy shortcuts, so that Right-Ctrl can be forwarded to the device.

Fixes #555

This allows for example to press `Ctrl`+`t` in Chrome to open a new tab (unfortunately, this shortcut does not work in Firefox) or to press `Ctrl`+`c` or `Ctrl`+`d` in Termux.

What do you think?

---

- [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/pr1446/1/scrcpy.exe)
  _SHA256: f07bb80ff82350a4b8d32bc6a00eeb9fc981a9c14bf7815018918dce09adb77c_

(to be replaced in v1.14 release)