### PR TITLE
Add restart explanation to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,9 @@ content (if supported by the app) relative to the center of the screen.
 Concretely, scrcpy generates additional touch events from a "virtual finger" at
 a location inverted through the center of the screen.
 
+#### Restart
+
+To restart the device, hold <kbd>MOD</kbd>+<kbd>p</kbd> (`POWER` button). Depending on the device, this opens a menu where `restart` or `shutdown` can be selected.
 
 #### Text injection preference
 


### PR DESCRIPTION
Sometimes there is no physical access to the device (think "Homeoffice through RDP" and such), but there could be the need to restart the device. 

I know this is common knowledge if you have access to the device, but because of the remote component one could be blind to those obvious solutions, so I added it to the REAMDE.md file.

I'm no native english speaker, so if anything is wrong please feel free to correct my mistakes.