### PR TITLE
Use --cask for latest versions of brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,16 @@ brew install scrcpy
 
 You need `adb`, accessible from your `PATH`. If you don't have it yet:
 
+Homebrew<=2.6.0
 ```bash
 brew cask install android-platform-tools
 ```
+
+Homebrew>=2.6.0
+```bash
+brew install --cask android-platform-tools
+```
+
 
 You can also [build the app manually][BUILD].
 


### PR DESCRIPTION
brew cask <command> was deprecated in favor of brew <command> --cask in Homebrew 2.6.0. Now that 2.7.0 has been released, they have been disabled.

https://github.com/Homebrew/discussions/discussions/340

I am happy to update the other language readmes once appropriate format is settled on. 