### PR TITLE
Use win64 ffmpeg built from BtbN

### DIFF
--- a/Makefile.CrossWindows
+++ b/Makefile.CrossWindows
@@ -33,7 +33,7 @@ VERSION := $(shell git describe --tags --always)
 WIN32_TARGET := $(WIN32_TARGET_DIR)-$(VERSION).zip
 WIN64_TARGET := $(WIN64_TARGET_DIR)-$(VERSION).zip
 
-release: clean zip-win32 zip-win64 sums
+release: clean zip-win64 sums
 	@echo "Windows archives generated in $(DIST)/"
 
 clean:

--- a/app/meson.build
+++ b/app/meson.build
@@ -53,9 +53,8 @@ else
     )
 
     prebuilt_ffmpeg_shared = meson.get_cross_property('prebuilt_ffmpeg_shared')
-    prebuilt_ffmpeg_dev = meson.get_cross_property('prebuilt_ffmpeg_dev')
     ffmpeg_bin_dir = meson.current_source_dir() + '/../prebuilt-deps/' + prebuilt_ffmpeg_shared + '/bin'
-    ffmpeg_include_dir = '../prebuilt-deps/' + prebuilt_ffmpeg_dev + '/include'
+    ffmpeg_include_dir = '../prebuilt-deps/' + prebuilt_ffmpeg_shared + '/include'
     ffmpeg = declare_dependency(
         dependencies: [
             cc.find_library('avcodec-58', dirs: ffmpeg_bin_dir),

--- a/cross_win64.txt
+++ b/cross_win64.txt
@@ -16,5 +16,4 @@ endian = 'little'
 
 [properties]
 prebuilt_ffmpeg_shared = 'ffmpeg-4.3.1-win64-shared'
-prebuilt_ffmpeg_dev = 'ffmpeg-4.3.1-win64-dev'
 prebuilt_sdl2 = 'SDL2-2.0.12/x86_64-w64-mingw32'

--- a/prebuilt-deps/Makefile
+++ b/prebuilt-deps/Makefile
@@ -20,14 +20,9 @@ prepare-ffmpeg-dev-win32:
 		ffmpeg-4.3.1-win32-dev
 
 prepare-ffmpeg-shared-win64:
-	@./prepare-dep https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-4.3.1-win64-shared.zip \
-		dd29b7f92f48dead4dd940492c7509138c0f99db445076d0a597007298a79940 \
+	@./prepare-dep https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2020-10-17-12-30/ffmpeg-n4.3.1-20-g8a2acdc6da-win64-lgpl-shared-4.3.zip \
+		db3a355a2569044ceb7b417aae0b4bed4a01b1ef0a762dd7a4610bd34d886203 \
 		ffmpeg-4.3.1-win64-shared
-
-prepare-ffmpeg-dev-win64:
-	@./prepare-dep https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-4.3.1-win64-dev.zip \
-		2e8038242cf8e1bd095c2978f196ff0462b122cc6ef7e74626a6af15459d8b81 \
-		ffmpeg-4.3.1-win64-dev
 
 prepare-sdl2:
 	@./prepare-dep https://libsdl.org/release/SDL2-devel-2.0.12-mingw.tar.gz \

--- a/prebuilt-deps/prepare-dep
+++ b/prebuilt-deps/prepare-dep
@@ -25,15 +25,37 @@ get_file() {
     checksum "$file" "$sum"
 }
 
+get_first_layer_dir_name() {
+    local file="$1"
+
+    if [[ "$file" == *.zip ]]
+    then
+        echo `unzip -Z -1 "$file" | head -n 1 | cut -d/ -f1`
+    elif [[ "$file" == *.tar.gz ]]
+    then
+        echo `tar tf "$file" | head -n 1 | cut -d/ -f1`
+    else
+        echo "Unsupported file: $file"
+        return 1
+    fi
+}
+
 extract() {
     local file="$1"
+    local dir="$2"
+
+    mkdir -p "$dir"
     echo "Extracting $file..."
     if [[ "$file" == *.zip ]]
     then
-        unzip -q "$file"
+        local folder_in_file=`get_first_layer_dir_name "$file"`
+
+        ln -s . "$dir"/"$folder_in_file"
+        unzip -q "$file" -d "$dir"
+        rm "$dir"/"$folder_in_file"
     elif [[ "$file" == *.tar.gz ]]
     then
-        tar xf "$file"
+        tar xf "$file" --strip 1 -C "$dir"
     else
         echo "Unsupported file: $file"
         return 1
@@ -51,7 +73,7 @@ get_dep() {
     else
         echo "$dir: not found"
         get_file "$url" "$file" "$sum"
-        extract "$file"
+        extract "$file" "$dir"
     fi
 }
 


### PR DESCRIPTION
There are three changes in this PR.

1. In script `prepare-dep` the third parameter will be the output folder name now.
2. Stop building win32 version due to lack of ffmpeg libs
3. Use BtbN built ffmpeg (win64-lgpl-shared)