### PR TITLE
remain title bar when use --window-borderles so that we can move and close the window

### DIFF
--- a/app/src/device.c
+++ b/app/src/device.c
@@ -11,7 +11,7 @@ device_read_info(socket_t device_socket, char *device_name, struct size *size) {
         LOGE("Could not retrieve device information");
         return false;
     }
-    // in case the client sends garbage!
+    // in case the client sends garbage
     buf[DEVICE_NAME_FIELD_LENGTH - 1] = '\0';
     // strcpy is safe here, since name contains at least
     // DEVICE_NAME_FIELD_LENGTH bytes and strlen(buf) < DEVICE_NAME_FIELD_LENGTH

--- a/app/src/device.c
+++ b/app/src/device.c
@@ -11,7 +11,7 @@ device_read_info(socket_t device_socket, char *device_name, struct size *size) {
         LOGE("Could not retrieve device information");
         return false;
     }
-    // in case the client sends garbage
+    // in case the client sends garbage!
     buf[DEVICE_NAME_FIELD_LENGTH - 1] = '\0';
     // strcpy is safe here, since name contains at least
     // DEVICE_NAME_FIELD_LENGTH bytes and strlen(buf) < DEVICE_NAME_FIELD_LENGTH

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -242,7 +242,7 @@ screen_init_rendering(struct screen *screen, const char *window_title,
 
     struct size window_size =
         get_initial_optimal_size(content_size, window_width, window_height);
-    uint32_t window_flags = SDL_WINDOW_HIDDEN | SDL_WINDOW_RESIZABLE;
+    uint32_t window_flags = SDL_WINDOW_HIDDEN;
 #ifdef HIDPI_SUPPORT
     window_flags |= SDL_WINDOW_ALLOW_HIGHDPI;
 #endif
@@ -254,8 +254,8 @@ screen_init_rendering(struct screen *screen, const char *window_title,
              "(compile with SDL >= 2.0.5 to enable it)");
 #endif
     }
-    if (window_borderless) {
-        window_flags |= SDL_WINDOW_BORDERLESS;
+    if (!window_borderless) {
+        window_flags |= SDL_WINDOW_RESIZABLE;
     }
 
     int x = window_x != SC_WINDOW_POSITION_UNDEFINED


### PR DESCRIPTION
Only remove left and right borders so that we can move and close the window