### PR TITLE
fix build error for macOS.

### DIFF
--- a/app/src/sys/unix/command.c
+++ b/app/src/sys/unix/command.c
@@ -5,6 +5,10 @@
 // modern glibc will complain without this
 #define _DEFAULT_SOURCE
 
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE /* for memset_pattern4() */
+#endif
+
 #include "command.h"
 
 #include "config.h"


### PR DESCRIPTION
Fix error below when build for macOS version.
---------------
```bash
~/git/GitHub/scrcpy(master ✗) ninja -Cx
ninja: Entering directory `x'
[0/3] Generating scrcpy-server with a custom command

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.3/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
25 actionable tasks: 1 executed, 24 up-to-date
[1/3] Compiling C object app/scrcpy.p/src_sys_unix_command.c.o
FAILED: app/scrcpy.p/src_sys_unix_command.c.o
cc -Iapp/scrcpy.p -Iapp -I../app -I../app/src -I/usr/local/Cellar/ffmpeg/4.3.1_4/include -I/usr/local/include/SDL2 -I/usr/local/opt/llvm/include -I/usr/local/opt/openssl/include -I/usr/local/opt/flex/include -flto -Xclang -fcolor-diagnostics -pipe -Wall -Winvalid-pch -Wextra -std=c11 -O3 -D_THREAD_SAFE -MD -MQ app/scrcpy.p/src_sys_unix_command.c.o -MF app/scrcpy.p/src_sys_unix_command.c.o.d -o app/scrcpy.p/src_sys_unix_command.c.o -c ../app/src/sys/unix/command.c
In file included from ../app/src/sys/unix/command.c:24:
In file included from ../app/src/util/log.h:4:
In file included from /usr/local/include/SDL2/SDL_log.h:40:
/usr/local/include/SDL2/SDL_stdinc.h:426:5: error: implicit declaration of function 'memset_pattern4' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    memset_pattern4(dst, &val, dwords * 4);
    ^
../app/src/sys/unix/command.c:31:12: error: implicit declaration of function 'strdup' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    path = strdup(path);
           ^
../app/src/sys/unix/command.c:31:12: note: did you mean 'strcmp'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/string.h:77:6: note: 'strcmp' declared here
int      strcmp(const char *__s1, const char *__s2);
         ^
../app/src/sys/unix/command.c:31:10: warning: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
    path = strdup(path);
         ^ ~~~~~~~~~~~~
../app/src/sys/unix/command.c:38:22: error: implicit declaration of function 'strtok_r' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
    for (char *dir = strtok_r(path, ":", &saveptr); dir;
                     ^
../app/src/sys/unix/command.c:38:22: note: did you mean 'strtok'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/string.h:90:7: note: 'strtok' declared here
char    *strtok(char *__str, const char *__sep);
         ^
../app/src/sys/unix/command.c:38:16: warning: incompatible integer to pointer conversion initializing 'char *' with an expression of type 'int' [-Wint-conversion]
    for (char *dir = strtok_r(path, ":", &saveptr); dir;
               ^     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../app/src/sys/unix/command.c:39:17: warning: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
            dir = strtok_r(NULL, ":", &saveptr)) {
                ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
3 warnings and 3 errors generated.
ninja: build stopped: subcommand failed.

```