### PR TITLE
Replace `scrcpy-noconsole.exe` by a simple wrapper script

### DIFF
--- a/Makefile.CrossWindows
+++ b/Makefile.CrossWindows
@@ -11,8 +11,7 @@
 .PHONY: default clean \
 	build-server \
 	prepare-deps-win32 prepare-deps-win64 \
-	build-win32 build-win32-noconsole \
-	build-win64 build-win64-noconsole \
+	build-win32 build-win64 \
 	dist-win32 dist-win64 \
 	zip-win32 zip-win64 \
 	sums release
@@ -21,9 +20,7 @@ GRADLE ?= ./gradlew
 
 SERVER_BUILD_DIR := build-server
 WIN32_BUILD_DIR := build-win32
-WIN32_NOCONSOLE_BUILD_DIR := build-win32-noconsole
 WIN64_BUILD_DIR := build-win64
-WIN64_NOCONSOLE_BUILD_DIR := build-win64-noconsole
 
 DIST := dist
 WIN32_TARGET_DIR := scrcpy-win32
@@ -39,7 +36,7 @@ release: clean zip-win32 zip-win64 sums
 clean:
 	$(GRADLE) clean
 	rm -rf "$(SERVER_BUILD_DIR)" "$(WIN32_BUILD_DIR)" "$(WIN64_BUILD_DIR)" \
-		   "$(WIN32_NOCONSOLE_BUILD_DIR)" "$(WIN64_NOCONSOLE_BUILD_DIR)" "$(DIST)"
+		   "$(DIST)"
 
 build-server:
 	[ -d "$(SERVER_BUILD_DIR)" ] || ( mkdir "$(SERVER_BUILD_DIR)" && \
@@ -60,17 +57,6 @@ build-win32: prepare-deps-win32
 			-Dportable=true )
 	ninja -C "$(WIN32_BUILD_DIR)"
 
-build-win32-noconsole: prepare-deps-win32
-	[ -d "$(WIN32_NOCONSOLE_BUILD_DIR)" ] || ( mkdir "$(WIN32_NOCONSOLE_BUILD_DIR)" && \
-		meson "$(WIN32_NOCONSOLE_BUILD_DIR)" \
-			--cross-file cross_win32.txt \
-			--buildtype release --strip -Db_lto=true \
-			-Dcrossbuild_windows=true \
-			-Dcompile_server=false \
-			-Dwindows_noconsole=true \
-			-Dportable=true )
-	ninja -C "$(WIN32_NOCONSOLE_BUILD_DIR)"
-
 prepare-deps-win64:
 	-$(MAKE) -C prebuilt-deps prepare-win64
 
@@ -84,23 +70,12 @@ build-win64: prepare-deps-win64
 			-Dportable=true )
 	ninja -C "$(WIN64_BUILD_DIR)"
 
-build-win64-noconsole: prepare-deps-win64
-	[ -d "$(WIN64_NOCONSOLE_BUILD_DIR)" ] || ( mkdir "$(WIN64_NOCONSOLE_BUILD_DIR)" && \
-		meson "$(WIN64_NOCONSOLE_BUILD_DIR)" \
-			--cross-file cross_win64.txt \
-			--buildtype release --strip -Db_lto=true \
-			-Dcrossbuild_windows=true \
-			-Dcompile_server=false \
-			-Dwindows_noconsole=true \
-			-Dportable=true )
-	ninja -C "$(WIN64_NOCONSOLE_BUILD_DIR)"
-
-dist-win32: build-server build-win32 build-win32-noconsole
+dist-win32: build-server build-win32
 	mkdir -p "$(DIST)/$(WIN32_TARGET_DIR)"
 	cp "$(SERVER_BUILD_DIR)"/server/scrcpy-server "$(DIST)/$(WIN32_TARGET_DIR)/"
 	cp "$(WIN32_BUILD_DIR)"/app/scrcpy.exe "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp "$(WIN32_NOCONSOLE_BUILD_DIR)"/app/scrcpy.exe "$(DIST)/$(WIN32_TARGET_DIR)/scrcpy-noconsole.exe"
 	cp data/scrcpy-console.bat "$(DIST)/$(WIN32_TARGET_DIR)"
+	cp data/scrcpy-noconsole.vbs "$(DIST)/$(WIN32_TARGET_DIR)"
 	cp prebuilt-deps/ffmpeg-4.3.1-win32-shared/bin/avutil-56.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
 	cp prebuilt-deps/ffmpeg-4.3.1-win32-shared/bin/avcodec-58.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
 	cp prebuilt-deps/ffmpeg-4.3.1-win32-shared/bin/avformat-58.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
@@ -111,12 +86,12 @@ dist-win32: build-server build-win32 build-win32-noconsole
 	cp prebuilt-deps/platform-tools/AdbWinUsbApi.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
 	cp prebuilt-deps/SDL2-2.0.12/i686-w64-mingw32/bin/SDL2.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
 
