### PR TITLE
meson: Do not use full path with mingw tools name.

### DIFF
--- a/cross_win32.txt
+++ b/cross_win32.txt
@@ -2,11 +2,11 @@
 
 [binaries]
 name = 'mingw'
-c = '/usr/bin/i686-w64-mingw32-gcc'
-cpp = '/usr/bin/i686-w64-mingw32-g++'
-ar = '/usr/bin/i686-w64-mingw32-ar'
-strip = '/usr/bin/i686-w64-mingw32-strip'
-pkgconfig = '/usr/bin/i686-w64-mingw32-pkg-config'
+c = 'i686-w64-mingw32-gcc'
+cpp = 'i686-w64-mingw32-g++'
+ar = 'i686-w64-mingw32-ar'
+strip = 'i686-w64-mingw32-strip'
+pkgconfig = 'i686-w64-mingw32-pkg-config'
 
 [host_machine]
 system = 'windows'

--- a/cross_win64.txt
+++ b/cross_win64.txt
@@ -2,11 +2,11 @@
 
 [binaries]
 name = 'mingw'
-c = '/usr/bin/x86_64-w64-mingw32-gcc'
-cpp = '/usr/bin/x86_64-w64-mingw32-g++'
-ar = '/usr/bin/x86_64-w64-mingw32-ar'
-strip = '/usr/bin/x86_64-w64-mingw32-strip'
-pkgconfig = '/usr/bin/x86_64-w64-mingw32-pkg-config'
+c = 'x86_64-w64-mingw32-gcc'
+cpp = 'x86_64-w64-mingw32-g++'
+ar = 'x86_64-w64-mingw32-ar'
+strip = 'x86_64-w64-mingw32-strip'
+pkgconfig = 'x86_64-w64-mingw32-pkg-config'
 
 [host_machine]
 system = 'windows'


### PR DESCRIPTION
This helps to use mingw toolchains which are not in /usr/bin path.