### PR TITLE
To fix windows build issue and Run adb kill-server when exit.

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,22 @@
+{
+    "configurations": [
+        {
+            "name": "Win32",
+            "includePath": [
+                "${default}"
+            ],
+            "defines": [
+                "_DEBUG",
+                "UNICODE",
+                "_UNICODE"
+            ],
+            "windowsSdkVersion": "10.0.19041.0",
+            "compilerPath": "C:/msys64/mingw64/bin/cc.exe",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "gcc-x64",
+            "compileCommands": "${workspaceFolder}/x/compile_commands.json"
+        }
+    ],
+    "version": 4
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "*.tcc": "c",
+        "random": "c",
+        "ostream": "c",
+        "streambuf": "c"
+    }
+}

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -258,6 +258,8 @@ screen_init_rendering(struct screen *screen, const char *window_title,
         window_flags |= SDL_WINDOW_BORDERLESS;
     }
 
+    SDL_SetHint(SDL_HINT_RENDER_DRIVER, "opengl");
+
     int x = window_x != SC_WINDOW_POSITION_UNDEFINED
           ? window_x : (int) SDL_WINDOWPOS_UNDEFINED;
     int y = window_y != SC_WINDOW_POSITION_UNDEFINED

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -504,5 +504,11 @@ server_stop(struct server *server) {
 
 void
 server_destroy(struct server *server) {
+    const char *const cmd[] = {
+        "kill-server",
+    };
+
+    adb_execute(server->serial, cmd, sizeof(cmd) / sizeof(cmd[0]));
+
     SDL_free(server->serial);
 }

--- a/server/meson.build
+++ b/server/meson.build
@@ -7,7 +7,7 @@ if prebuilt_server == ''
                   build_by_default: true,
                   build_always_stale: true,
                   output: 'scrcpy-server',
-                  command: [find_program('./scripts/build-wrapper.sh'), meson.current_source_dir(), '@OUTPUT@', get_option('buildtype')],
+                  command: ['sh', '../server/scripts/build-wrapper.sh', meson.current_source_dir(), '@OUTPUT@', get_option('buildtype')],
                   console: true,
                   install: true,
                   install_dir: 'share/scrcpy')


### PR DESCRIPTION
```
$ ninja -Cx
ninja: Entering directory `x'
[0/1] Generating scrcpy-server with a custom command
/bin/bash: D:/repos/scrcpy/server/./scripts/build-wrapper.sh: No such file or directory
FAILED: server/scrcpy-server
"bash" "D:/repos/scrcpy/server/./scripts/build-wrapper.sh" "D:/repos/scrcpy/server" "server/scrcpy-server" "debug"
ninja: build stopped: subcommand failed.
```