-dist-win64: build-server build-win64 build-win64-noconsole
+dist-win64: build-server build-win64
 	mkdir -p "$(DIST)/$(WIN64_TARGET_DIR)"
 	cp "$(SERVER_BUILD_DIR)"/server/scrcpy-server "$(DIST)/$(WIN64_TARGET_DIR)/"
 	cp "$(WIN64_BUILD_DIR)"/app/scrcpy.exe "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp "$(WIN64_NOCONSOLE_BUILD_DIR)"/app/scrcpy.exe "$(DIST)/$(WIN64_TARGET_DIR)/scrcpy-noconsole.exe"
 	cp data/scrcpy-console.bat "$(DIST)/$(WIN64_TARGET_DIR)"
+	cp data/scrcpy-noconsole.vbs "$(DIST)/$(WIN64_TARGET_DIR)"
 	cp prebuilt-deps/ffmpeg-4.3.1-win64-shared/bin/avutil-56.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
 	cp prebuilt-deps/ffmpeg-4.3.1-win64-shared/bin/avcodec-58.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
 	cp prebuilt-deps/ffmpeg-4.3.1-win64-shared/bin/avformat-58.dll "$(DIST)/$(WIN64_TARGET_DIR)/"

--- a/app/meson.build
+++ b/app/meson.build
@@ -119,9 +119,6 @@ conf.set('DEFAULT_BIT_RATE', '8000000')  # 8Mbps
 # enable High DPI support
 conf.set('HIDPI_SUPPORT', get_option('hidpi_support'))
 
-# disable console on Windows
-conf.set('WINDOWS_NOCONSOLE', get_option('windows_noconsole'))
-
 # run a server debugger and wait for a client to be attached
 conf.set('SERVER_DEBUGGER', get_option('server_debugger'))
 
@@ -132,18 +129,11 @@ configure_file(configuration: conf, output: 'config.h')
 
 src_dir = include_directories('src')
 
-if get_option('windows_noconsole')
-    link_args = [ '-Wl,--subsystem,windows' ]
-else
-    link_args = []
-endif
-
 executable('scrcpy', src,
            dependencies: dependencies,
            include_directories: src_dir,
            install: true,
-           c_args: [],
-           link_args: link_args)
+           c_args: [])
 
 install_man('scrcpy.1')
 

--- a/app/src/sys/win/command.c
+++ b/app/src/sys/win/command.c
@@ -39,12 +39,7 @@ cmd_execute(const char *const argv[], HANDLE *handle) {
         return PROCESS_ERROR_GENERIC;
     }
 
-#ifdef WINDOWS_NOCONSOLE
-    int flags = CREATE_NO_WINDOW;
-#else
-    int flags = 0;
-#endif
-    if (!CreateProcessW(NULL, wide, NULL, NULL, FALSE, flags, NULL, NULL, &si,
+    if (!CreateProcessW(NULL, wide, NULL, NULL, FALSE, 0, NULL, NULL, &si,
                         &pi)) {
         SDL_free(wide);
         *handle = NULL;

--- a/data/scrcpy-noconsole.vbs
+++ b/data/scrcpy-noconsole.vbs
@@ -1,0 +1,1 @@
+CreateObject("Wscript.Shell").Run "cmd /c scrcpy.exe", 0, false

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,6 @@
 option('compile_app', type: 'boolean', value: true, description: 'Build the client')
 option('compile_server', type: 'boolean', value: true, description: 'Build the server')
 option('crossbuild_windows', type: 'boolean', value: false, description: 'Build for Windows from Linux')
-option('windows_noconsole', type: 'boolean', value: false, description: 'Disable console on Windows (pass -mwindows flag)')
 option('prebuilt_server', type: 'string', description: 'Path of the prebuilt server')
 option('portable', type: 'boolean', value: false, description: 'Use scrcpy-server from the same directory as the scrcpy executable')
 option('hidpi_support', type: 'boolean', value: true, description: 'Enable High DPI support')


### PR DESCRIPTION
In the Windows releases (until v1.16), there are two binaries:
 - `scrcpy.exe` (which pauses on error to let the user a chance to see any error message before the terminal closes)
 - `scrcpy-noconsole.exe` which does not open a terminal

They both contain the whole program, and complicate the build system.

For the next release, the idea is to have 3 files:
 - `scrcpy.exe` the main binary, with the same behavior as on other platforms (no pause on error)
 - `scrcpy-console.bat` a simple wrapper script to pause on error (already mreged 904d47057987fcd2bc2bb9494758a611fa6ab2bc)
 - `scrcpy-noconsole.vbs` a one-line VBS script to start `scrcpy.exe` without a console (this PR)

`scrcpy-noconsole.vbs` just contains:
```vbs
CreateObject("Wscript.Shell").Run "cmd /c scrcpy.exe", 0, false
```

Refs https://github.com/Genymobile/scrcpy/issues/1975#issuecomment-745314161