### PR TITLE
fix: closes 1757

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -100,7 +100,7 @@ main(int argc, char *argv[]) {
 
 #if defined (__WINDOWS__) && ! defined (WINDOWS_NOCONSOLE)
     if (res != 0) {
-        fprintf(stderr, "Press any key to continue...\n");
+        fprintf(stderr, "Press Enter/Return to continue...\n");
         getchar();
     }
 #endif


### PR DESCRIPTION
closes #1757 

This was created to close the issue. As disscusion stated, the best, and easiest fix is to change the string/message displayed after the execution of `main`.

I hope this will get a positive feedback.

*I'm not sure if targeting master is the best option, but this is such a minor change, that it shouldn't create any issues.*