### PR TITLE
Improve mouse buttons events

### DIFF
--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -67,6 +67,9 @@ control_msg_serialize(const struct control_msg *msg, unsigned char *buf) {
             buffer_write32be(&buf[17],
                              (uint32_t) msg->inject_scroll_event.vscroll);
             return 21;
+        case CONTROL_MSG_TYPE_BACK_OR_SCREEN_ON:
+            buf[1] = msg->inject_keycode.action;
+            return 2;
         case CONTROL_MSG_TYPE_SET_CLIPBOARD: {
             buf[1] = !!msg->set_clipboard.paste;
             size_t len = write_string(msg->set_clipboard.text,
@@ -77,7 +80,6 @@ control_msg_serialize(const struct control_msg *msg, unsigned char *buf) {
         case CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE:
             buf[1] = msg->set_screen_power_mode.mode;
             return 2;
-        case CONTROL_MSG_TYPE_BACK_OR_SCREEN_ON:
         case CONTROL_MSG_TYPE_EXPAND_NOTIFICATION_PANEL:
         case CONTROL_MSG_TYPE_COLLAPSE_NOTIFICATION_PANEL:
         case CONTROL_MSG_TYPE_GET_CLIPBOARD:

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -65,6 +65,10 @@ struct control_msg {
             int32_t vscroll;
         } inject_scroll_event;
         struct {
+            enum android_keyevent_action action; // action for the BACK key
+            // screen may only be turned on on ACTION_DOWN
+        } back_or_screen_on;
+        struct {
             char *text; // owned, to be freed by free()
             bool paste;
         } set_clipboard;

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -646,13 +646,17 @@ input_manager_process_mouse_button(struct input_manager *im,
     }
 
     bool down = event->type == SDL_MOUSEBUTTONDOWN;
-    if (!im->forward_all_clicks && down) {
+    if (!im->forward_all_clicks) {
         if (control && event->button == SDL_BUTTON_RIGHT) {
-            press_back_or_turn_screen_on(im->controller);
+            if (down) {
+                press_back_or_turn_screen_on(im->controller);
+            }
             return;
         }
         if (control && event->button == SDL_BUTTON_MIDDLE) {
-            action_home(im->controller, ACTION_DOWN | ACTION_UP);
+            if (down) {
+                action_home(im->controller, ACTION_DOWN | ACTION_UP);
+            }
             return;
         }
 
@@ -665,7 +669,9 @@ input_manager_process_mouse_button(struct input_manager *im,
             bool outside = x < r->x || x >= r->x + r->w
                         || y < r->y || y >= r->y + r->h;
             if (outside) {
-                screen_resize_to_fit(im->screen);
+                if (down) {
+                    screen_resize_to_fit(im->screen);
+                }
                 return;
             }
         }

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -647,6 +647,8 @@ input_manager_process_mouse_button(struct input_manager *im,
 
     bool down = event->type == SDL_MOUSEBUTTONDOWN;
     if (!im->forward_all_clicks) {
+        int action = down ? ACTION_DOWN : ACTION_UP;
+
         if (control && event->button == SDL_BUTTON_RIGHT) {
             if (down) {
                 press_back_or_turn_screen_on(im->controller);
@@ -654,9 +656,7 @@ input_manager_process_mouse_button(struct input_manager *im,
             return;
         }
         if (control && event->button == SDL_BUTTON_MIDDLE) {
-            if (down) {
-                action_home(im->controller, ACTION_DOWN | ACTION_UP);
-            }
+            action_home(im->controller, action);
             return;
         }
 

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -146,14 +146,18 @@ static void test_serialize_inject_scroll_event(void) {
 static void test_serialize_back_or_screen_on(void) {
     struct control_msg msg = {
         .type = CONTROL_MSG_TYPE_BACK_OR_SCREEN_ON,
+        .back_or_screen_on = {
+            .action = AKEY_EVENT_ACTION_UP,
+        },
     };
 
     unsigned char buf[CONTROL_MSG_MAX_SIZE];
     size_t size = control_msg_serialize(&msg, buf);
-    assert(size == 1);
+    assert(size == 2);
 
     const unsigned char expected[] = {
         CONTROL_MSG_TYPE_BACK_OR_SCREEN_ON,
+        0x01, // AKEY_EVENT_ACTION_UP
     };
     assert(!memcmp(buf, expected, sizeof(expected)));
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
@@ -71,6 +71,13 @@ public final class ControlMessage {
         return msg;
     }
 
+    public static ControlMessage createBackOrScreenOn(int action) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_BACK_OR_SCREEN_ON;
+        msg.action = action;
+        return msg;
+    }
+
     public static ControlMessage createSetClipboard(String text, boolean paste) {
         ControlMessage msg = new ControlMessage();
         msg.type = TYPE_SET_CLIPBOARD;

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
@@ -11,6 +11,7 @@ public class ControlMessageReader {
     static final int INJECT_KEYCODE_PAYLOAD_LENGTH = 13;
     static final int INJECT_TOUCH_EVENT_PAYLOAD_LENGTH = 27;
     static final int INJECT_SCROLL_EVENT_PAYLOAD_LENGTH = 20;
+    static final int BACK_OR_SCREEN_ON_LENGTH = 1;
     static final int SET_SCREEN_POWER_MODE_PAYLOAD_LENGTH = 1;
     static final int SET_CLIPBOARD_FIXED_PAYLOAD_LENGTH = 1;
 
@@ -66,13 +67,15 @@ public class ControlMessageReader {
             case ControlMessage.TYPE_INJECT_SCROLL_EVENT:
                 msg = parseInjectScrollEvent();
                 break;
+            case ControlMessage.TYPE_BACK_OR_SCREEN_ON:
+                msg = parseBackOrScreenOnEvent();
+                break;
             case ControlMessage.TYPE_SET_CLIPBOARD:
                 msg = parseSetClipboard();
                 break;
             case ControlMessage.TYPE_SET_SCREEN_POWER_MODE:
                 msg = parseSetScreenPowerMode();
                 break;
-            case ControlMessage.TYPE_BACK_OR_SCREEN_ON:
             case ControlMessage.TYPE_EXPAND_NOTIFICATION_PANEL:
             case ControlMessage.TYPE_COLLAPSE_NOTIFICATION_PANEL:
             case ControlMessage.TYPE_GET_CLIPBOARD:
@@ -148,6 +151,14 @@ public class ControlMessageReader {
         int hScroll = buffer.getInt();
         int vScroll = buffer.getInt();
         return ControlMessage.createInjectScrollEvent(position, hScroll, vScroll);
+    }
+
+    private ControlMessage parseBackOrScreenOnEvent() {
+        if (buffer.remaining() < BACK_OR_SCREEN_ON_LENGTH) {
+            return null;
+        }
+        int action = toUnsigned(buffer.get());
+        return ControlMessage.createBackOrScreenOn(action);
     }
 
     private ControlMessage parseSetClipboard() {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -101,7 +101,7 @@ public class Controller {
                 break;
             case ControlMessage.TYPE_BACK_OR_SCREEN_ON:
                 if (device.supportsInputEvents()) {
-                    pressBackOrTurnScreenOn();
+                    pressBackOrTurnScreenOn(msg.getAction());
                 }
                 break;
             case ControlMessage.TYPE_EXPAND_NOTIFICATION_PANEL:
@@ -255,12 +255,22 @@ public class Controller {
         }, 200, TimeUnit.MILLISECONDS);
     }
 
-    private boolean pressBackOrTurnScreenOn() {
-        int keycode = Device.isScreenOn() ? KeyEvent.KEYCODE_BACK : KeyEvent.KEYCODE_POWER;
-        if (keepPowerModeOff && keycode == KeyEvent.KEYCODE_POWER) {
+    private boolean pressBackOrTurnScreenOn(int action) {
+        if (Device.isScreenOn()) {
+            return device.injectKeyEvent(action, KeyEvent.KEYCODE_BACK, 0, 0);
+        }
+
+        // Screen is off
+        // Only press POWER on ACTION_DOWN
+        if (action != KeyEvent.ACTION_DOWN) {
+            // do nothing,
+            return true;
+        }
+
+        if (keepPowerModeOff) {
             schedulePowerModeOff();
         }
-        return device.injectKeycode(keycode);
+        return device.injectKeycode(KeyEvent.KEYCODE_POWER);
     }
 
     private boolean setClipboard(String text, boolean paste) {

--- a/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
@@ -154,6 +154,7 @@ public class ControlMessageReaderTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(bos);
         dos.writeByte(ControlMessage.TYPE_BACK_OR_SCREEN_ON);
+        dos.writeByte(KeyEvent.ACTION_UP);
 
         byte[] packet = bos.toByteArray();
 
@@ -161,6 +162,7 @@ public class ControlMessageReaderTest {
         ControlMessage event = reader.next();
 
         Assert.assertEquals(ControlMessage.TYPE_BACK_OR_SCREEN_ON, event.getType());
+        Assert.assertEquals(KeyEvent.ACTION_DOWN, event.getAction());
     }
 
     @Test


### PR DESCRIPTION
Some mouse clicks DOWN are captured for shortcuts, but the matching UP
event was still forwarded to the device. Instead, capture both DOWN and UP for shortcuts, and do nothing on UP.

After than, forward middle-click and right-click shortcuts (respectively HOME and BACK-if-screen-is-off) respecting the DOWN and UP events from the mouse. This is consistent with the keyboard shortcuts.

Read individual commits for more details.