### PR TITLE
Support game controllers

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -112,6 +112,9 @@ scrcpy_print_usage(const char *arg0) {
         "        Do not display device (only when screen recording is\n"
         "        enabled).\n"
         "\n"
+        "    --no-game-controller\n"
+        "        Disable game controller support.\n"
+        "\n"
         "    --no-key-repeat\n"
         "        Do not forward repeated key events when a key is held down.\n"
         "\n"
@@ -719,6 +722,7 @@ guess_record_format(const char *filename) {
 #define OPT_V4L2_SINK              1027
 #define OPT_DISPLAY_BUFFER         1028
 #define OPT_V4L2_BUFFER            1029
+#define OPT_NO_GAME_CONTROLLER     1030
 
 bool
 scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
@@ -745,6 +749,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"max-size",               required_argument, NULL, 'm'},
         {"no-control",             no_argument,       NULL, 'n'},
         {"no-display",             no_argument,       NULL, 'N'},
+        {"no-game-controller",     no_argument,       NULL, OPT_NO_GAME_CONTROLLER},
         {"no-key-repeat",          no_argument,       NULL, OPT_NO_KEY_REPEAT},
         {"no-mipmaps",             no_argument,       NULL, OPT_NO_MIPMAPS},
         {"port",                   required_argument, NULL, 'p'},
@@ -919,6 +924,9 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
                 break;
             case OPT_NO_MIPMAPS:
                 opts->mipmaps = false;
+                break;
+            case OPT_NO_GAME_CONTROLLER:
+                opts->forward_game_controllers = false;
                 break;
             case OPT_NO_KEY_REPEAT:
                 opts->forward_key_repeat = false;

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -134,6 +134,20 @@ control_msg_serialize(const struct control_msg *msg, unsigned char *buf) {
         case CONTROL_MSG_TYPE_ROTATE_DEVICE:
             // no additional data
             return 1;
+        case CONTROL_MSG_TYPE_INJECT_GAME_CONTROLLER_AXIS:
+            buffer_write16be(&buf[1], msg->inject_game_controller_axis.id);
+            buf[3] = msg->inject_game_controller_axis.axis;
+            buffer_write16be(&buf[4], msg->inject_game_controller_axis.value);
+            return 6;
+        case CONTROL_MSG_TYPE_INJECT_GAME_CONTROLLER_BUTTON:
+            buffer_write16be(&buf[1], msg->inject_game_controller_button.id);
+            buf[3] = msg->inject_game_controller_button.button;
+            buf[4] = msg->inject_game_controller_button.state;
+            return 5;
+        case CONTROL_MSG_TYPE_INJECT_GAME_CONTROLLER_DEVICE:
+            buffer_write16be(&buf[1], msg->inject_game_controller_device.id);
+            buf[3] = msg->inject_game_controller_device.event;
+            return 4;
         default:
             LOGW("Unknown message type: %u", (unsigned) msg->type);
             return 0;

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -33,6 +33,9 @@ enum control_msg_type {
     CONTROL_MSG_TYPE_SET_CLIPBOARD,
     CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE,
     CONTROL_MSG_TYPE_ROTATE_DEVICE,
+    CONTROL_MSG_TYPE_INJECT_GAME_CONTROLLER_AXIS,
+    CONTROL_MSG_TYPE_INJECT_GAME_CONTROLLER_BUTTON,
+    CONTROL_MSG_TYPE_INJECT_GAME_CONTROLLER_DEVICE,
 };
 
 enum screen_power_mode {
@@ -76,6 +79,20 @@ struct control_msg {
         struct {
             enum screen_power_mode mode;
         } set_screen_power_mode;
+        struct {
+            int16_t id;
+            uint8_t axis;
+            int16_t value;
+        } inject_game_controller_axis;
+        struct {
+            int16_t id;
+            uint8_t button;
+            uint8_t state;
+        } inject_game_controller_button;
+        struct {
+            int16_t id;
+            uint8_t event;
+        } inject_game_controller_device;
     };
 };
 

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -61,6 +61,7 @@ input_manager_init(struct input_manager *im, struct controller *controller,
     im->repeat = 0;
 
     im->control = options->control;
+    im->forward_game_controllers = options->forward_game_controllers;
     im->forward_key_repeat = options->forward_key_repeat;
     im->prefer_text = options->prefer_text;
     im->forward_all_clicks = options->forward_all_clicks;
@@ -953,14 +954,14 @@ input_manager_handle_event(struct input_manager *im, SDL_Event *event) {
             input_manager_process_touch(im, &event->tfinger);
             return true;
         case SDL_CONTROLLERAXISMOTION:
-            if (!im->control) {
+            if (!im->control || !im->forward_game_controllers) {
                 break;
             }
             input_manager_process_controller_axis(im, &event->caxis);
             break;
         case SDL_CONTROLLERBUTTONDOWN:
         case SDL_CONTROLLERBUTTONUP:
-            if (!im->control) {
+            if (!im->control || !im->forward_game_controllers) {
                 break;
             }
             input_manager_process_controller_button(im, &event->cbutton);
@@ -968,7 +969,7 @@ input_manager_handle_event(struct input_manager *im, SDL_Event *event) {
         case SDL_CONTROLLERDEVICEADDED:
         // case SDL_CONTROLLERDEVICEREMAPPED:
         case SDL_CONTROLLERDEVICEREMOVED:
-            if (!im->control) {
+            if (!im->control || !im->forward_game_controllers) {
                 break;
             }
             input_manager_process_controller_device(im, &event->cdevice);

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -809,70 +809,6 @@ input_manager_process_mouse_wheel(struct input_manager *im,
     }
 }
 
-bool
-input_manager_handle_event(struct input_manager *im, SDL_Event *event) {
-    switch (event->type) {
-        case SDL_TEXTINPUT:
-            if (!im->control) {
-                return true;
-            }
-            input_manager_process_text_input(im, &event->text);
-            return true;
-        case SDL_KEYDOWN:
-        case SDL_KEYUP:
-            // some key events do not interact with the device, so process the
-            // event even if control is disabled
-            input_manager_process_key(im, &event->key);
-            return true;
-        case SDL_MOUSEMOTION:
-            if (!im->control) {
-                break;
-            }
-            input_manager_process_mouse_motion(im, &event->motion);
-            return true;
-        case SDL_MOUSEWHEEL:
-            if (!im->control) {
-                break;
-            }
-            input_manager_process_mouse_wheel(im, &event->wheel);
-            return true;
-        case SDL_MOUSEBUTTONDOWN:
-        case SDL_MOUSEBUTTONUP:
-            // some mouse events do not interact with the device, so process
-            // the event even if control is disabled
-            input_manager_process_mouse_button(im, &event->button);
-            return true;
-        case SDL_FINGERMOTION:
-        case SDL_FINGERDOWN:
-        case SDL_FINGERUP:
-            input_manager_process_touch(im, &event->tfinger);
-            return true;
-        case SDL_CONTROLLERAXISMOTION:
-            if (!options->control) {
-                break;
-            }
-            input_manager_process_controller_axis(&input_manager, &event->caxis);
-            break;
-        case SDL_CONTROLLERBUTTONDOWN:
-        case SDL_CONTROLLERBUTTONUP:
-            if (!options->control) {
-                break;
-            }
-            input_manager_process_controller_button(&input_manager, &event->cbutton);
-            break;
-        case SDL_CONTROLLERDEVICEADDED:
-        // case SDL_CONTROLLERDEVICEREMAPPED:
-        case SDL_CONTROLLERDEVICEREMOVED:
-            if (!options->control) {
-                break;
-            }
-            input_manager_process_controller_device(&input_manager, &event->cdevice);
-            break;
-    }
-
-    return false;
-}
-
 void
 input_manager_process_controller_axis(struct input_manager *im,
                                       const SDL_ControllerAxisEvent *event) {
@@ -976,4 +912,68 @@ input_manager_process_controller_device(struct input_manager *im,
     msg.inject_game_controller_device.event = event->type;
     msg.inject_game_controller_device.event -= SDL_CONTROLLERDEVICEADDED;
     controller_push_msg(im->controller, &msg);
+}
+
+bool
+input_manager_handle_event(struct input_manager *im, SDL_Event *event) {
+    switch (event->type) {
+        case SDL_TEXTINPUT:
+            if (!im->control) {
+                return true;
+            }
+            input_manager_process_text_input(im, &event->text);
+            return true;
+        case SDL_KEYDOWN:
+        case SDL_KEYUP:
+            // some key events do not interact with the device, so process the
+            // event even if control is disabled
+            input_manager_process_key(im, &event->key);
+            return true;
+        case SDL_MOUSEMOTION:
+            if (!im->control) {
+                break;
+            }
+            input_manager_process_mouse_motion(im, &event->motion);
+            return true;
+        case SDL_MOUSEWHEEL:
+            if (!im->control) {
+                break;
+            }
+            input_manager_process_mouse_wheel(im, &event->wheel);
+            return true;
+        case SDL_MOUSEBUTTONDOWN:
+        case SDL_MOUSEBUTTONUP:
+            // some mouse events do not interact with the device, so process
+            // the event even if control is disabled
+            input_manager_process_mouse_button(im, &event->button);
+            return true;
+        case SDL_FINGERMOTION:
+        case SDL_FINGERDOWN:
+        case SDL_FINGERUP:
+            input_manager_process_touch(im, &event->tfinger);
+            return true;
+        case SDL_CONTROLLERAXISMOTION:
+            if (!im->control) {
+                break;
+            }
+            input_manager_process_controller_axis(im, &event->caxis);
+            break;
+        case SDL_CONTROLLERBUTTONDOWN:
+        case SDL_CONTROLLERBUTTONUP:
+            if (!im->control) {
+                break;
+            }
+            input_manager_process_controller_button(im, &event->cbutton);
+            break;
+        case SDL_CONTROLLERDEVICEADDED:
+        // case SDL_CONTROLLERDEVICEREMAPPED:
+        case SDL_CONTROLLERDEVICEREMOVED:
+            if (!im->control) {
+                break;
+            }
+            input_manager_process_controller_device(im, &event->cdevice);
+            break;
+    }
+
+    return false;
 }

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -12,9 +12,12 @@
 #include "scrcpy.h"
 #include "screen.h"
 
+#define MAX_GAME_CONTROLLERS 16
+
 struct input_manager {
     struct controller *controller;
     struct screen *screen;
+    SDL_GameController *game_controllers[MAX_GAME_CONTROLLERS];
 
     // SDL reports repeated events as a boolean, but Android expects the actual
     // number of repetitions. This variable keeps track of the count.

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -24,6 +24,7 @@ struct input_manager {
     unsigned repeat;
 
     bool control;
+    bool forward_game_controllers;
     bool forward_key_repeat;
     bool prefer_text;
     bool forward_all_clicks;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -59,7 +59,7 @@ BOOL WINAPI windows_ctrl_handler(DWORD ctrl_type) {
 static bool
 sdl_init_and_configure(bool display, const char *render_driver,
                        bool disable_screensaver) {
-    uint32_t flags = display ? SDL_INIT_VIDEO : SDL_INIT_EVENTS;
+    uint32_t flags = (display ? SDL_INIT_VIDEO : 0) | SDL_INIT_GAMECONTROLLER;
     if (SDL_Init(flags)) {
         LOGC("Could not initialize SDL: %s", SDL_GetError());
         return false;

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -94,6 +94,7 @@ struct scrcpy_options {
     bool stay_awake;
     bool force_adb_forward;
     bool disable_screensaver;
+    bool forward_game_controllers;
     bool forward_key_repeat;
     bool forward_all_clicks;
     bool legacy_paste;
@@ -144,6 +145,7 @@ struct scrcpy_options {
     .stay_awake = false, \
     .force_adb_forward = false, \
     .disable_screensaver = false, \
+    .forward_game_controllers = true, \
     .forward_key_repeat = true, \
     .forward_all_clicks = false, \
     .legacy_paste = false, \

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -17,7 +17,8 @@
 #define SERVER_FILENAME "scrcpy-server"
 
 #define DEFAULT_SERVER_PATH PREFIX "/share/scrcpy/" SERVER_FILENAME
-#define DEVICE_SERVER_PATH "/data/local/tmp/scrcpy-server.jar"
+#define DEVICE_SERVER_DIR "/data/local/tmp"
+#define DEVICE_SERVER_PATH DEVICE_SERVER_DIR "/scrcpy-server.jar"
 
 static char *
 get_server_path(void) {
@@ -280,6 +281,7 @@ execute_server(struct server *server, const struct server_params *params) {
     const char *const cmd[] = {
         "shell",
         "CLASSPATH=" DEVICE_SERVER_PATH,
+        "LD_LIBRARY_PATH=" DEVICE_SERVER_DIR,
         "app_process",
 #ifdef SERVER_DEBUGGER
 # define SERVER_DEBUGGER_PORT "5005"

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -281,8 +281,8 @@ execute_server(struct server *server, const struct server_params *params) {
     const char *const cmd[] = {
         "shell",
         "CLASSPATH=" DEVICE_SERVER_PATH,
-        "LD_LIBRARY_PATH=" DEVICE_SERVER_DIR,
         "app_process",
+        "-Djna.boot.library.path=/data/local/tmp",
 #ifdef SERVER_DEBUGGER
 # define SERVER_DEBUGGER_PORT "5005"
 # ifdef SERVER_DEBUGGER_METHOD_NEW

--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -183,8 +183,11 @@ sc_v4l2_sink_open(struct sc_v4l2_sink *vs) {
         goto error_mutex_destroy;
     }
 
-    // FIXME
-    const AVOutputFormat *format = find_muxer("video4linux2,v4l2");
+    const AVOutputFormat *format = find_muxer("v4l2");
+    if (!format) {
+        // Alternative name
+        format = find_muxer("video4linux2");
+    }
     if (!format) {
         LOGE("Could not find v4l2 muxer");
         goto error_cond_destroy;

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -20,6 +20,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation 'net.java.dev.jna:jna:5.6.0@aar'
     testImplementation 'junit:junit:4.13'
 }
 

--- a/server/proguard-rules.pro
+++ b/server/proguard-rules.pro
@@ -19,3 +19,7 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontwarn java.awt.*
+-keep class com.sun.jna.* { *; }
+-keepclassmembers class * extends com.sun.jna.* { public *; }

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -151,7 +151,7 @@ public final class CleanUp {
     }
 
     private static void unlinkNativeLibs() {
-        for (String lib : Server.NATIVE_LIBRARIES){
+        for (String lib : Server.NATIVE_LIBRARIES) {
             try {
                 new File(Server.SERVER_DIR + "/" + lib).delete();
             } catch (Exception e) {

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -17,7 +17,7 @@ import java.io.IOException;
  */
 public final class CleanUp {
 
-    public static final String SERVER_PATH = "/data/local/tmp/scrcpy-server.jar";
+    public static final String SERVER_PATH = Server.SERVER_DIR + "/scrcpy-server.jar";
 
     // A simple struct to be passed from the main process to the cleanup process
     public static class Config implements Parcelable {
@@ -150,8 +150,19 @@ public final class CleanUp {
         }
     }
 
+    private static void unlinkNativeLibs() {
+        for (String lib : Server.NATIVE_LIBRARIES){
+            try {
+                new File(Server.SERVER_DIR + "/" + lib).delete();
+            } catch (Exception e) {
+                Ln.e("Could not unlink native library " + lib, e);
+            }
+        }
+    }
+
     public static void main(String... args) {
         unlinkSelf();
+        unlinkNativeLibs();
 
         try {
             // Wait for the server to die

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
@@ -17,6 +17,9 @@ public final class ControlMessage {
     public static final int TYPE_SET_CLIPBOARD = 9;
     public static final int TYPE_SET_SCREEN_POWER_MODE = 10;
     public static final int TYPE_ROTATE_DEVICE = 11;
+    public static final int TYPE_INJECT_GAME_CONTROLLER_AXIS = 12;
+    public static final int TYPE_INJECT_GAME_CONTROLLER_BUTTON = 13;
+    public static final int TYPE_INJECT_GAME_CONTROLLER_DEVICE = 14;
 
     private int type;
     private String text;
@@ -31,6 +34,12 @@ public final class ControlMessage {
     private int vScroll;
     private boolean paste;
     private int repeat;
+    private int gameControllerId;
+    private int gameControllerAxis;
+    private int gameControllerAxisValue;
+    private int gameControllerButton;
+    private int gameControllerButtonState;
+    private int gameControllerDeviceEvent;
 
     private ControlMessage() {
     }
@@ -97,6 +106,32 @@ public final class ControlMessage {
         return msg;
     }
 
+    public static ControlMessage createInjectGameControllerAxis(int id, int axis, int value) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_INJECT_GAME_CONTROLLER_AXIS;
+        msg.gameControllerId = id;
+        msg.gameControllerAxis = axis;
+        msg.gameControllerAxisValue = value;
+        return msg;
+    }
+
+    public static ControlMessage createInjectGameControllerButton(int id, int button, int state) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_INJECT_GAME_CONTROLLER_BUTTON;
+        msg.gameControllerId = id;
+        msg.gameControllerButton = button;
+        msg.gameControllerButtonState = state;
+        return msg;
+    }
+
+    public static ControlMessage createInjectGameControllerDevice(int id, int event) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_INJECT_GAME_CONTROLLER_DEVICE;
+        msg.gameControllerId = id;
+        msg.gameControllerDeviceEvent = event;
+        return msg;
+    }
+
     public static ControlMessage createEmpty(int type) {
         ControlMessage msg = new ControlMessage();
         msg.type = type;
@@ -154,4 +189,29 @@ public final class ControlMessage {
     public int getRepeat() {
         return repeat;
     }
+
+    public int getGameControllerId() {
+        return gameControllerId;
+    }
+
+    public int getGameControllerAxis() {
+        return gameControllerAxis;
+    }
+
+    public int getGameControllerAxisValue() {
+        return gameControllerAxisValue;
+    }
+
+    public int getGameControllerButton() {
+        return gameControllerButton;
+    }
+
+    public int getGameControllerButtonState() {
+        return gameControllerButtonState;
+    }
+
+    public int getGameControllerDeviceEvent() {
+        return gameControllerDeviceEvent;
+    }
+
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
@@ -14,6 +14,9 @@ public class ControlMessageReader {
     static final int BACK_OR_SCREEN_ON_LENGTH = 1;
     static final int SET_SCREEN_POWER_MODE_PAYLOAD_LENGTH = 1;
     static final int SET_CLIPBOARD_FIXED_PAYLOAD_LENGTH = 1;
+    static final int INJECT_GAME_CONTROLLER_AXIS_PAYLOAD_LENGTH = 5;
+    static final int INJECT_GAME_CONTROLLER_BUTTON_PAYLOAD_LENGTH = 4;
+    static final int INJECT_GAME_CONTROLLER_DEVICE_PAYLOAD_LENGTH = 3;
 
     private static final int MESSAGE_MAX_SIZE = 1 << 18; // 256k
 
@@ -82,6 +85,15 @@ public class ControlMessageReader {
             case ControlMessage.TYPE_GET_CLIPBOARD:
             case ControlMessage.TYPE_ROTATE_DEVICE:
                 msg = ControlMessage.createEmpty(type);
+                break;
+            case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_AXIS:
+                msg = parseInjectGameControllerAxis();
+                break;
+            case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_BUTTON:
+                msg = parseInjectGameControllerButton();
+                break;
+            case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_DEVICE:
+                msg = parseInjectGameControllerDevice();
                 break;
             default:
                 Ln.w("Unknown event type: " + type);
@@ -180,6 +192,35 @@ public class ControlMessageReader {
         }
         int mode = buffer.get();
         return ControlMessage.createSetScreenPowerMode(mode);
+    }
+
+    private ControlMessage parseInjectGameControllerAxis() {
+        if (buffer.remaining() < INJECT_GAME_CONTROLLER_AXIS_PAYLOAD_LENGTH) {
+            return null;
+        }
+        int id = buffer.getShort();
+        int axis = buffer.get();
+        int value = buffer.getShort();
+        return ControlMessage.createInjectGameControllerAxis(id, axis, value);
+    }
+
+    private ControlMessage parseInjectGameControllerButton() {
+        if (buffer.remaining() < INJECT_GAME_CONTROLLER_BUTTON_PAYLOAD_LENGTH) {
+            return null;
+        }
+        int id = buffer.getShort();
+        int button = buffer.get();
+        int state = buffer.get();
+        return ControlMessage.createInjectGameControllerButton(id, button, state);
+    }
+
+    private ControlMessage parseInjectGameControllerDevice() {
+        if (buffer.remaining() < INJECT_GAME_CONTROLLER_DEVICE_PAYLOAD_LENGTH) {
+            return null;
+        }
+        int id = buffer.getShort();
+        int event = buffer.get();
+        return ControlMessage.createInjectGameControllerDevice(id, event);
     }
 
     private static Position readPosition(ByteBuffer buffer) {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -185,7 +185,12 @@ public class Controller {
 
                     switch (event) {
                         case GameController.DEVICE_ADDED:
-                            gameControllers.append(id, new GameController());
+                            try {
+                                gameControllers.append(id, new GameController());
+                            } catch (Exception e) {
+                                Ln.e("It seems your phone doesn't support this feature without root. Game controllers will be disabled.", e);
+                                gameControllersEnabled = false;
+                            }
                             break;
 
                         case GameController.DEVICE_REMOVED:

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -42,7 +42,7 @@ public class Controller {
         sender = new DeviceMessageSender(connection);
 
         try {
-            GameController.loadNativeLibraries();
+            UinputDevice.loadNativeLibraries();
             gameControllersEnabled = true;
         } catch (UnsatisfiedLinkError e) {
             Ln.e("Could not load native libraries. Game controllers will be disabled.", e);

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -188,7 +188,7 @@ public class Controller {
                             try {
                                 gameControllers.append(id, new GameController());
                             } catch (Exception e) {
-                                Ln.e("It seems your phone doesn't support this feature without root. Game controllers will be disabled.", e);
+                                Ln.e("Failed to add new game controller. Game controllers will be disabled.", e);
                                 gameControllersEnabled = false;
                             }
                             break;

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -42,7 +42,7 @@ public class Controller {
         sender = new DeviceMessageSender(connection);
 
         try {
-            GameController.load_native_libraries();
+            GameController.loadNativeLibraries();
             gameControllersEnabled = true;
         } catch (UnsatisfiedLinkError e) {
             Ln.e("Could not load native libraries. Game controllers will be disabled.", e);
@@ -168,7 +168,7 @@ public class Controller {
                     int id = msg.getGameControllerId();
                     int button = msg.getGameControllerButton();
                     int state = msg.getGameControllerButtonState();
-                    
+
                     GameController controller = gameControllers.get(id);
 
                     if (controller != null) {
@@ -197,7 +197,7 @@ public class Controller {
                             } else {
                                 Ln.w("Non-existant game controller removed.");
                             }
-                            
+
                             break;
 
                         default:

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -152,11 +152,15 @@ public class Controller {
                     int id = msg.getGameControllerId();
                     int axis = msg.getGameControllerAxis();
                     int value = msg.getGameControllerAxisValue();
-                    if (!gameControllers.contains(id)) {
+
+                    GameController controller = gameControllers.get(id);
+
+                    if (controller != null) {
+                        controller.setAxis(axis, value);
+                    } else {
                         Ln.w("Received data for non-existant controller.");
-                        break;
                     }
-                    gameControllers.get(id).setAxis(axis, value);
+                    break;
                 }
                 break;
             case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_BUTTON:
@@ -164,11 +168,14 @@ public class Controller {
                     int id = msg.getGameControllerId();
                     int button = msg.getGameControllerButton();
                     int state = msg.getGameControllerButtonState();
-                    if (!gameControllers.contains(id)) {
+                    
+                    GameController controller = gameControllers.get(id);
+
+                    if (controller != null) {
+                        controller.setButton(button, state);
+                    } else {
                         Ln.w("Received data for non-existant controller.");
-                        break;
                     }
-                    gameControllers.get(id).setButton(button, state);
                 }
                 break;
             case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_DEVICE:
@@ -182,12 +189,15 @@ public class Controller {
                             break;
 
                         case GameController.DEVICE_REMOVED:
-                            if (!gameControllers.contains(id)) {
+                            GameController controller = gameControllers.get(id);
+
+                            if (controller != null) {
+                                controller.close();
+                                gameControllers.delete(id);
+                            } else {
                                 Ln.w("Non-existant game controller removed.");
-                                break;
                             }
-                            gameControllers.get(id).close();
-                            gameControllers.delete(id);
+                            
                             break;
 
                         default:

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -135,6 +135,29 @@ public class Controller {
             case ControlMessage.TYPE_ROTATE_DEVICE:
                 Device.rotateDevice();
                 break;
+            case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_AXIS:
+                {
+                    int id = msg.getGameControllerId();
+                    int axis = msg.getGameControllerAxis();
+                    int value = msg.getGameControllerAxisValue();
+                    Ln.d(String.format("Received gc axis: %d %d %d", id, axis, value));
+                }
+                break;
+            case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_BUTTON:
+                {
+                    int id = msg.getGameControllerId();
+                    int button = msg.getGameControllerButton();
+                    int state = msg.getGameControllerButtonState();
+                    Ln.d(String.format("Received gc button: %d %d %d", id, button, state));
+                }
+                break;
+            case ControlMessage.TYPE_INJECT_GAME_CONTROLLER_DEVICE:
+                {
+                    int id = msg.getGameControllerId();
+                    int event = msg.getGameControllerDeviceEvent();
+                    Ln.d(String.format("Received gc device event: %d %d", id, event));
+                }
+                break;
             default:
                 // do nothing
         }

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -152,8 +152,7 @@ public class Controller {
                     int id = msg.getGameControllerId();
                     int axis = msg.getGameControllerAxis();
                     int value = msg.getGameControllerAxisValue();
-                    if (!gameControllers.contains(id))
-                    {
+                    if (!gameControllers.contains(id)) {
                         Ln.w("Received data for non-existant controller.");
                         break;
                     }
@@ -165,8 +164,7 @@ public class Controller {
                     int id = msg.getGameControllerId();
                     int button = msg.getGameControllerButton();
                     int state = msg.getGameControllerButtonState();
-                    if (!gameControllers.contains(id))
-                    {
+                    if (!gameControllers.contains(id)) {
                         Ln.w("Received data for non-existant controller.");
                         break;
                     }
@@ -182,16 +180,18 @@ public class Controller {
                         case GameController.DEVICE_ADDED:
                             gameControllers.append(id, new GameController());
                             break;
-                    
+
                         case GameController.DEVICE_REMOVED:
-                            if (!gameControllers.contains(id))
-                            {
+                            if (!gameControllers.contains(id)) {
                                 Ln.w("Non-existant game controller removed.");
                                 break;
                             }
                             gameControllers.get(id).close();
                             gameControllers.delete(id);
                             break;
+
+                        default:
+                            Ln.w("Unknown game controller event received.");
                     }
                 }
                 break;

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -1,0 +1,372 @@
+package com.genymobile.scrcpy;
+
+import java.io.*;
+import java.util.Arrays;
+import java.util.List;
+import com.sun.jna.Library;
+import com.sun.jna.Platform;
+import com.sun.jna.Native;
+import com.sun.jna.Structure;
+import com.sun.jna.Pointer;
+
+public final class GameController {
+    public static final int DEVICE_ADDED = 0;
+    public static final int DEVICE_REMOVED = 1;
+
+    private static int UINPUT_MAX_NAME_SIZE = 80;
+
+    public static class input_id extends Structure {
+        public short bustype = 0;
+        public short vendor = 0;
+        public short product = 0;
+        public short version = 0;
+    
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("bustype", "vendor", "product", "version");
+        }
+    }
+
+    public static class uinput_setup extends Structure {
+        public input_id id;
+        public byte[] name = new byte[UINPUT_MAX_NAME_SIZE];
+        public int ff_effects_max = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("id", "name", "ff_effects_max");
+        }
+    }
+
+    public static class input_event32 extends Structure {
+        public long time = 0;
+        public short type = 0;
+        public short code = 0;
+        public int value = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("time", "type", "code", "value");
+        }
+    }
+
+    public static class input_event64 extends Structure {
+        public long sec = 0;
+        public long usec = 0;
+        public short type = 0;
+        public short code = 0;
+        public int value = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("sec", "usec", "type", "code", "value");
+        }
+    }
+
+    private static int _IOC_NONE = 0;
+    private static int _IOC_WRITE = 1;
+
+    private static int _IOC_DIRSHIFT = 30;
+    private static int _IOC_TYPESHIFT = 8;
+    private static int _IOC_NRSHIFT = 0;
+    private static int _IOC_SIZESHIFT = 16;
+
+    private static int _IOC(int dir, int type, int nr, int size) {
+        return (dir << _IOC_DIRSHIFT) |
+               (type << _IOC_TYPESHIFT) |
+               (nr << _IOC_NRSHIFT) |
+               (size << _IOC_SIZESHIFT);
+    }
+
+    private static int _IO(int type, int nr, int size) {
+        return _IOC(_IOC_NONE, type, nr, size);
+    }
+
+    private static int _IOW(int type, int nr, int size) {
+        return _IOC(_IOC_WRITE, type, nr, size);
+    }
+
+    private static final int O_WRONLY = 01;
+    private static final int O_NONBLOCK = 04000;
+
+    private static final int BUS_USB = 0x03;
+    
+    private static final int UINPUT_IOCTL_BASE = 'U';
+
+    private static final int UI_SET_EVBIT = _IOW(UINPUT_IOCTL_BASE, 100, 4);
+    private static final int UI_SET_KEYBIT = _IOW(UINPUT_IOCTL_BASE, 101, 4);
+    private static final int UI_SET_ABSBIT = _IOW(UINPUT_IOCTL_BASE, 103, 4);
+
+    private static final int UI_DEV_SETUP = _IOW(UINPUT_IOCTL_BASE, 3, new uinput_setup().size());
+    private static final int UI_DEV_CREATE = _IO(UINPUT_IOCTL_BASE, 1, 0);
+    private static final int UI_DEV_DESTROY = _IO(UINPUT_IOCTL_BASE, 2, 0);
+
+    private static final short EV_SYN = 0x00;
+    private static final short EV_KEY = 0x01;
+    private static final short EV_ABS = 0x03;
+
+    private static final short SYN_REPORT = 0x00;
+
+    private static final short BTN_A = 0x130;
+    private static final short BTN_B = 0x131;
+    private static final short BTN_X = 0x133;
+    private static final short BTN_Y = 0x134;
+    private static final short BTN_TL = 0x136;
+    private static final short BTN_TR = 0x137;
+    private static final short BTN_SELECT = 0x13a;
+    private static final short BTN_START = 0x13b;
+    private static final short BTN_MODE = 0x13c;
+    private static final short BTN_THUMBL = 0x13d;
+    private static final short BTN_THUMBR = 0x13e;
+
+    private static final short ABS_X = 0x00;
+    private static final short ABS_Y = 0x01;
+    private static final short ABS_Z = 0x02;
+    private static final short ABS_RX = 0x03;
+    private static final short ABS_RY = 0x04;
+    private static final short ABS_RZ = 0x05;
+    private static final short ABS_HAT0X = 0x10;
+    private static final short ABS_HAT0Y = 0x11;
+
+    private static final short XBOX_BTN_A = BTN_A;
+    private static final short XBOX_BTN_B = BTN_B;
+    private static final short XBOX_BTN_X = BTN_X;
+    private static final short XBOX_BTN_Y = BTN_Y;
+    private static final short XBOX_BTN_BACK = BTN_SELECT;
+    private static final short XBOX_BTN_START = BTN_START;
+    private static final short XBOX_BTN_LB = BTN_TL;
+    private static final short XBOX_BTN_RB = BTN_TR;
+    private static final short XBOX_BTN_GUIDE = BTN_MODE;
+    private static final short XBOX_BTN_LS = BTN_THUMBL;
+    private static final short XBOX_BTN_RS = BTN_THUMBR;
+
+    private static final short XBOX_ABS_LSX = ABS_X;
+    private static final short XBOX_ABS_LSY = ABS_Y;
+    private static final short XBOX_ABS_RSX = ABS_RX;
+    private static final short XBOX_ABS_RSY = ABS_RY;
+    private static final short XBOX_ABS_DPADX = ABS_HAT0X;
+    private static final short XBOX_ABS_DPADY = ABS_HAT0Y;
+    private static final short XBOX_ABS_LT = ABS_Z;
+    private static final short XBOX_ABS_RT = ABS_RZ;
+
+    private static final int SDL_CONTROLLER_AXIS_LEFTX = 0;
+    private static final int SDL_CONTROLLER_AXIS_LEFTY = 1;
+    private static final int SDL_CONTROLLER_AXIS_RIGHTX = 2;
+    private static final int SDL_CONTROLLER_AXIS_RIGHTY = 3;
+    private static final int SDL_CONTROLLER_AXIS_TRIGGERLEFT = 4;
+    private static final int SDL_CONTROLLER_AXIS_TRIGGERRIGHT = 5;
+
+    private static final int SDL_CONTROLLER_BUTTON_A = 0;
+    private static final int SDL_CONTROLLER_BUTTON_B = 1;
+    private static final int SDL_CONTROLLER_BUTTON_X = 2;
+    private static final int SDL_CONTROLLER_BUTTON_Y = 3;
+    private static final int SDL_CONTROLLER_BUTTON_BACK = 4;
+    private static final int SDL_CONTROLLER_BUTTON_GUIDE = 5;
+    private static final int SDL_CONTROLLER_BUTTON_START = 6;
+    private static final int SDL_CONTROLLER_BUTTON_LEFTSTICK = 7;
+    private static final int SDL_CONTROLLER_BUTTON_RIGHTSTICK = 8;
+    private static final int SDL_CONTROLLER_BUTTON_LEFTSHOULDER = 9;
+    private static final int SDL_CONTROLLER_BUTTON_RIGHTSHOULDER = 10;
+    private static final int SDL_CONTROLLER_BUTTON_DPAD_UP = 11;
+    private static final int SDL_CONTROLLER_BUTTON_DPAD_DOWN = 12;
+    private static final int SDL_CONTROLLER_BUTTON_DPAD_LEFT = 13;
+    private static final int SDL_CONTROLLER_BUTTON_DPAD_RIGHT = 14;
+
+    private int fd;
+
+    public interface LibC extends Library {
+        LibC fn = (LibC)Native.load("c", LibC.class);
+
+        int open(String pathname, int flags);
+        int ioctl(int fd, long request, Object... args);
+        long write(int fd, Pointer buf, long count);
+        int close(int fd);
+    }
+
+    static public void load_native_libraries() {
+        GameController.LibC.fn.write(1, null, 0);
+    }
+
+    public GameController() {
+        fd = LibC.fn.open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+        if (fd == -1) {
+            throw new RuntimeException("Couldn't open uinput device.");
+        }
+    
+        LibC.fn.ioctl(fd, UI_SET_EVBIT, EV_KEY);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_A);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_B);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_X);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_Y);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_BACK);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_START);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_LB);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_RB);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_GUIDE);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_LS);
+        LibC.fn.ioctl(fd, UI_SET_KEYBIT, XBOX_BTN_RS);
+    
+        LibC.fn.ioctl(fd, UI_SET_EVBIT, EV_ABS);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_LSX);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_LSY);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_RSX);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_RSY);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_DPADX);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_DPADY);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_LT);
+        LibC.fn.ioctl(fd, UI_SET_ABSBIT, XBOX_ABS_RT);
+
+        uinput_setup usetup = new uinput_setup();
+        usetup.id.bustype = BUS_USB;
+        usetup.id.vendor = 0x045e;
+        usetup.id.product = 0x028e;
+        byte[] name = "Microsoft X-Box 360 pad".getBytes();
+        System.arraycopy(name, 0, usetup.name, 0, name.length);
+
+        if (LibC.fn.ioctl(fd, UI_DEV_SETUP, usetup) == -1) {
+            close();
+            throw new RuntimeException("Couldn't setup uinput device.");
+        }
+    
+        if (LibC.fn.ioctl(fd, UI_DEV_CREATE) == -1) {
+            close();
+            throw new RuntimeException("Couldn't create uinput device.");
+        }
+    }
+
+    public void close() {
+        if (fd != -1) {
+            LibC.fn.ioctl(fd, UI_DEV_DESTROY);
+            LibC.fn.close(fd);
+            fd = -1;
+        }
+    }
+
+    private static void emit32(int fd, short type, short code, int val) {
+        input_event32 ie = new input_event32();
+
+        ie.type = type;
+        ie.code = code;
+        ie.value = val;
+
+        ie.write();
+
+        LibC.fn.write(fd, ie.getPointer(), ie.size());
+    }
+
+    private static void emit64(int fd, short type, short code, int val) {
+        input_event64 ie = new input_event64();
+
+        ie.type = type;
+        ie.code = code;
+        ie.value = val;
+
+        ie.write();
+
+        LibC.fn.write(fd, ie.getPointer(), ie.size());
+    }
+
+    private static void emit(int fd, short type, short code, int val) {
+        if (Platform.is64Bit()) {
+            emit64(fd, type, code, val);
+        } else {
+            emit32(fd, type, code, val);
+        }
+    }
+
+    private static short translateAxis(int axis) {
+        switch (axis) {
+            case SDL_CONTROLLER_AXIS_LEFTX:
+                return XBOX_ABS_LSX;
+
+            case SDL_CONTROLLER_AXIS_LEFTY:
+                return XBOX_ABS_LSY;
+
+            case SDL_CONTROLLER_AXIS_RIGHTX:
+                return XBOX_ABS_RSX;
+
+            case SDL_CONTROLLER_AXIS_RIGHTY:
+                return XBOX_ABS_RSY;
+
+            case SDL_CONTROLLER_AXIS_TRIGGERLEFT:
+                return XBOX_ABS_LT;
+
+            case SDL_CONTROLLER_AXIS_TRIGGERRIGHT:
+                return XBOX_ABS_RT;
+
+            default:
+                return 0;
+        }
+    }
+
+    private static short translateButton(int button) {
+        switch (button) {
+            case SDL_CONTROLLER_BUTTON_A:
+                return XBOX_BTN_A;
+
+            case SDL_CONTROLLER_BUTTON_B:
+                return XBOX_BTN_B;
+
+            case SDL_CONTROLLER_BUTTON_X:
+                return XBOX_BTN_X;
+
+            case SDL_CONTROLLER_BUTTON_Y:
+                return XBOX_BTN_Y;
+
+            case SDL_CONTROLLER_BUTTON_BACK:
+                return XBOX_BTN_BACK;
+
+            case SDL_CONTROLLER_BUTTON_GUIDE:
+                return XBOX_BTN_GUIDE;
+
+            case SDL_CONTROLLER_BUTTON_START:
+                return XBOX_BTN_START;
+
+            case SDL_CONTROLLER_BUTTON_LEFTSTICK:
+                return XBOX_BTN_LS;
+
+            case SDL_CONTROLLER_BUTTON_RIGHTSTICK:
+                return XBOX_BTN_RS;
+
+            case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+                return XBOX_BTN_LB;
+
+            case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+                return XBOX_BTN_RB;
+
+            default:
+                return 0;
+        }
+    }
+
+    public void setAxis(int axis, int value) {
+        emit(fd, EV_ABS, translateAxis(axis), (value + 0x8000) >> 8);
+        emit(fd, EV_SYN, SYN_REPORT, 0);
+    }
+
+    public void setButton(int button, int state) {
+        // DPad buttons are usually reported as axes
+
+        switch (button) {
+            case SDL_CONTROLLER_BUTTON_DPAD_UP:
+                emit(fd, EV_ABS, XBOX_ABS_DPADY, state != 0 ? 0 : 127);
+                break;
+
+            case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+                emit(fd, EV_ABS, XBOX_ABS_DPADY, state != 0 ? 255 : 127);
+                break;
+
+            case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+                emit(fd, EV_ABS, XBOX_ABS_DPADX, state != 0 ? 0 : 127);
+                break;
+
+            case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+                emit(fd, EV_ABS, XBOX_ABS_DPADX, state != 0 ? 255 : 127);
+                break;
+        
+            default:
+                emit(fd, EV_KEY, translateButton(button), state);
+        }
+        emit(fd, EV_SYN, SYN_REPORT, 0);
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -9,156 +9,7 @@ import com.sun.jna.Structure;
 import java.util.Arrays;
 import java.util.List;
 
-public final class GameController {
-    public static final int DEVICE_ADDED = 0;
-    public static final int DEVICE_REMOVED = 1;
-
-    private static final int UINPUT_MAX_NAME_SIZE = 80;
-
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class InputId extends Structure {
-        public short bustype = 0;
-        public short vendor = 0;
-        public short product = 0;
-        public short version = 0;
-
-        @Override
-        protected List<String> getFieldOrder() {
-            return Arrays.asList("bustype", "vendor", "product", "version");
-        }
-    }
-
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class UinputSetup extends Structure {
-        public InputId id;
-        public byte[] name = new byte[UINPUT_MAX_NAME_SIZE];
-        public int ffEffectsMax = 0;
-
-        @Override
-        protected List<String> getFieldOrder() {
-            return Arrays.asList("id", "name", "ffEffectsMax");
-        }
-    }
-
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class InputAbsinfo extends Structure {
-        public int value = 0;
-        public int minimum = 0;
-        public int maximum = 0;
-        public int fuzz = 0;
-        public int flat = 0;
-        public int resolution = 0;
-
-        @Override
-        protected List<String> getFieldOrder() {
-            return Arrays.asList("value", "minimum", "maximum", "fuzz", "flat", "resolution");
-        }
-    };
-
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class UinputAbsSetup extends Structure {
-        public short code;
-        public InputAbsinfo absinfo;
-
-        @Override
-        protected List<String> getFieldOrder() {
-            return Arrays.asList("code", "absinfo");
-        }
-    };
-
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class InputEvent32 extends Structure {
-        public long time = 0;
-        public short type = 0;
-        public short code = 0;
-        public int value = 0;
-
-        @Override
-        protected List<String> getFieldOrder() {
-            return Arrays.asList("time", "type", "code", "value");
-        }
-    }
-
-    @SuppressWarnings("checkstyle:VisibilityModifier")
-    public static class InputEvent64 extends Structure {
-        public long sec = 0;
-        public long usec = 0;
-        public short type = 0;
-        public short code = 0;
-        public int value = 0;
-
-        @Override
-        protected List<String> getFieldOrder() {
-            return Arrays.asList("sec", "usec", "type", "code", "value");
-        }
-    }
-
-    private static final int IOC_NONE = 0;
-    private static final int IOC_WRITE = 1;
-
-    private static final int IOC_DIRSHIFT = 30;
-    private static final int IOC_TYPESHIFT = 8;
-    private static final int IOC_NRSHIFT = 0;
-    private static final int IOC_SIZESHIFT = 16;
-
-    private static int ioc(int dir, int type, int nr, int size) {
-        return (dir << IOC_DIRSHIFT)
-             | (type << IOC_TYPESHIFT)
-             | (nr << IOC_NRSHIFT)
-             | (size << IOC_SIZESHIFT);
-    }
-
-    private static int io(int type, int nr, int size) {
-        return ioc(IOC_NONE, type, nr, size);
-    }
-
-    private static int iow(int type, int nr, int size) {
-        return ioc(IOC_WRITE, type, nr, size);
-    }
-
-    private static final int O_WRONLY = 01;
-    private static final int O_NONBLOCK = 04000;
-
-    private static final int BUS_USB = 0x03;
-
-    private static final int UINPUT_IOCTL_BASE = 'U';
-
-    private static final int UI_SET_EVBIT = iow(UINPUT_IOCTL_BASE, 100, 4);
-    private static final int UI_SET_KEYBIT = iow(UINPUT_IOCTL_BASE, 101, 4);
-    private static final int UI_SET_ABSBIT = iow(UINPUT_IOCTL_BASE, 103, 4);
-    private static final int UI_ABS_SETUP = iow(UINPUT_IOCTL_BASE, 4, new UinputAbsSetup().size());
-
-    private static final int UI_DEV_SETUP = iow(UINPUT_IOCTL_BASE, 3, new UinputSetup().size());
-    private static final int UI_DEV_CREATE = io(UINPUT_IOCTL_BASE, 1, 0);
-    private static final int UI_DEV_DESTROY = io(UINPUT_IOCTL_BASE, 2, 0);
-
-    private static final short EV_SYN = 0x00;
-    private static final short EV_KEY = 0x01;
-    private static final short EV_ABS = 0x03;
-
-    private static final short SYN_REPORT = 0x00;
-
-    private static final short BTN_A = 0x130;
-    private static final short BTN_B = 0x131;
-    private static final short BTN_X = 0x133;
-    private static final short BTN_Y = 0x134;
-    private static final short BTN_TL = 0x136;
-    private static final short BTN_TR = 0x137;
-    private static final short BTN_SELECT = 0x13a;
-    private static final short BTN_START = 0x13b;
-    private static final short BTN_MODE = 0x13c;
-    private static final short BTN_THUMBL = 0x13d;
-    private static final short BTN_THUMBR = 0x13e;
-
-    private static final short ABS_X = 0x00;
-    private static final short ABS_Y = 0x01;
-    private static final short ABS_Z = 0x02;
-    private static final short ABS_RX = 0x03;
-    private static final short ABS_RY = 0x04;
-    private static final short ABS_RZ = 0x05;
-    private static final short ABS_HAT0X = 0x10;
-    private static final short ABS_HAT0Y = 0x11;
-
+public final class GameController extends UinputDevice {
     private static final short XBOX_BTN_A = BTN_A;
     private static final short XBOX_BTN_B = BTN_B;
     private static final short XBOX_BTN_X = BTN_X;
@@ -203,28 +54,11 @@ public final class GameController {
     public static final int SDL_CONTROLLER_BUTTON_DPAD_LEFT = 13;
     public static final int SDL_CONTROLLER_BUTTON_DPAD_RIGHT = 14;
 
-    private int fd;
-
-    public interface LibC extends Library {
-        LibC FN = (LibC) Native.load("c", LibC.class);
-
-        int open(String pathname, int flags);
-        int ioctl(int fd, long request, Object... args);
-        long write(int fd, Pointer buf, long count);
-        int close(int fd);
-    }
-
-    public static void loadNativeLibraries() {
-        GameController.LibC.FN.write(1, null, 0);
-    }
-
     public GameController() {
-        fd = LibC.FN.open("/dev/uinput", O_WRONLY | O_NONBLOCK);
-        if (fd == -1) {
-            throw new RuntimeException("Couldn't open uinput device.");
-        }
+        setup();
+    }
 
-        LibC.FN.ioctl(fd, UI_SET_EVBIT, EV_KEY);
+    protected void setupKeys() {
         addKey(XBOX_BTN_A);
         addKey(XBOX_BTN_B);
         addKey(XBOX_BTN_X);
@@ -236,8 +70,13 @@ public final class GameController {
         addKey(XBOX_BTN_GUIDE);
         addKey(XBOX_BTN_LS);
         addKey(XBOX_BTN_RS);
+    }
 
-        LibC.FN.ioctl(fd, UI_SET_EVBIT, EV_ABS);
+    protected boolean hasKeys() {
+        return true;
+    }
+
+    protected void setupAbs() {
         addAbs(XBOX_ABS_LSX, -32768, 32767, 16, 128);
         addAbs(XBOX_ABS_LSY, -32768, 32767, 16, 128);
         addAbs(XBOX_ABS_RSX, -32768, 32767, 16, 128);
@@ -248,87 +87,22 @@ public final class GameController {
         // but allow higher precision (eg. Xbox One controller)
         addAbs(XBOX_ABS_LT, 0, 32767, 0, 0);
         addAbs(XBOX_ABS_RT, 0, 32767, 0, 0);
-
-        UinputSetup usetup = new UinputSetup();
-        usetup.id.bustype = BUS_USB;
-        usetup.id.vendor = 0x045e;
-        usetup.id.product = 0x028e;
-        byte[] name = "Microsoft X-Box 360 pad".getBytes();
-        System.arraycopy(name, 0, usetup.name, 0, name.length);
-
-        if (LibC.FN.ioctl(fd, UI_DEV_SETUP, usetup) == -1) {
-            close();
-            throw new RuntimeException("Couldn't setup uinput device.");
-        }
-
-        if (LibC.FN.ioctl(fd, UI_DEV_CREATE) == -1) {
-            close();
-            throw new RuntimeException("Couldn't create uinput device.");
-        }
     }
 
-    public void close() {
-        if (fd != -1) {
-            LibC.FN.ioctl(fd, UI_DEV_DESTROY);
-            LibC.FN.close(fd);
-            fd = -1;
-        }
+    protected boolean hasAbs() {
+        return true;
     }
 
-    private void addKey(int key) {
-        if (LibC.FN.ioctl(fd, UI_SET_KEYBIT, key) == -1) {
-            Ln.e("Could not add key event.");
-        }
+    protected short getVendor() {
+        return 0x045e;
     }
 
-    private void addAbs(short code, int minimum, int maximum, int fuzz, int flat) {
-        if (LibC.FN.ioctl(fd, UI_SET_ABSBIT, code) == -1) {
-            Ln.e("Could not add absolute event.");
-        }
-
-        UinputAbsSetup absSetup = new UinputAbsSetup();
-
-        absSetup.code = code;
-        absSetup.absinfo.minimum = minimum;
-        absSetup.absinfo.maximum = maximum;
-        absSetup.absinfo.fuzz = fuzz;
-        absSetup.absinfo.flat = flat;
-
-        if (LibC.FN.ioctl(fd, UI_ABS_SETUP, absSetup) == -1) {
-            Ln.e("Could not set absolute event info.");
-        }
+    protected short getProduct() {
+        return 0x028e;
     }
 
-    private static void emit32(int fd, short type, short code, int val) {
-        InputEvent32 ie = new InputEvent32();
-
-        ie.type = type;
-        ie.code = code;
-        ie.value = val;
-
-        ie.write();
-
-        LibC.FN.write(fd, ie.getPointer(), ie.size());
-    }
-
-    private static void emit64(int fd, short type, short code, int val) {
-        InputEvent64 ie = new InputEvent64();
-
-        ie.type = type;
-        ie.code = code;
-        ie.value = val;
-
-        ie.write();
-
-        LibC.FN.write(fd, ie.getPointer(), ie.size());
-    }
-
-    private static void emit(int fd, short type, short code, int val) {
-        if (Platform.is64Bit()) {
-            emit64(fd, type, code, val);
-        } else {
-            emit32(fd, type, code, val);
-        }
+    protected String getName() {
+        return "Microsoft X-Box 360 pad";
     }
 
     private static short translateAxis(int axis) {
@@ -397,8 +171,8 @@ public final class GameController {
     }
 
     public void setAxis(int axis, int value) {
-        emit(fd, EV_ABS, translateAxis(axis), value);
-        emit(fd, EV_SYN, SYN_REPORT, 0);
+        emitAbs(translateAxis(axis), value);
+        emitReport();
     }
 
     public void setButton(int button, int state) {
@@ -406,24 +180,24 @@ public final class GameController {
 
         switch (button) {
             case SDL_CONTROLLER_BUTTON_DPAD_UP:
-                emit(fd, EV_ABS, XBOX_ABS_DPADY, state != 0 ? -1 : 0);
+                emitAbs(XBOX_ABS_DPADY, state != 0 ? -1 : 0);
                 break;
 
             case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-                emit(fd, EV_ABS, XBOX_ABS_DPADY, state != 0 ? 1 : 0);
+                emitAbs(XBOX_ABS_DPADY, state != 0 ? 1 : 0);
                 break;
 
             case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-                emit(fd, EV_ABS, XBOX_ABS_DPADX, state != 0 ? -1 : 0);
+                emitAbs(XBOX_ABS_DPADX, state != 0 ? -1 : 0);
                 break;
 
             case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-                emit(fd, EV_ABS, XBOX_ABS_DPADX, state != 0 ? 1 : 0);
+                emitAbs(XBOX_ABS_DPADX, state != 0 ? 1 : 0);
                 break;
 
             default:
-                emit(fd, EV_KEY, translateButton(button), state);
+                emitKey(translateButton(button), state);
         }
-        emit(fd, EV_SYN, SYN_REPORT, 0);
+        emitReport();
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -1,25 +1,26 @@
 package com.genymobile.scrcpy;
 
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
 import java.util.Arrays;
 import java.util.List;
-import com.sun.jna.Library;
-import com.sun.jna.Platform;
-import com.sun.jna.Native;
-import com.sun.jna.Structure;
-import com.sun.jna.Pointer;
 
 public final class GameController {
     public static final int DEVICE_ADDED = 0;
     public static final int DEVICE_REMOVED = 1;
 
-    private static int UINPUT_MAX_NAME_SIZE = 80;
+    private static final int UINPUT_MAX_NAME_SIZE = 80;
 
     public static class input_id extends Structure {
         public short bustype = 0;
         public short vendor = 0;
         public short product = 0;
         public short version = 0;
-    
+
         @Override
         protected List<String> getFieldOrder() {
             return Arrays.asList("bustype", "vendor", "product", "version");
@@ -54,10 +55,9 @@ public final class GameController {
     public static class uinput_abs_setup extends Structure {
         public short code;
         public input_absinfo absinfo;
-    
+
         @Override
-        protected List<String> getFieldOrder()
-        {
+        protected List<String> getFieldOrder() {
             return Arrays.asList("code", "absinfo");
         }
     };
@@ -87,19 +87,19 @@ public final class GameController {
         }
     }
 
-    private static int _IOC_NONE = 0;
-    private static int _IOC_WRITE = 1;
+    private static final int _IOC_NONE = 0;
+    private static final int _IOC_WRITE = 1;
 
-    private static int _IOC_DIRSHIFT = 30;
-    private static int _IOC_TYPESHIFT = 8;
-    private static int _IOC_NRSHIFT = 0;
-    private static int _IOC_SIZESHIFT = 16;
+    private static final int _IOC_DIRSHIFT = 30;
+    private static final int _IOC_TYPESHIFT = 8;
+    private static final int _IOC_NRSHIFT = 0;
+    private static final int _IOC_SIZESHIFT = 16;
 
     private static int _IOC(int dir, int type, int nr, int size) {
-        return (dir << _IOC_DIRSHIFT) |
-               (type << _IOC_TYPESHIFT) |
-               (nr << _IOC_NRSHIFT) |
-               (size << _IOC_SIZESHIFT);
+        return (dir << _IOC_DIRSHIFT)
+             | (type << _IOC_TYPESHIFT)
+             | (nr << _IOC_NRSHIFT)
+             | (size << _IOC_SIZESHIFT);
     }
 
     private static int _IO(int type, int nr, int size) {
@@ -114,7 +114,7 @@ public final class GameController {
     private static final int O_NONBLOCK = 04000;
 
     private static final int BUS_USB = 0x03;
-    
+
     private static final int UINPUT_IOCTL_BASE = 'U';
 
     private static final int UI_SET_EVBIT = _IOW(UINPUT_IOCTL_BASE, 100, 4);
@@ -200,7 +200,7 @@ public final class GameController {
     private int fd;
 
     public interface LibC extends Library {
-        LibC fn = (LibC)Native.load("c", LibC.class);
+        LibC fn = (LibC) Native.load("c", LibC.class);
 
         int open(String pathname, int flags);
         int ioctl(int fd, long request, Object... args);
@@ -208,7 +208,7 @@ public final class GameController {
         int close(int fd);
     }
 
-    static public void load_native_libraries() {
+    public static void load_native_libraries() {
         GameController.LibC.fn.write(1, null, 0);
     }
 
@@ -217,7 +217,7 @@ public final class GameController {
         if (fd == -1) {
             throw new RuntimeException("Couldn't open uinput device.");
         }
-    
+
         LibC.fn.ioctl(fd, UI_SET_EVBIT, EV_KEY);
         add_key(XBOX_BTN_A);
         add_key(XBOX_BTN_B);
@@ -230,7 +230,7 @@ public final class GameController {
         add_key(XBOX_BTN_GUIDE);
         add_key(XBOX_BTN_LS);
         add_key(XBOX_BTN_RS);
-    
+
         LibC.fn.ioctl(fd, UI_SET_EVBIT, EV_ABS);
         add_abs(XBOX_ABS_LSX, -32768, 32767, 16, 128);
         add_abs(XBOX_ABS_LSY, -32768, 32767, 16, 128);
@@ -254,7 +254,7 @@ public final class GameController {
             close();
             throw new RuntimeException("Couldn't setup uinput device.");
         }
-    
+
         if (LibC.fn.ioctl(fd, UI_DEV_CREATE) == -1) {
             close();
             throw new RuntimeException("Couldn't create uinput device.");
@@ -414,7 +414,7 @@ public final class GameController {
             case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
                 emit(fd, EV_ABS, XBOX_ABS_DPADX, state != 0 ? 1 : 0);
                 break;
-        
+
             default:
                 emit(fd, EV_KEY, translateButton(button), state);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -174,28 +174,28 @@ public final class GameController {
     private static final short XBOX_ABS_LT = ABS_Z;
     private static final short XBOX_ABS_RT = ABS_RZ;
 
-    private static final int SDL_CONTROLLER_AXIS_LEFTX = 0;
-    private static final int SDL_CONTROLLER_AXIS_LEFTY = 1;
-    private static final int SDL_CONTROLLER_AXIS_RIGHTX = 2;
-    private static final int SDL_CONTROLLER_AXIS_RIGHTY = 3;
-    private static final int SDL_CONTROLLER_AXIS_TRIGGERLEFT = 4;
-    private static final int SDL_CONTROLLER_AXIS_TRIGGERRIGHT = 5;
+    public static final int SDL_CONTROLLER_AXIS_LEFTX = 0;
+    public static final int SDL_CONTROLLER_AXIS_LEFTY = 1;
+    public static final int SDL_CONTROLLER_AXIS_RIGHTX = 2;
+    public static final int SDL_CONTROLLER_AXIS_RIGHTY = 3;
+    public static final int SDL_CONTROLLER_AXIS_TRIGGERLEFT = 4;
+    public static final int SDL_CONTROLLER_AXIS_TRIGGERRIGHT = 5;
 
-    private static final int SDL_CONTROLLER_BUTTON_A = 0;
-    private static final int SDL_CONTROLLER_BUTTON_B = 1;
-    private static final int SDL_CONTROLLER_BUTTON_X = 2;
-    private static final int SDL_CONTROLLER_BUTTON_Y = 3;
-    private static final int SDL_CONTROLLER_BUTTON_BACK = 4;
-    private static final int SDL_CONTROLLER_BUTTON_GUIDE = 5;
-    private static final int SDL_CONTROLLER_BUTTON_START = 6;
-    private static final int SDL_CONTROLLER_BUTTON_LEFTSTICK = 7;
-    private static final int SDL_CONTROLLER_BUTTON_RIGHTSTICK = 8;
-    private static final int SDL_CONTROLLER_BUTTON_LEFTSHOULDER = 9;
-    private static final int SDL_CONTROLLER_BUTTON_RIGHTSHOULDER = 10;
-    private static final int SDL_CONTROLLER_BUTTON_DPAD_UP = 11;
-    private static final int SDL_CONTROLLER_BUTTON_DPAD_DOWN = 12;
-    private static final int SDL_CONTROLLER_BUTTON_DPAD_LEFT = 13;
-    private static final int SDL_CONTROLLER_BUTTON_DPAD_RIGHT = 14;
+    public static final int SDL_CONTROLLER_BUTTON_A = 0;
+    public static final int SDL_CONTROLLER_BUTTON_B = 1;
+    public static final int SDL_CONTROLLER_BUTTON_X = 2;
+    public static final int SDL_CONTROLLER_BUTTON_Y = 3;
+    public static final int SDL_CONTROLLER_BUTTON_BACK = 4;
+    public static final int SDL_CONTROLLER_BUTTON_GUIDE = 5;
+    public static final int SDL_CONTROLLER_BUTTON_START = 6;
+    public static final int SDL_CONTROLLER_BUTTON_LEFTSTICK = 7;
+    public static final int SDL_CONTROLLER_BUTTON_RIGHTSTICK = 8;
+    public static final int SDL_CONTROLLER_BUTTON_LEFTSHOULDER = 9;
+    public static final int SDL_CONTROLLER_BUTTON_RIGHTSHOULDER = 10;
+    public static final int SDL_CONTROLLER_BUTTON_DPAD_UP = 11;
+    public static final int SDL_CONTROLLER_BUTTON_DPAD_DOWN = 12;
+    public static final int SDL_CONTROLLER_BUTTON_DPAD_LEFT = 13;
+    public static final int SDL_CONTROLLER_BUTTON_DPAD_RIGHT = 14;
 
     private int fd;
 

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -1,14 +1,5 @@
 package com.genymobile.scrcpy;
 
-import com.sun.jna.Library;
-import com.sun.jna.Native;
-import com.sun.jna.Platform;
-import com.sun.jna.Pointer;
-import com.sun.jna.Structure;
-
-import java.util.Arrays;
-import java.util.List;
-
 public final class GameController extends UinputDevice {
     private static final short XBOX_BTN_A = BTN_A;
     private static final short XBOX_BTN_B = BTN_B;

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -129,8 +129,8 @@ public final class GameController {
     private static final int UI_ABS_SETUP = iow(UINPUT_IOCTL_BASE, 4, new UinputAbsSetup().size());
 
     private static final int UI_DEV_SETUP = iow(UINPUT_IOCTL_BASE, 3, new UinputSetup().size());
-    private static final int UI_DEV_CREATE = iow(UINPUT_IOCTL_BASE, 1, 0);
-    private static final int UI_DEV_DESTROY = iow(UINPUT_IOCTL_BASE, 2, 0);
+    private static final int UI_DEV_CREATE = io(UINPUT_IOCTL_BASE, 1, 0);
+    private static final int UI_DEV_DESTROY = io(UINPUT_IOCTL_BASE, 2, 0);
 
     private static final short EV_SYN = 0x00;
     private static final short EV_KEY = 0x01;

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -1,6 +1,5 @@
 package com.genymobile.scrcpy;
 
-import java.io.*;
 import java.util.Arrays;
 import java.util.List;
 import com.sun.jna.Library;

--- a/server/src/main/java/com/genymobile/scrcpy/GameController.java
+++ b/server/src/main/java/com/genymobile/scrcpy/GameController.java
@@ -15,7 +15,8 @@ public final class GameController {
 
     private static final int UINPUT_MAX_NAME_SIZE = 80;
 
-    public static class input_id extends Structure {
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputId extends Structure {
         public short bustype = 0;
         public short vendor = 0;
         public short product = 0;
@@ -27,18 +28,20 @@ public final class GameController {
         }
     }
 
-    public static class uinput_setup extends Structure {
-        public input_id id;
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class UinputSetup extends Structure {
+        public InputId id;
         public byte[] name = new byte[UINPUT_MAX_NAME_SIZE];
-        public int ff_effects_max = 0;
+        public int ffEffectsMax = 0;
 
         @Override
         protected List<String> getFieldOrder() {
-            return Arrays.asList("id", "name", "ff_effects_max");
+            return Arrays.asList("id", "name", "ffEffectsMax");
         }
     }
 
-    public static class input_absinfo extends Structure {
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputAbsinfo extends Structure {
         public int value = 0;
         public int minimum = 0;
         public int maximum = 0;
@@ -52,9 +55,10 @@ public final class GameController {
         }
     };
 
-    public static class uinput_abs_setup extends Structure {
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class UinputAbsSetup extends Structure {
         public short code;
-        public input_absinfo absinfo;
+        public InputAbsinfo absinfo;
 
         @Override
         protected List<String> getFieldOrder() {
@@ -62,7 +66,8 @@ public final class GameController {
         }
     };
 
-    public static class input_event32 extends Structure {
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputEvent32 extends Structure {
         public long time = 0;
         public short type = 0;
         public short code = 0;
@@ -74,7 +79,8 @@ public final class GameController {
         }
     }
 
-    public static class input_event64 extends Structure {
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputEvent64 extends Structure {
         public long sec = 0;
         public long usec = 0;
         public short type = 0;
@@ -87,27 +93,27 @@ public final class GameController {
         }
     }
 
-    private static final int _IOC_NONE = 0;
-    private static final int _IOC_WRITE = 1;
+    private static final int IOC_NONE = 0;
+    private static final int IOC_WRITE = 1;
 
-    private static final int _IOC_DIRSHIFT = 30;
-    private static final int _IOC_TYPESHIFT = 8;
-    private static final int _IOC_NRSHIFT = 0;
-    private static final int _IOC_SIZESHIFT = 16;
+    private static final int IOC_DIRSHIFT = 30;
+    private static final int IOC_TYPESHIFT = 8;
+    private static final int IOC_NRSHIFT = 0;
+    private static final int IOC_SIZESHIFT = 16;
 
-    private static int _IOC(int dir, int type, int nr, int size) {
-        return (dir << _IOC_DIRSHIFT)
-             | (type << _IOC_TYPESHIFT)
-             | (nr << _IOC_NRSHIFT)
-             | (size << _IOC_SIZESHIFT);
+    private static int ioc(int dir, int type, int nr, int size) {
+        return (dir << IOC_DIRSHIFT)
+             | (type << IOC_TYPESHIFT)
+             | (nr << IOC_NRSHIFT)
+             | (size << IOC_SIZESHIFT);
     }
 
-    private static int _IO(int type, int nr, int size) {
-        return _IOC(_IOC_NONE, type, nr, size);
+    private static int io(int type, int nr, int size) {
+        return ioc(IOC_NONE, type, nr, size);
     }
 
-    private static int _IOW(int type, int nr, int size) {
-        return _IOC(_IOC_WRITE, type, nr, size);
+    private static int iow(int type, int nr, int size) {
+        return ioc(IOC_WRITE, type, nr, size);
     }
 
     private static final int O_WRONLY = 01;
@@ -117,14 +123,14 @@ public final class GameController {
 
     private static final int UINPUT_IOCTL_BASE = 'U';
 
-    private static final int UI_SET_EVBIT = _IOW(UINPUT_IOCTL_BASE, 100, 4);
-    private static final int UI_SET_KEYBIT = _IOW(UINPUT_IOCTL_BASE, 101, 4);
-    private static final int UI_SET_ABSBIT = _IOW(UINPUT_IOCTL_BASE, 103, 4);
-    private static final int UI_ABS_SETUP = _IOW(UINPUT_IOCTL_BASE, 4, new uinput_abs_setup().size());
+    private static final int UI_SET_EVBIT = iow(UINPUT_IOCTL_BASE, 100, 4);
+    private static final int UI_SET_KEYBIT = iow(UINPUT_IOCTL_BASE, 101, 4);
+    private static final int UI_SET_ABSBIT = iow(UINPUT_IOCTL_BASE, 103, 4);
+    private static final int UI_ABS_SETUP = iow(UINPUT_IOCTL_BASE, 4, new UinputAbsSetup().size());
 
-    private static final int UI_DEV_SETUP = _IOW(UINPUT_IOCTL_BASE, 3, new uinput_setup().size());
-    private static final int UI_DEV_CREATE = _IO(UINPUT_IOCTL_BASE, 1, 0);
-    private static final int UI_DEV_DESTROY = _IO(UINPUT_IOCTL_BASE, 2, 0);
+    private static final int UI_DEV_SETUP = iow(UINPUT_IOCTL_BASE, 3, new UinputSetup().size());
+    private static final int UI_DEV_CREATE = iow(UINPUT_IOCTL_BASE, 1, 0);
+    private static final int UI_DEV_DESTROY = iow(UINPUT_IOCTL_BASE, 2, 0);
 
     private static final short EV_SYN = 0x00;
     private static final short EV_KEY = 0x01;
@@ -200,7 +206,7 @@ public final class GameController {
     private int fd;
 
     public interface LibC extends Library {
-        LibC fn = (LibC) Native.load("c", LibC.class);
+        LibC FN = (LibC) Native.load("c", LibC.class);
 
         int open(String pathname, int flags);
         int ioctl(int fd, long request, Object... args);
@@ -208,54 +214,54 @@ public final class GameController {
         int close(int fd);
     }
 
-    public static void load_native_libraries() {
-        GameController.LibC.fn.write(1, null, 0);
+    public static void loadNativeLibraries() {
+        GameController.LibC.FN.write(1, null, 0);
     }
 
     public GameController() {
-        fd = LibC.fn.open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+        fd = LibC.FN.open("/dev/uinput", O_WRONLY | O_NONBLOCK);
         if (fd == -1) {
             throw new RuntimeException("Couldn't open uinput device.");
         }
 
-        LibC.fn.ioctl(fd, UI_SET_EVBIT, EV_KEY);
-        add_key(XBOX_BTN_A);
-        add_key(XBOX_BTN_B);
-        add_key(XBOX_BTN_X);
-        add_key(XBOX_BTN_Y);
-        add_key(XBOX_BTN_BACK);
-        add_key(XBOX_BTN_START);
-        add_key(XBOX_BTN_LB);
-        add_key(XBOX_BTN_RB);
-        add_key(XBOX_BTN_GUIDE);
-        add_key(XBOX_BTN_LS);
-        add_key(XBOX_BTN_RS);
+        LibC.FN.ioctl(fd, UI_SET_EVBIT, EV_KEY);
+        addKey(XBOX_BTN_A);
+        addKey(XBOX_BTN_B);
+        addKey(XBOX_BTN_X);
+        addKey(XBOX_BTN_Y);
+        addKey(XBOX_BTN_BACK);
+        addKey(XBOX_BTN_START);
+        addKey(XBOX_BTN_LB);
+        addKey(XBOX_BTN_RB);
+        addKey(XBOX_BTN_GUIDE);
+        addKey(XBOX_BTN_LS);
+        addKey(XBOX_BTN_RS);
 
-        LibC.fn.ioctl(fd, UI_SET_EVBIT, EV_ABS);
-        add_abs(XBOX_ABS_LSX, -32768, 32767, 16, 128);
-        add_abs(XBOX_ABS_LSY, -32768, 32767, 16, 128);
-        add_abs(XBOX_ABS_RSX, -32768, 32767, 16, 128);
-        add_abs(XBOX_ABS_RSY, -32768, 32767, 16, 128);
-        add_abs(XBOX_ABS_DPADX, -1, 1, 0, 0);
-        add_abs(XBOX_ABS_DPADY, -1, 1, 0, 0);
+        LibC.FN.ioctl(fd, UI_SET_EVBIT, EV_ABS);
+        addAbs(XBOX_ABS_LSX, -32768, 32767, 16, 128);
+        addAbs(XBOX_ABS_LSY, -32768, 32767, 16, 128);
+        addAbs(XBOX_ABS_RSX, -32768, 32767, 16, 128);
+        addAbs(XBOX_ABS_RSY, -32768, 32767, 16, 128);
+        addAbs(XBOX_ABS_DPADX, -1, 1, 0, 0);
+        addAbs(XBOX_ABS_DPADY, -1, 1, 0, 0);
         // These values deviate from the real Xbox 360 controller,
         // but allow higher precision (eg. Xbox One controller)
-        add_abs(XBOX_ABS_LT, 0, 32767, 0, 0);
-        add_abs(XBOX_ABS_RT, 0, 32767, 0, 0);
+        addAbs(XBOX_ABS_LT, 0, 32767, 0, 0);
+        addAbs(XBOX_ABS_RT, 0, 32767, 0, 0);
 
-        uinput_setup usetup = new uinput_setup();
+        UinputSetup usetup = new UinputSetup();
         usetup.id.bustype = BUS_USB;
         usetup.id.vendor = 0x045e;
         usetup.id.product = 0x028e;
         byte[] name = "Microsoft X-Box 360 pad".getBytes();
         System.arraycopy(name, 0, usetup.name, 0, name.length);
 
-        if (LibC.fn.ioctl(fd, UI_DEV_SETUP, usetup) == -1) {
+        if (LibC.FN.ioctl(fd, UI_DEV_SETUP, usetup) == -1) {
             close();
             throw new RuntimeException("Couldn't setup uinput device.");
         }
 
-        if (LibC.fn.ioctl(fd, UI_DEV_CREATE) == -1) {
+        if (LibC.FN.ioctl(fd, UI_DEV_CREATE) == -1) {
             close();
             throw new RuntimeException("Couldn't create uinput device.");
         }
@@ -263,38 +269,38 @@ public final class GameController {
 
     public void close() {
         if (fd != -1) {
-            LibC.fn.ioctl(fd, UI_DEV_DESTROY);
-            LibC.fn.close(fd);
+            LibC.FN.ioctl(fd, UI_DEV_DESTROY);
+            LibC.FN.close(fd);
             fd = -1;
         }
     }
 
-    private void add_key(int key) {
-        if (LibC.fn.ioctl(fd, UI_SET_KEYBIT, key) == -1) {
+    private void addKey(int key) {
+        if (LibC.FN.ioctl(fd, UI_SET_KEYBIT, key) == -1) {
             Ln.e("Could not add key event.");
         }
     }
 
-    private void add_abs(short code, int minimum, int maximum, int fuzz, int flat) {
-        if (LibC.fn.ioctl(fd, UI_SET_ABSBIT, code) == -1) {
+    private void addAbs(short code, int minimum, int maximum, int fuzz, int flat) {
+        if (LibC.FN.ioctl(fd, UI_SET_ABSBIT, code) == -1) {
             Ln.e("Could not add absolute event.");
         }
 
-        uinput_abs_setup abs_setup = new uinput_abs_setup();
+        UinputAbsSetup absSetup = new UinputAbsSetup();
 
-        abs_setup.code = code;
-        abs_setup.absinfo.minimum = minimum;
-        abs_setup.absinfo.maximum = maximum;
-        abs_setup.absinfo.fuzz = fuzz;
-        abs_setup.absinfo.flat = flat;
+        absSetup.code = code;
+        absSetup.absinfo.minimum = minimum;
+        absSetup.absinfo.maximum = maximum;
+        absSetup.absinfo.fuzz = fuzz;
+        absSetup.absinfo.flat = flat;
 
-        if (LibC.fn.ioctl(fd, UI_ABS_SETUP, abs_setup) == -1) {
+        if (LibC.FN.ioctl(fd, UI_ABS_SETUP, absSetup) == -1) {
             Ln.e("Could not set absolute event info.");
         }
     }
 
     private static void emit32(int fd, short type, short code, int val) {
-        input_event32 ie = new input_event32();
+        InputEvent32 ie = new InputEvent32();
 
         ie.type = type;
         ie.code = code;
@@ -302,11 +308,11 @@ public final class GameController {
 
         ie.write();
 
-        LibC.fn.write(fd, ie.getPointer(), ie.size());
+        LibC.FN.write(fd, ie.getPointer(), ie.size());
     }
 
     private static void emit64(int fd, short type, short code, int val) {
-        input_event64 ie = new input_event64();
+        InputEvent64 ie = new InputEvent64();
 
         ie.type = type;
         ie.code = code;
@@ -314,7 +320,7 @@ public final class GameController {
 
         ie.write();
 
-        LibC.fn.write(fd, ie.getPointer(), ie.size());
+        LibC.FN.write(fd, ie.getPointer(), ie.size());
     }
 
     private static void emit(int fd, short type, short code, int val) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -16,7 +16,6 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ExecutionException;
 
 public final class Server {
 

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -12,7 +12,6 @@ import android.text.TextUtils;
 import java.io.InputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Locale;
 
@@ -47,7 +46,7 @@ public final class Server {
 
                     resStream.close();
                     fileStream.close();
-                    
+
                     break;
                 } catch (Exception e) {
                     Ln.e("Could not extract native library for " + abi, e);

--- a/server/src/main/java/com/genymobile/scrcpy/UinputDevice.java
+++ b/server/src/main/java/com/genymobile/scrcpy/UinputDevice.java
@@ -1,0 +1,296 @@
+package com.genymobile.scrcpy;
+
+import com.sun.jna.Library;
+import com.sun.jna.Native;
+import com.sun.jna.Platform;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+import java.util.Arrays;
+import java.util.List;
+
+public abstract class UinputDevice {
+    public static final int DEVICE_ADDED = 0;
+    public static final int DEVICE_REMOVED = 1;
+
+    private static final int UINPUT_MAX_NAME_SIZE = 80;
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputId extends Structure {
+        public short bustype = 0;
+        public short vendor = 0;
+        public short product = 0;
+        public short version = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("bustype", "vendor", "product", "version");
+        }
+    }
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class UinputSetup extends Structure {
+        public InputId id;
+        public byte[] name = new byte[UINPUT_MAX_NAME_SIZE];
+        public int ffEffectsMax = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("id", "name", "ffEffectsMax");
+        }
+    }
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputAbsinfo extends Structure {
+        public int value = 0;
+        public int minimum = 0;
+        public int maximum = 0;
+        public int fuzz = 0;
+        public int flat = 0;
+        public int resolution = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("value", "minimum", "maximum", "fuzz", "flat", "resolution");
+        }
+    };
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class UinputAbsSetup extends Structure {
+        public short code;
+        public InputAbsinfo absinfo;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("code", "absinfo");
+        }
+    };
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputEvent32 extends Structure {
+        public long time = 0;
+        public short type = 0;
+        public short code = 0;
+        public int value = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("time", "type", "code", "value");
+        }
+    }
+
+    @SuppressWarnings("checkstyle:VisibilityModifier")
+    public static class InputEvent64 extends Structure {
+        public long sec = 0;
+        public long usec = 0;
+        public short type = 0;
+        public short code = 0;
+        public int value = 0;
+
+        @Override
+        protected List<String> getFieldOrder() {
+            return Arrays.asList("sec", "usec", "type", "code", "value");
+        }
+    }
+
+    private static final int IOC_NONE = 0;
+    private static final int IOC_WRITE = 1;
+
+    private static final int IOC_DIRSHIFT = 30;
+    private static final int IOC_TYPESHIFT = 8;
+    private static final int IOC_NRSHIFT = 0;
+    private static final int IOC_SIZESHIFT = 16;
+
+    private static int ioc(int dir, int type, int nr, int size) {
+        return (dir << IOC_DIRSHIFT)
+             | (type << IOC_TYPESHIFT)
+             | (nr << IOC_NRSHIFT)
+             | (size << IOC_SIZESHIFT);
+    }
+
+    private static int io(int type, int nr, int size) {
+        return ioc(IOC_NONE, type, nr, size);
+    }
+
+    private static int iow(int type, int nr, int size) {
+        return ioc(IOC_WRITE, type, nr, size);
+    }
+
+    private static final int O_WRONLY = 01;
+    private static final int O_NONBLOCK = 04000;
+
+    private static final int BUS_USB = 0x03;
+
+    private static final int UINPUT_IOCTL_BASE = 'U';
+
+    private static final int UI_SET_EVBIT = iow(UINPUT_IOCTL_BASE, 100, 4);
+    private static final int UI_SET_KEYBIT = iow(UINPUT_IOCTL_BASE, 101, 4);
+    private static final int UI_SET_ABSBIT = iow(UINPUT_IOCTL_BASE, 103, 4);
+    private static final int UI_ABS_SETUP = iow(UINPUT_IOCTL_BASE, 4, new UinputAbsSetup().size());
+
+    private static final int UI_DEV_SETUP = iow(UINPUT_IOCTL_BASE, 3, new UinputSetup().size());
+    private static final int UI_DEV_CREATE = io(UINPUT_IOCTL_BASE, 1, 0);
+    private static final int UI_DEV_DESTROY = io(UINPUT_IOCTL_BASE, 2, 0);
+
+    private static final short EV_SYN = 0x00;
+    private static final short EV_KEY = 0x01;
+    private static final short EV_ABS = 0x03;
+
+    private static final short SYN_REPORT = 0x00;
+
+    protected static final short BTN_A = 0x130;
+    protected static final short BTN_B = 0x131;
+    protected static final short BTN_X = 0x133;
+    protected static final short BTN_Y = 0x134;
+    protected static final short BTN_TL = 0x136;
+    protected static final short BTN_TR = 0x137;
+    protected static final short BTN_SELECT = 0x13a;
+    protected static final short BTN_START = 0x13b;
+    protected static final short BTN_MODE = 0x13c;
+    protected static final short BTN_THUMBL = 0x13d;
+    protected static final short BTN_THUMBR = 0x13e;
+
+    protected static final short ABS_X = 0x00;
+    protected static final short ABS_Y = 0x01;
+    protected static final short ABS_Z = 0x02;
+    protected static final short ABS_RX = 0x03;
+    protected static final short ABS_RY = 0x04;
+    protected static final short ABS_RZ = 0x05;
+    protected static final short ABS_HAT0X = 0x10;
+    protected static final short ABS_HAT0Y = 0x11;
+
+    private int fd = -1;
+
+    public interface LibC extends Library {
+        LibC FN = (LibC) Native.load("c", LibC.class);
+
+        int open(String pathname, int flags);
+        int ioctl(int fd, long request, Object... args);
+        long write(int fd, Pointer buf, long count);
+        int close(int fd);
+    }
+
+    public static void loadNativeLibraries() {
+        UinputDevice.LibC.FN.write(1, null, 0);
+    }
+
+    protected void setup() {
+        fd = LibC.FN.open("/dev/uinput", O_WRONLY | O_NONBLOCK);
+        if (fd == -1) {
+            throw new RuntimeException("Couldn't open uinput device.");
+        }
+
+        if (hasKeys())
+        {
+            LibC.FN.ioctl(fd, UI_SET_EVBIT, EV_KEY);
+            setupKeys();
+        }
+
+        if (hasAbs())
+        {
+            LibC.FN.ioctl(fd, UI_SET_EVBIT, EV_ABS);
+            setupAbs();
+        }
+
+        UinputSetup usetup = new UinputSetup();
+        usetup.id.bustype = BUS_USB;
+        usetup.id.vendor = getVendor();
+        usetup.id.product = getProduct();
+        byte[] name = getName().getBytes();
+        System.arraycopy(name, 0, usetup.name, 0, name.length);
+
+        if (LibC.FN.ioctl(fd, UI_DEV_SETUP, usetup) == -1) {
+            close();
+            throw new RuntimeException("Couldn't setup uinput device.");
+        }
+
+        if (LibC.FN.ioctl(fd, UI_DEV_CREATE) == -1) {
+            close();
+            throw new RuntimeException("Couldn't create uinput device.");
+        }
+    }
+
+    public void close() {
+        if (fd != -1) {
+            LibC.FN.ioctl(fd, UI_DEV_DESTROY);
+            LibC.FN.close(fd);
+            fd = -1;
+        }
+    }
+
+    protected abstract void setupKeys();
+    protected abstract boolean hasKeys();
+    protected abstract void setupAbs();
+    protected abstract boolean hasAbs();
+    protected abstract short getVendor();
+    protected abstract short getProduct();
+    protected abstract String getName();
+
+    protected void addKey(int key) {
+        if (LibC.FN.ioctl(fd, UI_SET_KEYBIT, key) == -1) {
+            Ln.e("Could not add key event.");
+        }
+    }
+
+    protected void addAbs(short code, int minimum, int maximum, int fuzz, int flat) {
+        if (LibC.FN.ioctl(fd, UI_SET_ABSBIT, code) == -1) {
+            Ln.e("Could not add absolute event.");
+        }
+
+        UinputAbsSetup absSetup = new UinputAbsSetup();
+
+        absSetup.code = code;
+        absSetup.absinfo.minimum = minimum;
+        absSetup.absinfo.maximum = maximum;
+        absSetup.absinfo.fuzz = fuzz;
+        absSetup.absinfo.flat = flat;
+
+        if (LibC.FN.ioctl(fd, UI_ABS_SETUP, absSetup) == -1) {
+            Ln.e("Could not set absolute event info.");
+        }
+    }
+
+    private static void emit32(int fd, short type, short code, int val) {
+        InputEvent32 ie = new InputEvent32();
+
+        ie.type = type;
+        ie.code = code;
+        ie.value = val;
+
+        ie.write();
+
+        LibC.FN.write(fd, ie.getPointer(), ie.size());
+    }
+
+    private static void emit64(int fd, short type, short code, int val) {
+        InputEvent64 ie = new InputEvent64();
+
+        ie.type = type;
+        ie.code = code;
+        ie.value = val;
+
+        ie.write();
+
+        LibC.FN.write(fd, ie.getPointer(), ie.size());
+    }
+
+    private static void emit(int fd, short type, short code, int val) {
+        if (Platform.is64Bit()) {
+            emit64(fd, type, code, val);
+        } else {
+            emit32(fd, type, code, val);
+        }
+    }
+
+    protected void emitAbs(short abs, int value) {
+        emit(fd, EV_ABS, abs, value);
+    }
+
+    protected void emitKey(short key, int state) {
+        emit(fd, EV_KEY, key, state);
+    }
+
+    protected void emitReport() {
+        emit(fd, EV_SYN, SYN_REPORT, 0);
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/UinputDevice.java
+++ b/server/src/main/java/com/genymobile/scrcpy/UinputDevice.java
@@ -181,14 +181,12 @@ public abstract class UinputDevice {
             throw new RuntimeException("Couldn't open uinput device.");
         }
 
-        if (hasKeys())
-        {
+        if (hasKeys()) {
             libC.ioctl(fd, UI_SET_EVBIT, EV_KEY);
             setupKeys();
         }
 
-        if (hasAbs())
-        {
+        if (hasAbs()) {
             libC.ioctl(fd, UI_SET_EVBIT, EV_ABS);
             setupAbs();
         }

--- a/server/src/main/java/com/genymobile/scrcpy/UinputUnsupportedException.java
+++ b/server/src/main/java/com/genymobile/scrcpy/UinputUnsupportedException.java
@@ -1,0 +1,7 @@
+package com.genymobile.scrcpy;
+
+public class UinputUnsupportedException extends RuntimeException {
+    public UinputUnsupportedException(Exception e) {
+        super("device does not support uinput without root", e);
+    }
+}

--- a/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
@@ -315,6 +315,76 @@ public class ControlMessageReaderTest {
     }
 
     @Test
+    public void testParseGameControllerAxisEvent() throws IOException {
+        ControlMessageReader reader = new ControlMessageReader();
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeByte(ControlMessage.TYPE_INJECT_GAME_CONTROLLER_AXIS);
+        dos.writeShort(0x1234);
+        dos.writeByte(GameController.SDL_CONTROLLER_AXIS_RIGHTY);
+        dos.writeShort(-32768);
+        byte[] packet = bos.toByteArray();
+
+        // The message type (1 byte) does not count
+        Assert.assertEquals(ControlMessageReader.INJECT_GAME_CONTROLLER_AXIS_PAYLOAD_LENGTH, packet.length - 1);
+
+        reader.readFrom(new ByteArrayInputStream(packet));
+        ControlMessage event = reader.next();
+
+        Assert.assertEquals(ControlMessage.TYPE_INJECT_GAME_CONTROLLER_AXIS, event.getType());
+        Assert.assertEquals(0x1234, event.getGameControllerId());
+        Assert.assertEquals(GameController.SDL_CONTROLLER_AXIS_RIGHTY, event.getGameControllerAxis());
+        Assert.assertEquals(-32768, event.getGameControllerAxisValue());
+    }
+
+    @Test
+    public void testParseGameControllerButtonEvent() throws IOException {
+        ControlMessageReader reader = new ControlMessageReader();
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeByte(ControlMessage.TYPE_INJECT_GAME_CONTROLLER_BUTTON);
+        dos.writeShort(0x1234);
+        dos.writeByte(GameController.SDL_CONTROLLER_BUTTON_START);
+        dos.writeByte(1);
+        byte[] packet = bos.toByteArray();
+
+        // The message type (1 byte) does not count
+        Assert.assertEquals(ControlMessageReader.INJECT_GAME_CONTROLLER_BUTTON_PAYLOAD_LENGTH, packet.length - 1);
+
+        reader.readFrom(new ByteArrayInputStream(packet));
+        ControlMessage event = reader.next();
+
+        Assert.assertEquals(ControlMessage.TYPE_INJECT_GAME_CONTROLLER_BUTTON, event.getType());
+        Assert.assertEquals(0x1234, event.getGameControllerId());
+        Assert.assertEquals(GameController.SDL_CONTROLLER_BUTTON_START, event.getGameControllerButton());
+        Assert.assertEquals(1, event.getGameControllerButtonState());
+    }
+
+    @Test
+    public void testParseGameControllerDeviceEvent() throws IOException {
+        ControlMessageReader reader = new ControlMessageReader();
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeByte(ControlMessage.TYPE_INJECT_GAME_CONTROLLER_DEVICE);
+        dos.writeShort(0x1234);
+        dos.writeByte(GameController.DEVICE_REMOVED);
+        byte[] packet = bos.toByteArray();
+
+        // The message type (1 byte) does not count
+        Assert.assertEquals(ControlMessageReader.INJECT_GAME_CONTROLLER_DEVICE_PAYLOAD_LENGTH, packet.length - 1);
+
+        reader.readFrom(new ByteArrayInputStream(packet));
+        ControlMessage event = reader.next();
+
+        Assert.assertEquals(ControlMessage.TYPE_INJECT_GAME_CONTROLLER_DEVICE, event.getType());
+        Assert.assertEquals(0x1234, event.getGameControllerId());
+        Assert.assertEquals(GameController.DEVICE_REMOVED, event.getGameControllerDeviceEvent());
+    }
+
+    @Test
     public void testMultiEvents() throws IOException {
         ControlMessageReader reader = new ControlMessageReader();
 


### PR DESCRIPTION
closes #99 

## What it does

- Handles events from connected game controllers;
- Transfers game controller events to Android device;
- Emulates an Xbox 360 game controller input device.

## Important stuff

- In order to emulate input devices, we need a few system calls (`open`, `ioctl`, `write` and `close`). Since we can't use most of these directly from Java (AFAIK), we need either native code or a library that allows us to call these functions. To avoid depending on the NDK, I'm using the Java Native Access library;
- JNA requires a native library (libjnidispatch.so). For some reason, `app_process` doesn't want to load it, so right now it's extracted to `/data/local/tmp` on initialization and cleaned up later.

## Things you can help with

- Testing:
    - Comment whether it works on your device or not, so I can keep a list;
    - Axes behavior;
    - Multiple controllers.
- Find a way to use the `ioctl` syscall without native code;
- Load native libraries without extracting them;
- Figure out multiple controllers with event injection.

## To-do

- [x] Add command line option for disabling game controllers
- [x] Write tests
- [x] Isolate uinput related stuff into another class (so other types of devices can be implemented)
- [x] Fix input not working when uinput fails
- [x] Support legacy uinput
- [x] Look into event injection (for when uinput is unavailable)
- [ ] Look into getting games to recognize axis movement when using event injection
- [ ] Implement controller through event injection

## Out of scope

I probably won't be adding some special features to this pull request, such as:
- Vibration
- Battery reporting
- Lights
- Touchpad

## Feedback

If you have any feedback (suggestions, complaints, new info, ...), please don't hesitate to write it down below.

## Tested devices

Manufacturer | Model | Android version | Last tested on | Tested by | Supported | Supported with root
:-:|:-:|:-:|:-:|:-:|:-:|:-:
Motorola | Moto G<sup>5</sup> Plus | 8.1 | 2021-04-30 | @LHLaurini | :x: | :grey_question:
Motorola | moto g(6) play | 9 | 2021-04-30 | @LHLaurini | :x: | :grey_question:
Samsung | Galaxy A7 2018 | 10 | 2021-04-06 | @Fablo020 | :x: | :grey_question:
Samsung | Galaxy M21s | 11 | 2021-04-30 | @LHLaurini | :heavy_check_mark: | :grey_question:
Huawei | Honor Play COR-L29 | 9 | 2021-05-01 | @Cannahawk | :x: | :grey_question:
Xiaomi | Pocophone F1 | 11 | 2021-05-23 | @Nightm4res | :grey_question: | :heavy_check_mark:
Sony | Xperia XZ1 Compact | 11 | 2021-06-14 | @Schlumpf7 | :heavy_check_mark: | :grey_question:
Sony | Xperia XZ | :grey_question: | 2021-06-15 | @Schlumpf7 | :heavy_check_mark: | :grey_question:
Blackview | BV6000 | :grey_question: | 2021-06-15 | @Schlumpf7 | :heavy_check_mark: | :grey_question:
Xiaomi | Mi A3 | 11 | 2021-06-17 | @RuiGuilherme | :heavy_check_mark: | :grey_question:
Nvidia | Shield TV | 11 | 2022-02-12 | @scaldav | :heavy_check_mark: | :grey_question:
Blackview | BV6300 Pro | 10 | 2022-05-02 | @Fancy2209 | :heavy_check_mark: | :grey_question:
Google | Pixel 6 | 12 | 2022-06-02 | @AntoninHuaut | :heavy_check_mark: | :grey_question:
Redmi | Note 9 Pro 5G | 12 | 2022-06-18 | @esec | :heavy_check_mark: | :grey_question:
Redmi | Note 5 Pro | 11[*](#issuecomment-1160959261 "LineageOS 18") | 2022-06-20 | @Sigmacringe | :heavy_check_mark: | :grey_question:

The list of (un)supported devices can change anytime.

### Reporting a new device

If you have tested with a device not on the list, please report it by writing a comment below. Please follow (more or less) the following format:

    **Manufacturer**: Foo
    **Model**: Bar 12
    **Android version**: 123.4 (specify if not stock)
    **Root**: Y/N

## NEW: Windows and Linux releases 

Prebuilt versions of scrcpy with the new patches can be found [here](https://github.com/LHLaurini/scrcpy/releases). Remember to set the `SCRCPY_SERVER_PATH` variable.