### PR TITLE
Add v4l2loopback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ If `--max-size` is also specified, resizing is applied after cropping.
 To lock the orientation of the mirroring:
 
 ```bash
+scrcpy --lock-video-orientation initial   # initial (current) orientation
 scrcpy --lock-video-orientation 0   # natural orientation
 scrcpy --lock-video-orientation 1   # 90° counterclockwise
 scrcpy --lock-video-orientation 2   # 180°

--- a/README.md
+++ b/README.md
@@ -491,18 +491,6 @@ scrcpy -Sw
 ```
 
 
-#### Render expired frames
-
-By default, to minimize latency, _scrcpy_ always renders the last decoded frame
-available, and drops any previous one.
-
-To force the rendering of all frames (at a cost of a possible increased
-latency), use:
-
-```bash
-scrcpy --render-expired-frames
-```
-
 #### Show touches
 
 For presentations, it may be useful to show physical touches (on the physical

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ If `--max-size` is also specified, resizing is applied after cropping.
 To lock the orientation of the mirroring:
 
 ```bash
-scrcpy --lock-video-orientation initial   # initial (current) orientation
+scrcpy --lock-video-orientation     # initial (current) orientation
 scrcpy --lock-video-orientation 0   # natural orientation
 scrcpy --lock-video-orientation 1   # 90° counterclockwise
 scrcpy --lock-video-orientation 2   # 180°

--- a/README.md
+++ b/README.md
@@ -226,7 +226,9 @@ error will give the available encoders:
 scrcpy --encoder _
 ```
 
-### Recording
+### Capture
+
+#### Recording
 
 It is possible to record the screen while mirroring:
 
@@ -248,6 +250,58 @@ performance reasons). Frames are _timestamped_ on the device, so [packet delay
 variation] does not impact the recorded file.
 
 [packet delay variation]: https://en.wikipedia.org/wiki/Packet_delay_variation
+
+
+#### v4l2loopback
+
+On Linux, it is possible to send the video stream to a v4l2 loopback device, so
+that the Android device can be opened like a webcam by any v4l2-capable tool.
+
+The module `v4l2loopback` must be installed:
+
+```bash
+sudo apt install v4l2loopback-dkms
+```
+
+To create a v4l2 device:
+
+```bash
+sudo modprobe v4l2loopback
+```
+
+This will create a new video device in `/dev/videoN`, where `N` is an integer
+(more [options](https://github.com/umlaeute/v4l2loopback#options) are available
+to create several devices or devices with specific IDs).
+
+To list the enabled devices:
+
+```bash
+# requires v4l-utils package
+v4l2-ctl --list-devices
+
+# simple but might be sufficient
+ls /dev/video*
+```
+
+To start scrcpy using a v4l2 sink:
+
+```bash
+scrcpy --v4l2-sink=/dev/videoN
+scrcpy --v4l2-sink=/dev/videoN -N  # --no-display to disable mirroring window
+```
+
+(replace `N` by the device ID, check with `ls /dev/video*`)
+
+Once enabled, you can open your video stream with a v4l2-capable tool:
+
+```bash
+ffplay -i /dev/videoN
+vlc v4l2:///dev/videoN   # VLC might add some buffering delay
+```
+
+For example, you could capture the video within [OBS].
+
+[OBS]: https://obsproject.com/
 
 
 ### Connection

--- a/app/meson.build
+++ b/app/meson.build
@@ -33,6 +33,11 @@ else
     src += [ 'src/sys/unix/process.c' ]
 endif
 
+v4l2_support = host_machine.system() == 'linux'
+if v4l2_support
+    src += [ 'src/v4l2_sink.c' ]
+endif
+
 check_functions = [
     'strdup'
 ]
@@ -48,6 +53,10 @@ if not get_option('crossbuild_windows')
         dependency('libavutil'),
         dependency('sdl2'),
     ]
+
+    if v4l2_support
+        dependencies += dependency('libavdevice')
+    endif
 
 else
 
@@ -123,6 +132,9 @@ conf.set('SERVER_DEBUGGER', get_option('server_debugger'))
 
 # select the debugger method ('old' for Android < 9, 'new' for Android >= 9)
 conf.set('SERVER_DEBUGGER_METHOD_NEW', get_option('server_debugger_method') == 'new')
+
+# enable V4L2 support (linux only)
+conf.set('HAVE_V4L2', v4l2_support)
 
 configure_file(configuration: conf, output: 'config.h')
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -83,10 +83,12 @@ Inject computer clipboard text as a sequence of key events on Ctrl+v (like MOD+S
 This is a workaround for some devices not behaving as expected when setting the device clipboard programmatically.
 
 .TP
-.BI "\-\-lock\-video\-orientation " value
+.BI "\-\-lock\-video\-orientation " [value]
 Lock video orientation to \fIvalue\fR. Possible values are "unlocked", "initial" (locked to the initial orientation), 0, 1, 2 and 3. Natural device orientation is 0, and each increment adds a 90 degrees otation counterclockwise.
 
 Default is "unlocked".
+
+Passing the option without argument is equivalent to passing "initial".
 
 .TP
 .BI "\-\-max\-fps " value

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -156,10 +156,6 @@ Supported names are currently "direct3d", "opengl", "opengles2", "opengles", "me
 .UE
 
 .TP
-.B \-\-render\-expired\-frames
-By default, to minimize latency, scrcpy always renders the last available decoded frame, and drops any previous ones. This flag forces to render all frames, at a cost of a possible increased latency.
-
-.TP
 .BI "\-\-rotation " value
 Set the initial display rotation. Possibles values are 0, 1, 2 and 3. Each increment adds a 90 degrees rotation counterclockwise.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -84,9 +84,9 @@ This is a workaround for some devices not behaving as expected when setting the 
 
 .TP
 .BI "\-\-lock\-video\-orientation " value
-Lock video orientation to \fIvalue\fR. Possible values are -1 (unlocked), 0, 1, 2 and 3. Natural device orientation is 0, and each increment adds a 90 degrees otation counterclockwise.
+Lock video orientation to \fIvalue\fR. Possible values are "unlocked", "initial" (locked to the initial orientation), 0, 1, 2 and 3. Natural device orientation is 0, and each increment adds a 90 degrees otation counterclockwise.
 
-Default is -1 (unlocked).
+Default is "unlocked".
 
 .TP
 .BI "\-\-max\-fps " value

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -186,6 +186,12 @@ Enable "show touches" on start, restore the initial value on exit.
 It only shows physical touches (not clicks from scrcpy).
 
 .TP
+.BI "\-\-v4l2-sink " /dev/videoN
+Output to v4l2loopback device.
+
+It requires to lock the video orientation (see --lock-video-orientation).
+
+.TP
 .BI "\-V, \-\-verbosity " value
 Set the log level ("debug", "info", "warn" or "error").
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -143,12 +143,6 @@ scrcpy_print_usage(const char *arg0) {
         "        \"opengles2\", \"opengles\", \"metal\" and \"software\".\n"
         "        <https://wiki.libsdl.org/SDL_HINT_RENDER_DRIVER>\n"
         "\n"
-        "    --render-expired-frames\n"
-        "        By default, to minimize latency, scrcpy always renders the\n"
-        "        last available decoded frame, and drops any previous ones.\n"
-        "        This flag forces to render all frames, at a cost of a\n"
-        "        possible increased latency.\n"
-        "\n"
         "    --rotation value\n"
         "        Set the initial display rotation.\n"
         "        Possibles values are 0, 1, 2 and 3. Each increment adds a 90\n"
@@ -816,7 +810,8 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
                 opts->stay_awake = true;
                 break;
             case OPT_RENDER_EXPIRED_FRAMES:
-                opts->render_expired_frames = true;
+                LOGW("Option --render-expired-frames has been removed. This "
+                     "flag has been ignored.");
                 break;
             case OPT_WINDOW_TITLE:
                 opts->window_title = optarg;

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -79,13 +79,15 @@ scrcpy_print_usage(const char *arg0) {
         "        This is a workaround for some devices not behaving as\n"
         "        expected when setting the device clipboard programmatically.\n"
         "\n"
-        "    --lock-video-orientation value\n"
+        "    --lock-video-orientation [value]\n"
         "        Lock video orientation to value.\n"
         "        Possible values are \"unlocked\", \"initial\" (locked to the\n"
         "        initial orientation), 0, 1, 2 and 3.\n"
         "        Natural device orientation is 0, and each increment adds a\n"
         "        90 degrees rotation counterclockwise.\n"
         "        Default is \"unlocked\".\n"
+        "        Passing the option without argument is equivalent to passing\n"
+        "        \"initial\".\n"
         "\n"
         "    --max-fps value\n"
         "        Limit the frame rate of screen capture (officially supported\n"
@@ -386,7 +388,7 @@ parse_max_fps(const char *s, uint16_t *max_fps) {
 static bool
 parse_lock_video_orientation(const char *s,
                              enum sc_lock_video_orientation *lock_mode) {
-    if (!strcmp(s, "initial")) {
+    if (!s || !strcmp(s, "initial")) {
         // Without argument, lock the initial orientation
         *lock_mode = SC_LOCK_VIDEO_ORIENTATION_INITIAL;
         return true;
@@ -693,7 +695,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"fullscreen",             no_argument,       NULL, 'f'},
         {"help",                   no_argument,       NULL, 'h'},
         {"legacy-paste",           no_argument,       NULL, OPT_LEGACY_PASTE},
-        {"lock-video-orientation", required_argument, NULL,
+        {"lock-video-orientation", optional_argument, NULL,
                                                   OPT_LOCK_VIDEO_ORIENTATION},
         {"max-fps",                required_argument, NULL, OPT_MAX_FPS},
         {"max-size",               required_argument, NULL, 'm'},

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -176,6 +176,13 @@ scrcpy_print_usage(const char *arg0) {
         "        on exit.\n"
         "        It only shows physical touches (not clicks from scrcpy).\n"
         "\n"
+#ifdef HAVE_V4L2
+        "    --v4l2-sink /dev/videoN\n"
+        "        Output to v4l2loopback device.\n"
+        "        It requires to lock the video orientation (see\n"
+        "        --lock-video-orientation).\n"
+        "\n"
+#endif
         "    -V, --verbosity value\n"
         "        Set the log level (debug, info, warn or error).\n"
 #ifndef NDEBUG
@@ -676,6 +683,7 @@ guess_record_format(const char *filename) {
 #define OPT_LEGACY_PASTE           1024
 #define OPT_ENCODER_NAME           1025
 #define OPT_POWER_OFF_ON_CLOSE     1026
+#define OPT_V4L2_SINK              1027
 
 bool
 scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
@@ -717,6 +725,9 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
         {"show-touches",           no_argument,       NULL, 't'},
         {"stay-awake",             no_argument,       NULL, 'w'},
         {"turn-screen-off",        no_argument,       NULL, 'S'},
+#ifdef HAVE_V4L2
+        {"v4l2-sink",              required_argument, NULL, OPT_V4L2_SINK},
+#endif
         {"verbosity",              required_argument, NULL, 'V'},
         {"version",                no_argument,       NULL, 'v'},
         {"window-title",           required_argument, NULL, OPT_WINDOW_TITLE},
@@ -901,16 +912,36 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]) {
             case OPT_POWER_OFF_ON_CLOSE:
                 opts->power_off_on_close = true;
                 break;
+#ifdef HAVE_V4L2
+            case OPT_V4L2_SINK:
+                opts->v4l2_device = optarg;
+                break;
+#endif
             default:
                 // getopt prints the error message on stderr
                 return false;
         }
     }
 
+#ifdef HAVE_V4L2
+    if (!opts->display && !opts->record_filename && !opts->v4l2_device) {
+        LOGE("-N/--no-display requires either screen recording (-r/--record)"
+             " or sink to v4l2loopback device (--v4l2-sink)");
+        return false;
+    }
+
+    if (opts->v4l2_device && opts->lock_video_orientation
+                             == SC_LOCK_VIDEO_ORIENTATION_UNLOCKED) {
+        LOGI("Video orientation is locked for v4l2 sink. "
+             "See --lock-video-orientation.");
+        opts->lock_video_orientation = SC_LOCK_VIDEO_ORIENTATION_INITIAL;
+    }
+#else
     if (!opts->display && !opts->record_filename) {
         LOGE("-N/--no-display requires screen recording (-r/--record)");
         return false;
     }
+#endif
 
     int index = optind;
     if (index < argc) {

--- a/app/src/common.h
+++ b/app/src/common.h
@@ -8,4 +8,7 @@
 #define MIN(X,Y) (X) < (Y) ? (X) : (Y)
 #define MAX(X,Y) (X) > (Y) ? (X) : (Y)
 
+#define container_of(ptr, type, member) \
+    ((type *) (((char *) (ptr)) - offsetof(type, member)))
+
 #endif

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -8,7 +8,6 @@
 # define _DARWIN_C_SOURCE
 #endif
 
-#include <libavcodec/version.h>
 #include <libavformat/version.h>
 #include <SDL2/SDL_version.h>
 
@@ -31,15 +30,6 @@
 # define SCRCPY_LAVF_HAS_NEW_MUXER_ITERATOR_API
 #else
 # define SCRCPY_LAVF_REQUIRES_REGISTER_ALL
-#endif
-
-// In ffmpeg/doc/APIchanges:
-// 2016-04-21 - 7fc329e - lavc 57.37.100 - avcodec.h
-//   Add a new audio/video encoding and decoding API with decoupled input
-//   and output -- avcodec_send_packet(), avcodec_receive_frame(),
-//   avcodec_send_frame() and avcodec_receive_packet().
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(57, 37, 100)
-# define SCRCPY_LAVF_HAS_NEW_ENCODING_DECODING_API
 #endif
 
 #if SDL_VERSION_ATLEAST(2, 0, 5)

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -12,16 +12,6 @@
 #include <SDL2/SDL_version.h>
 
 // In ffmpeg/doc/APIchanges:
-// 2016-04-11 - 6f69f7a / 9200514 - lavf 57.33.100 / 57.5.0 - avformat.h
-//   Add AVStream.codecpar, deprecate AVStream.codec.
-#if    (LIBAVFORMAT_VERSION_MICRO >= 100 /* FFmpeg */ && \
-        LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 33, 100)) \
-    || (LIBAVFORMAT_VERSION_MICRO < 100 && /* Libav */ \
-        LIBAVFORMAT_VERSION_INT >= AV_VERSION_INT(57, 5, 0))
-# define SCRCPY_LAVF_HAS_NEW_CODEC_PARAMS_API
-#endif
-
-// In ffmpeg/doc/APIchanges:
 // 2018-02-06 - 0694d87024 - lavf 58.9.100 - avformat.h
 //   Deprecate use of av_register_input_format(), av_register_output_format(),
 //   av_register_all(), av_iformat_next(), av_oformat_next().

--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -99,8 +99,8 @@ decoder_push(struct decoder *decoder, const AVPacket *packet) {
         return true;
     }
 
-    int ret;
-    if ((ret = avcodec_send_packet(decoder->codec_ctx, packet)) < 0) {
+    int ret = avcodec_send_packet(decoder->codec_ctx, packet);
+    if (ret < 0 && ret != AVERROR(EAGAIN)) {
         LOGE("Could not send video packet: %d", ret);
         return false;
     }

--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -6,11 +6,6 @@
 #include "video_buffer.h"
 #include "util/log.h"
 
-void
-decoder_init(struct decoder *decoder, struct video_buffer *vb) {
-    decoder->video_buffer = vb;
-}
-
 bool
 decoder_open(struct decoder *decoder, const AVCodec *codec) {
     decoder->codec_ctx = avcodec_alloc_context3(codec);
@@ -62,4 +57,9 @@ decoder_push(struct decoder *decoder, const AVPacket *packet) {
         return false;
     }
     return true;
+}
+
+void
+decoder_init(struct decoder *decoder, struct video_buffer *vb) {
+    decoder->video_buffer = vb;
 }

--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -36,9 +36,6 @@ decoder_close(struct decoder *decoder) {
 
 bool
 decoder_push(struct decoder *decoder, const AVPacket *packet) {
-// the new decoding/encoding API has been introduced by:
-// <http://git.videolan.org/?p=ffmpeg.git;a=commitdiff;h=7fc329e2dd6226dfecaa4a1d7adf353bf2773726>
-#ifdef SCRCPY_LAVF_HAS_NEW_ENCODING_DECODING_API
     int ret;
     if ((ret = avcodec_send_packet(decoder->codec_ctx, packet)) < 0) {
         LOGE("Could not send video packet: %d", ret);
@@ -53,19 +50,5 @@ decoder_push(struct decoder *decoder, const AVPacket *packet) {
         LOGE("Could not receive video frame: %d", ret);
         return false;
     }
-#else
-    int got_picture;
-    int len = avcodec_decode_video2(decoder->codec_ctx,
-                                    decoder->video_buffer->producer_frame,
-                                    &got_picture,
-                                    packet);
-    if (len < 0) {
-        LOGE("Could not decode video packet: %d", len);
-        return false;
-    }
-    if (got_picture) {
-        video_buffer_producer_offer_frame(decoder->video_buffer);
-    }
-#endif
     return true;
 }

--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -41,8 +41,14 @@ decoder_close(struct decoder *decoder) {
     avcodec_free_context(&decoder->codec_ctx);
 }
 
-bool
+static bool
 decoder_push(struct decoder *decoder, const AVPacket *packet) {
+    bool is_config = packet->pts == AV_NOPTS_VALUE;
+    if (is_config) {
+        // nothing to do
+        return true;
+    }
+
     int ret;
     if ((ret = avcodec_send_packet(decoder->codec_ctx, packet)) < 0) {
         LOGE("Could not send video packet: %d", ret);

--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -69,8 +69,3 @@ decoder_push(struct decoder *decoder, const AVPacket *packet) {
 #endif
     return true;
 }
-
-void
-decoder_interrupt(struct decoder *decoder) {
-    video_buffer_interrupt(decoder->video_buffer);
-}

--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -6,6 +6,9 @@
 #include "video_buffer.h"
 #include "util/log.h"
 
+/** Downcast packet_sink to decoder */
+#define DOWNCAST(SINK) container_of(SINK, struct decoder, packet_sink)
+
 bool
 decoder_open(struct decoder *decoder, const AVCodec *codec) {
     decoder->codec_ctx = avcodec_alloc_context3(codec);
@@ -59,7 +62,33 @@ decoder_push(struct decoder *decoder, const AVPacket *packet) {
     return true;
 }
 
+static bool
+decoder_packet_sink_open(struct sc_packet_sink *sink, const AVCodec *codec) {
+    struct decoder *decoder = DOWNCAST(sink);
+    return decoder_open(decoder, codec);
+}
+
+static void
+decoder_packet_sink_close(struct sc_packet_sink *sink) {
+    struct decoder *decoder = DOWNCAST(sink);
+    decoder_close(decoder);
+}
+
+static bool
+decoder_packet_sink_push(struct sc_packet_sink *sink, const AVPacket *packet) {
+    struct decoder *decoder = DOWNCAST(sink);
+    return decoder_push(decoder, packet);
+}
+
 void
 decoder_init(struct decoder *decoder, struct video_buffer *vb) {
     decoder->video_buffer = vb;
+
+    static const struct sc_packet_sink_ops ops = {
+        .open = decoder_packet_sink_open,
+        .close = decoder_packet_sink_close,
+        .push = decoder_packet_sink_push,
+    };
+
+    decoder->packet_sink.ops = &ops;
 }

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -8,7 +8,7 @@
 #include <stdbool.h>
 #include <libavformat/avformat.h>
 
-#define DECODER_MAX_SINKS 1
+#define DECODER_MAX_SINKS 2
 
 struct decoder {
     struct sc_packet_sink packet_sink; // packet sink trait

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -3,12 +3,16 @@
 
 #include "common.h"
 
+#include "trait/packet_sink.h"
+
 #include <stdbool.h>
 #include <libavformat/avformat.h>
 
 struct video_buffer;
 
 struct decoder {
+    struct sc_packet_sink packet_sink; // packet sink trait
+
     struct video_buffer *video_buffer;
 
     AVCodecContext *codec_ctx;

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -26,7 +26,4 @@ decoder_close(struct decoder *decoder);
 bool
 decoder_push(struct decoder *decoder, const AVPacket *packet);
 
-void
-decoder_interrupt(struct decoder *decoder);
-
 #endif

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -28,7 +28,4 @@ decoder_open(struct decoder *decoder, const AVCodec *codec);
 void
 decoder_close(struct decoder *decoder);
 
-bool
-decoder_push(struct decoder *decoder, const AVPacket *packet);
-
 #endif

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -12,6 +12,7 @@ struct decoder {
     struct video_buffer *video_buffer;
 
     AVCodecContext *codec_ctx;
+    AVFrame *frame;
 };
 
 void

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -8,24 +8,22 @@
 #include <stdbool.h>
 #include <libavformat/avformat.h>
 
-struct video_buffer;
+#define DECODER_MAX_SINKS 1
 
 struct decoder {
     struct sc_packet_sink packet_sink; // packet sink trait
 
-    struct video_buffer *video_buffer;
+    struct sc_frame_sink *sinks[DECODER_MAX_SINKS];
+    unsigned sink_count;
 
     AVCodecContext *codec_ctx;
     AVFrame *frame;
 };
 
 void
-decoder_init(struct decoder *decoder, struct video_buffer *vb);
-
-bool
-decoder_open(struct decoder *decoder, const AVCodec *codec);
+decoder_init(struct decoder *decoder);
 
 void
-decoder_close(struct decoder *decoder);
+decoder_add_sink(struct decoder *decoder, struct sc_frame_sink *sink);
 
 #endif

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -6,6 +6,9 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <libavformat/avformat.h>
+#ifdef HAVE_V4L2
+# include <libavdevice/avdevice.h>
+#endif
 #define SDL_MAIN_HANDLED // avoid link error on Linux Windows Subsystem
 #include <SDL2/SDL.h>
 
@@ -28,6 +31,11 @@ print_version(void) {
     fprintf(stderr, " - libavutil %d.%d.%d\n", LIBAVUTIL_VERSION_MAJOR,
                                                LIBAVUTIL_VERSION_MINOR,
                                                LIBAVUTIL_VERSION_MICRO);
+#ifdef HAVE_V4L2
+    fprintf(stderr, " - libavdevice %d.%d.%d\n", LIBAVDEVICE_VERSION_MAJOR,
+                                                 LIBAVDEVICE_VERSION_MINOR,
+                                                 LIBAVDEVICE_VERSION_MICRO);
+#endif
 }
 
 static SDL_LogPriority
@@ -88,6 +96,12 @@ main(int argc, char *argv[]) {
 
 #ifdef SCRCPY_LAVF_REQUIRES_REGISTER_ALL
     av_register_all();
+#endif
+
+#ifdef HAVE_V4L2
+    if (args.opts.v4l2_device) {
+        avdevice_register_all();
+    }
 #endif
 
     if (avformat_network_init()) {

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -141,19 +141,11 @@ recorder_open(struct recorder *recorder, const AVCodec *input_codec) {
         return false;
     }
 
-#ifdef SCRCPY_LAVF_HAS_NEW_CODEC_PARAMS_API
     ostream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
     ostream->codecpar->codec_id = input_codec->id;
     ostream->codecpar->format = AV_PIX_FMT_YUV420P;
     ostream->codecpar->width = recorder->declared_frame_size.width;
     ostream->codecpar->height = recorder->declared_frame_size.height;
-#else
-    ostream->codec->codec_type = AVMEDIA_TYPE_VIDEO;
-    ostream->codec->codec_id = input_codec->id;
-    ostream->codec->pix_fmt = AV_PIX_FMT_YUV420P;
-    ostream->codec->width = recorder->declared_frame_size.width;
-    ostream->codec->height = recorder->declared_frame_size.height;
-#endif
 
     int ret = avio_open(&recorder->ctx->pb, recorder->filename,
                         AVIO_FLAG_WRITE);
@@ -188,13 +180,8 @@ recorder_write_header(struct recorder *recorder, const AVPacket *packet) {
     // copy the first packet to the extra data
     memcpy(extradata, packet->data, packet->size);
 
-#ifdef SCRCPY_LAVF_HAS_NEW_CODEC_PARAMS_API
     ostream->codecpar->extradata = extradata;
     ostream->codecpar->extradata_size = packet->size;
-#else
-    ostream->codec->extradata = extradata;
-    ostream->codec->extradata_size = packet->size;
-#endif
 
     int ret = avformat_write_header(recorder->ctx, NULL);
     if (ret < 0) {

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -216,7 +216,7 @@ run_recorder(void *data) {
     return 0;
 }
 
-bool
+static bool
 recorder_open(struct recorder *recorder, const AVCodec *input_codec) {
     const char *format_name = recorder_get_format_name(recorder->format);
     assert(format_name);
@@ -277,7 +277,7 @@ recorder_open(struct recorder *recorder, const AVCodec *input_codec) {
     return true;
 }
 
-void
+static void
 recorder_close(struct recorder *recorder) {
     sc_mutex_lock(&recorder->mutex);
     recorder->stopped = true;
@@ -290,7 +290,7 @@ recorder_close(struct recorder *recorder) {
     avformat_free_context(recorder->ctx);
 }
 
-bool
+static bool
 recorder_push(struct recorder *recorder, const AVPacket *packet) {
     sc_mutex_lock(&recorder->mutex);
     assert(!recorder->stopped);

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -4,6 +4,7 @@
 #include <libavutil/time.h>
 
 #include "util/log.h"
+#include "util/str_util.h"
 
 /** Downcast packet_sink to recorder */
 #define DOWNCAST(SINK) container_of(SINK, struct recorder, packet_sink)
@@ -22,8 +23,8 @@ find_muxer(const char *name) {
 #else
         oformat = av_oformat_next(oformat);
 #endif
-        // until null or with having the requested name
-    } while (oformat && strcmp(oformat->name, name));
+        // until null or containing the requested name
+    } while (oformat && !strlist_contains(oformat->name, ',', name));
     return oformat;
 }
 

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -22,7 +22,7 @@ find_muxer(const char *name) {
 #else
         oformat = av_oformat_next(oformat);
 #endif
-        // until null or with name "mp4"
+        // until null or with having the requested name
     } while (oformat && strcmp(oformat->name, name));
     return oformat;
 }

--- a/app/src/recorder.h
+++ b/app/src/recorder.h
@@ -8,6 +8,7 @@
 
 #include "coords.h"
 #include "scrcpy.h"
+#include "trait/packet_sink.h"
 #include "util/queue.h"
 #include "util/thread.h"
 
@@ -19,6 +20,8 @@ struct record_packet {
 struct recorder_queue QUEUE(struct record_packet);
 
 struct recorder {
+    struct sc_packet_sink packet_sink; // packet sink trait
+
     char *filename;
     enum sc_record_format format;
     AVFormatContext *ctx;

--- a/app/src/recorder.h
+++ b/app/src/recorder.h
@@ -49,13 +49,4 @@ recorder_init(struct recorder *recorder, const char *filename,
 void
 recorder_destroy(struct recorder *recorder);
 
-bool
-recorder_open(struct recorder *recorder, const AVCodec *input_codec);
-
-void
-recorder_close(struct recorder *recorder);
-
-bool
-recorder_push(struct recorder *recorder, const AVPacket *packet);
-
 #endif

--- a/app/src/recorder.h
+++ b/app/src/recorder.h
@@ -28,7 +28,7 @@ struct recorder {
     sc_thread thread;
     sc_mutex mutex;
     sc_cond queue_cond;
-    bool stopped; // set on recorder_stop() by the stream reader
+    bool stopped; // set on recorder_close()
     bool failed; // set on packet write failure
     struct recorder_queue queue;
 
@@ -51,15 +51,6 @@ recorder_open(struct recorder *recorder, const AVCodec *input_codec);
 
 void
 recorder_close(struct recorder *recorder);
-
-bool
-recorder_start(struct recorder *recorder);
-
-void
-recorder_stop(struct recorder *recorder);
-
-void
-recorder_join(struct recorder *recorder);
 
 bool
 recorder_push(struct recorder *recorder, const AVPacket *packet);

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -398,6 +398,10 @@ scrcpy(const struct scrcpy_options *options) {
     ret = event_loop(options);
     LOGD("quit...");
 
+    // Close the window immediately on closing, because screen_destroy() may
+    // only be called once the stream thread is joined (it may take time)
+    screen_hide_window(&screen);
+
 end:
     // The stream is not stopped explicitly, because it will stop by itself on
     // end-of-stream

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -25,14 +25,12 @@
 #include "server.h"
 #include "stream.h"
 #include "tiny_xpm.h"
-#include "video_buffer.h"
 #include "util/log.h"
 #include "util/net.h"
 
 static struct server server;
 static struct screen screen;
 static struct fps_counter fps_counter;
-static struct video_buffer video_buffer;
 static struct stream stream;
 static struct decoder decoder;
 static struct recorder recorder;
@@ -247,7 +245,6 @@ scrcpy(const struct scrcpy_options *options) {
 
     bool server_started = false;
     bool fps_counter_initialized = false;
-    bool video_buffer_initialized = false;
     bool file_handler_initialized = false;
     bool recorder_initialized = false;
     bool stream_started = false;
@@ -304,11 +301,6 @@ scrcpy(const struct scrcpy_options *options) {
             goto end;
         }
         fps_counter_initialized = true;
-
-        if (!video_buffer_init(&video_buffer)) {
-            goto end;
-        }
-        video_buffer_initialized = true;
 
         if (options->control) {
             if (!file_handler_init(&file_handler, server.serial,
@@ -376,8 +368,7 @@ scrcpy(const struct scrcpy_options *options) {
             .fullscreen = options->fullscreen,
         };
 
-        if (!screen_init(&screen, &video_buffer, &fps_counter,
-                         &screen_params)) {
+        if (!screen_init(&screen, &fps_counter, &screen_params)) {
             goto end;
         }
         screen_initialized = true;
@@ -451,10 +442,6 @@ end:
     if (file_handler_initialized) {
         file_handler_join(&file_handler);
         file_handler_destroy(&file_handler);
-    }
-
-    if (video_buffer_initialized) {
-        video_buffer_destroy(&video_buffer);
     }
 
     if (fps_counter_initialized) {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -336,7 +336,15 @@ scrcpy(const struct scrcpy_options *options) {
 
     av_log_set_callback(av_log_callback);
 
-    stream_init(&stream, server.video_socket, dec, rec);
+    stream_init(&stream, server.video_socket);
+
+    if (dec) {
+        stream_add_sink(&stream, &dec->packet_sink);
+    }
+
+    if (rec) {
+        stream_add_sink(&stream, &rec->packet_sink);
+    }
 
     if (options->display) {
         if (options->control) {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -305,7 +305,7 @@ scrcpy(const struct scrcpy_options *options) {
         }
         fps_counter_initialized = true;
 
-        if (!video_buffer_init(&video_buffer, options->render_expired_frames)) {
+        if (!video_buffer_init(&video_buffer)) {
             goto end;
         }
         video_buffer_initialized = true;
@@ -398,11 +398,8 @@ scrcpy(const struct scrcpy_options *options) {
     LOGD("quit...");
 
 end:
-    // stop stream and controller so that they don't continue once their socket
-    // is shutdown
-    if (stream_started) {
-        stream_stop(&stream);
-    }
+    // The stream is not stopped explicitly, because it will stop by itself on
+    // end-of-stream
     if (controller_started) {
         controller_stop(&controller);
     }

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -318,7 +318,7 @@ scrcpy(const struct scrcpy_options *options) {
             file_handler_initialized = true;
         }
 
-        decoder_init(&decoder, &video_buffer);
+        decoder_init(&decoder);
         dec = &decoder;
     }
 
@@ -381,6 +381,8 @@ scrcpy(const struct scrcpy_options *options) {
             goto end;
         }
         screen_initialized = true;
+
+        decoder_add_sink(&decoder, &screen.frame_sink);
 
         if (options->turn_screen_off) {
             struct control_msg msg;

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -72,7 +72,6 @@ struct scrcpy_options {
     bool control;
     bool display;
     bool turn_screen_off;
-    bool render_expired_frames;
     bool prefer_text;
     bool window_borderless;
     bool mipmaps;
@@ -120,7 +119,6 @@ struct scrcpy_options {
     .control = true, \
     .display = true, \
     .turn_screen_off = false, \
-    .render_expired_frames = false, \
     .prefer_text = false, \
     .window_borderless = false, \
     .mipmaps = true, \

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -62,6 +62,7 @@ struct scrcpy_options {
     const char *render_driver;
     const char *codec_options;
     const char *encoder_name;
+    const char *v4l2_device;
     enum sc_log_level log_level;
     enum sc_record_format record_format;
     struct sc_port_range port_range;
@@ -103,6 +104,7 @@ struct scrcpy_options {
     .render_driver = NULL, \
     .codec_options = NULL, \
     .encoder_name = NULL, \
+    .v4l2_device = NULL, \
     .log_level = SC_LOG_LEVEL_INFO, \
     .record_format = SC_RECORD_FORMAT_AUTO, \
     .port_range = { \

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -20,6 +20,16 @@ enum sc_record_format {
     SC_RECORD_FORMAT_MKV,
 };
 
+enum sc_lock_video_orientation {
+    SC_LOCK_VIDEO_ORIENTATION_UNLOCKED = -1,
+    // lock the current orientation when scrcpy starts
+    SC_LOCK_VIDEO_ORIENTATION_INITIAL = -2,
+    SC_LOCK_VIDEO_ORIENTATION_0 = 0,
+    SC_LOCK_VIDEO_ORIENTATION_1,
+    SC_LOCK_VIDEO_ORIENTATION_2,
+    SC_LOCK_VIDEO_ORIENTATION_3,
+};
+
 #define SC_MAX_SHORTCUT_MODS 8
 
 enum sc_shortcut_mod {
@@ -59,7 +69,7 @@ struct scrcpy_options {
     uint16_t max_size;
     uint32_t bit_rate;
     uint16_t max_fps;
-    int8_t lock_video_orientation;
+    enum sc_lock_video_orientation lock_video_orientation;
     uint8_t rotation;
     int16_t window_x; // SC_WINDOW_POSITION_UNDEFINED for "auto"
     int16_t window_y; // SC_WINDOW_POSITION_UNDEFINED for "auto"
@@ -106,7 +116,7 @@ struct scrcpy_options {
     .max_size = 0, \
     .bit_rate = DEFAULT_BIT_RATE, \
     .max_fps = 0, \
-    .lock_video_orientation = -1, \
+    .lock_video_orientation = SC_LOCK_VIDEO_ORIENTATION_UNLOCKED, \
     .rotation = 0, \
     .window_x = SC_WINDOW_POSITION_UNDEFINED, \
     .window_y = SC_WINDOW_POSITION_UNDEFINED, \

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -247,6 +247,9 @@ static bool
 screen_frame_sink_open(struct sc_frame_sink *sink) {
     struct screen *screen = DOWNCAST(sink);
     (void) screen;
+#ifndef NDEBUG
+    screen->open = true;
+#endif
 
     // nothing to do, the screen is already open on the main thread
     return true;
@@ -256,6 +259,9 @@ static void
 screen_frame_sink_close(struct sc_frame_sink *sink) {
     struct screen *screen = DOWNCAST(sink);
     (void) screen;
+#ifndef NDEBUG
+    screen->open = false;
+#endif
 
     // nothing to do, the screen lifecycle is not managed by the frame producer
 }
@@ -435,6 +441,10 @@ screen_init(struct screen *screen, struct fps_counter *fps_counter,
 
     screen->frame_sink.ops = &ops;
 
+#ifndef NDEBUG
+    screen->open = false;
+#endif
+
     return true;
 }
 
@@ -445,6 +455,9 @@ screen_show_window(struct screen *screen) {
 
 void
 screen_destroy(struct screen *screen) {
+#ifndef NDEBUG
+    assert(!screen->open);
+#endif
     av_frame_free(&screen->frame);
     SDL_DestroyTexture(screen->texture);
     SDL_DestroyRenderer(screen->renderer);

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -284,14 +284,12 @@ screen_frame_sink_close(struct sc_frame_sink *sink) {
 static bool
 screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
     struct screen *screen = DOWNCAST(sink);
-    return video_buffer_push(screen->vb, frame);
+    return video_buffer_push(&screen->vb, frame);
 }
 
 bool
-screen_init(struct screen *screen, struct video_buffer *vb,
-            struct fps_counter *fps_counter,
+screen_init(struct screen *screen, struct fps_counter *fps_counter,
             const struct screen_params *params) {
-    screen->vb = vb;
     screen->fps_counter = fps_counter;
 
     screen->resize_pending = false;
@@ -299,11 +297,17 @@ screen_init(struct screen *screen, struct video_buffer *vb,
     screen->fullscreen = false;
     screen->maximized = false;
 
+    bool ok = video_buffer_init(&screen->vb);
+    if (!ok) {
+        LOGE("Could not initialize video buffer");
+        return false;
+    }
+
     static const struct video_buffer_callbacks cbs = {
         .on_frame_available = on_frame_available,
         .on_frame_skipped = on_frame_skipped,
     };
-    video_buffer_set_consumer_callbacks(vb, &cbs, screen);
+    video_buffer_set_consumer_callbacks(&screen->vb, &cbs, screen);
 
     screen->frame_size = params->frame_size;
     screen->rotation = params->rotation;
@@ -349,6 +353,7 @@ screen_init(struct screen *screen, struct video_buffer *vb,
     if (!screen->renderer) {
         LOGC("Could not create renderer: %s", SDL_GetError());
         SDL_DestroyWindow(screen->window);
+        video_buffer_destroy(&screen->vb);
         return false;
     }
 
@@ -400,6 +405,7 @@ screen_init(struct screen *screen, struct video_buffer *vb,
         LOGC("Could not create texture: %s", SDL_GetError());
         SDL_DestroyRenderer(screen->renderer);
         SDL_DestroyWindow(screen->window);
+        video_buffer_destroy(&screen->vb);
         return false;
     }
 
@@ -409,6 +415,7 @@ screen_init(struct screen *screen, struct video_buffer *vb,
         SDL_DestroyTexture(screen->texture);
         SDL_DestroyRenderer(screen->renderer);
         SDL_DestroyWindow(screen->window);
+        video_buffer_destroy(&screen->vb);
         return false;
     }
 
@@ -449,6 +456,7 @@ screen_destroy(struct screen *screen) {
     SDL_DestroyTexture(screen->texture);
     SDL_DestroyRenderer(screen->renderer);
     SDL_DestroyWindow(screen->window);
+    video_buffer_destroy(&screen->vb);
 }
 
 static void
@@ -554,7 +562,7 @@ update_texture(struct screen *screen, const AVFrame *frame) {
 static bool
 screen_update_frame(struct screen *screen) {
     av_frame_unref(screen->frame);
-    video_buffer_consume(screen->vb, screen->frame);
+    video_buffer_consume(&screen->vb, screen->frame);
     AVFrame *frame = screen->frame;
 
     fps_counter_add_rendered_frame(screen->fps_counter);

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -454,6 +454,11 @@ screen_show_window(struct screen *screen) {
 }
 
 void
+screen_hide_window(struct screen *screen) {
+    SDL_HideWindow(screen->window);
+}
+
+void
 screen_destroy(struct screen *screen) {
 #ifndef NDEBUG
     assert(!screen->open);

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -36,6 +36,8 @@ struct screen {
     bool fullscreen;
     bool maximized;
     bool mipmaps;
+
+    AVFrame *frame;
 };
 
 struct screen_params {

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -15,6 +15,10 @@
 struct screen {
     struct sc_frame_sink frame_sink; // frame sink trait
 
+#ifndef NDEBUG
+    bool open; // track the open/close state to assert correct behavior
+#endif
+
     struct video_buffer vb;
     struct fps_counter *fps_counter;
 

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -10,13 +10,12 @@
 #include "coords.h"
 #include "opengl.h"
 #include "trait/frame_sink.h"
-
-struct video_buffer;
+#include "video_buffer.h"
 
 struct screen {
     struct sc_frame_sink frame_sink; // frame sink trait
 
-    struct video_buffer *vb;
+    struct video_buffer vb;
     struct fps_counter *fps_counter;
 
     SDL_Window *window;
@@ -63,8 +62,7 @@ struct screen_params {
 
 // initialize screen, create window, renderer and texture (window is hidden)
 bool
-screen_init(struct screen *screen, struct video_buffer *vb,
-            struct fps_counter *fps_counter,
+screen_init(struct screen *screen, struct fps_counter *fps_counter,
             const struct screen_params *params);
 
 // destroy window, renderer and texture (if any)

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -73,6 +73,13 @@ screen_init(struct screen *screen, struct fps_counter *fps_counter,
 void
 screen_destroy(struct screen *screen);
 
+// hide the window
+//
+// It is used to hide the window immediately on closing without waiting for
+// screen_destroy()
+void
+screen_hide_window(struct screen *screen);
+
 // render the texture to the renderer
 //
 // Set the update_content_rect flag if the window or content size may have

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -9,10 +9,13 @@
 
 #include "coords.h"
 #include "opengl.h"
+#include "trait/frame_sink.h"
 
 struct video_buffer;
 
 struct screen {
+    struct sc_frame_sink frame_sink; // frame sink trait
+
     struct video_buffer *vb;
     struct fps_counter *fps_counter;
 

--- a/app/src/stream.c
+++ b/app/src/stream.c
@@ -203,17 +203,12 @@ run_stream(void *data) {
             LOGE("Could not open recorder");
             goto finally_close_decoder;
         }
-
-        if (!recorder_start(stream->recorder)) {
-            LOGE("Could not start recorder");
-            goto finally_close_recorder;
-        }
     }
 
     stream->parser = av_parser_init(AV_CODEC_ID_H264);
     if (!stream->parser) {
         LOGE("Could not initialize parser");
-        goto finally_stop_and_join_recorder;
+        goto finally_close_recorder;
     }
 
     // We must only pass complete frames to av_parser_parse2()!
@@ -243,12 +238,6 @@ run_stream(void *data) {
     }
 
     av_parser_close(stream->parser);
-finally_stop_and_join_recorder:
-    if (stream->recorder) {
-        recorder_stop(stream->recorder);
-        LOGI("Finishing recording...");
-        recorder_join(stream->recorder);
-    }
 finally_close_recorder:
     if (stream->recorder) {
         recorder_close(stream->recorder);

--- a/app/src/stream.c
+++ b/app/src/stream.c
@@ -286,13 +286,6 @@ stream_start(struct stream *stream) {
 }
 
 void
-stream_stop(struct stream *stream) {
-    if (stream->decoder) {
-        decoder_interrupt(stream->decoder);
-    }
-}
-
-void
 stream_join(struct stream *stream) {
     sc_thread_join(&stream->thread, NULL);
 }

--- a/app/src/stream.h
+++ b/app/src/stream.h
@@ -8,14 +8,19 @@
 #include <libavformat/avformat.h>
 #include <SDL2/SDL_atomic.h>
 
+#include "trait/packet_sink.h"
 #include "util/net.h"
 #include "util/thread.h"
+
+#define STREAM_MAX_SINKS 2
 
 struct stream {
     socket_t socket;
     sc_thread thread;
-    struct decoder *decoder;
-    struct recorder *recorder;
+
+    struct sc_packet_sink *sinks[STREAM_MAX_SINKS];
+    unsigned sink_count;
+
     AVCodecContext *codec_ctx;
     AVCodecParserContext *parser;
     // successive packets may need to be concatenated, until a non-config
@@ -25,8 +30,10 @@ struct stream {
 };
 
 void
-stream_init(struct stream *stream, socket_t socket,
-            struct decoder *decoder, struct recorder *recorder);
+stream_init(struct stream *stream, socket_t socket);
+
+void
+stream_add_sink(struct stream *stream, struct sc_packet_sink *sink);
 
 bool
 stream_start(struct stream *stream);

--- a/app/src/stream.h
+++ b/app/src/stream.h
@@ -32,9 +32,6 @@ bool
 stream_start(struct stream *stream);
 
 void
-stream_stop(struct stream *stream);
-
-void
 stream_join(struct stream *stream);
 
 #endif

--- a/app/src/trait/frame_sink.h
+++ b/app/src/trait/frame_sink.h
@@ -1,0 +1,26 @@
+#ifndef SC_FRAME_SINK
+#define SC_FRAME_SINK
+
+#include "common.h"
+
+#include <assert.h>
+#include <stdbool.h>
+
+typedef struct AVFrame AVFrame;
+
+/**
+ * Frame sink trait.
+ *
+ * Component able to receive AVFrames should implement this trait.
+ */
+struct sc_frame_sink {
+    const struct sc_frame_sink_ops *ops;
+};
+
+struct sc_frame_sink_ops {
+    bool (*open)(struct sc_frame_sink *sink);
+    void (*close)(struct sc_frame_sink *sink);
+    bool (*push)(struct sc_frame_sink *sink, const AVFrame *frame);
+};
+
+#endif

--- a/app/src/trait/packet_sink.h
+++ b/app/src/trait/packet_sink.h
@@ -1,0 +1,27 @@
+#ifndef SC_PACKET_SINK
+#define SC_PACKET_SINK
+
+#include "common.h"
+
+#include <assert.h>
+#include <stdbool.h>
+
+typedef struct AVCodec AVCodec;
+typedef struct AVPacket AVPacket;
+
+/**
+ * Packet sink trait.
+ *
+ * Component able to receive AVPackets should implement this trait.
+ */
+struct sc_packet_sink {
+    const struct sc_packet_sink_ops *ops;
+};
+
+struct sc_packet_sink_ops {
+    bool (*open)(struct sc_packet_sink *sink, const AVCodec *codec);
+    void (*close)(struct sc_packet_sink *sink);
+    bool (*push)(struct sc_packet_sink *sink, const AVPacket *packet);
+};
+
+#endif

--- a/app/src/util/str_util.c
+++ b/app/src/util/str_util.c
@@ -140,6 +140,24 @@ parse_integer_with_suffix(const char *s, long *out) {
     return true;
 }
 
+bool
+strlist_contains(const char *list, char sep, const char *s) {
+    char *p;
+    do {
+        p = strchr(list, sep);
+
+        size_t token_len = p ? (size_t) (p - list) : strlen(list);
+        if (!strncmp(list, s, token_len)) {
+            return true;
+        }
+
+        if (p) {
+            list = p + 1;
+        }
+    } while (p);
+    return false;
+}
+
 size_t
 utf8_truncation_index(const char *utf8, size_t max_len) {
     size_t len = strlen(utf8);

--- a/app/src/util/str_util.h
+++ b/app/src/util/str_util.h
@@ -43,6 +43,11 @@ parse_integers(const char *s, const char sep, size_t max_items, long *out);
 bool
 parse_integer_with_suffix(const char *s, long *out);
 
+// search s in the list separated by sep
+// for example, strlist_contains("a,bc,def", ',', "bc") returns true
+bool
+strlist_contains(const char *list, char sep, const char *s);
+
 // return the index to truncate a UTF-8 string at a valid position
 size_t
 utf8_truncation_index(const char *utf8, size_t max_len);

--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -1,0 +1,341 @@
+#include "v4l2_sink.h"
+
+#include "util/log.h"
+#include "util/str_util.h"
+
+/** Downcast frame_sink to sc_v4l2_sink */
+#define DOWNCAST(SINK) container_of(SINK, struct sc_v4l2_sink, frame_sink)
+
+static const AVRational SCRCPY_TIME_BASE = {1, 1000000}; // timestamps in us
+
+static const AVOutputFormat *
+find_muxer(const char *name) {
+#ifdef SCRCPY_LAVF_HAS_NEW_MUXER_ITERATOR_API
+    void *opaque = NULL;
+#endif
+    const AVOutputFormat *oformat = NULL;
+    do {
+#ifdef SCRCPY_LAVF_HAS_NEW_MUXER_ITERATOR_API
+        oformat = av_muxer_iterate(&opaque);
+#else
+        oformat = av_oformat_next(oformat);
+#endif
+        // until null or containing the requested name
+    } while (oformat && !strlist_contains(oformat->name, ',', name));
+    return oformat;
+}
+
+static bool
+write_header(struct sc_v4l2_sink *vs, const AVPacket *packet) {
+    AVStream *ostream = vs->format_ctx->streams[0];
+
+    uint8_t *extradata = av_malloc(packet->size * sizeof(uint8_t));
+    if (!extradata) {
+        LOGC("Could not allocate extradata");
+        return false;
+    }
+
+    // copy the first packet to the extra data
+    memcpy(extradata, packet->data, packet->size);
+
+    ostream->codecpar->extradata = extradata;
+    ostream->codecpar->extradata_size = packet->size;
+
+    int ret = avformat_write_header(vs->format_ctx, NULL);
+    if (ret < 0) {
+        LOGE("Failed to write header to %s", vs->device_name);
+        return false;
+    }
+
+    return true;
+}
+
+static void
+rescale_packet(struct sc_v4l2_sink *vs, AVPacket *packet) {
+    AVStream *ostream = vs->format_ctx->streams[0];
+    av_packet_rescale_ts(packet, SCRCPY_TIME_BASE, ostream->time_base);
+}
+
+static bool
+write_packet(struct sc_v4l2_sink *vs, AVPacket *packet) {
+    if (!vs->header_written) {
+        bool ok = write_header(vs, packet);
+        if (!ok) {
+            return false;
+        }
+        vs->header_written = true;
+        return true;
+    }
+
+    rescale_packet(vs, packet);
+
+    bool ok = av_write_frame(vs->format_ctx, packet) >= 0;
+
+    // Failing to write the last frame is not very serious, no future frame may
+    // depend on it, so the resulting file will still be valid
+    (void) ok;
+
+    return true;
+}
+
+static bool
+encode_and_write_frame(struct sc_v4l2_sink *vs, const AVFrame *frame) {
+    int ret = avcodec_send_frame(vs->encoder_ctx, frame);
+    if (ret < 0 && ret != AVERROR(EAGAIN)) {
+        LOGE("Could not send v4l2 video frame: %d", ret);
+        return false;
+    }
+
+    AVPacket *packet = &vs->packet;
+    ret = avcodec_receive_packet(vs->encoder_ctx, packet);
+    if (ret == 0) {
+        // A packet was received
+
+        bool ok = write_packet(vs, packet);
+        if (!ok) {
+            LOGW("Could not send packet to v4l2 sink");
+            return false;
+        }
+        av_packet_unref(packet);
+    } else if (ret != AVERROR(EAGAIN)) {
+        LOGE("Could not receive v4l2 video packet: %d", ret);
+        return false;
+    }
+
+    return true;
+}
+
+static int
+run_v4l2_sink(void *data) {
+    struct sc_v4l2_sink *vs = data;
+
+    for (;;) {
+        sc_mutex_lock(&vs->mutex);
+
+        while (!vs->stopped && vs->vb.pending_frame_consumed) {
+            sc_cond_wait(&vs->cond, &vs->mutex);
+        }
+
+        if (vs->stopped) {
+            sc_mutex_unlock(&vs->mutex);
+            break;
+        }
+
+        sc_mutex_unlock(&vs->mutex);
+
+        video_buffer_consume(&vs->vb, vs->frame);
+        bool ok = encode_and_write_frame(vs, vs->frame);
+        if (!ok) {
+            LOGE("Could not send frame to v4l2 sink");
+            break;
+        }
+    }
+
+    LOGD("V4l2 thread ended");
+
+    return 0;
+}
+
+static bool
+sc_v4l2_sink_open(struct sc_v4l2_sink *vs) {
+    bool ok = video_buffer_init(&vs->vb);
+    if (!ok) {
+        return false;
+    }
+
+    ok = sc_mutex_init(&vs->mutex);
+    if (!ok) {
+        LOGC("Could not create mutex");
+        goto error_video_buffer_destroy;
+    }
+
+    ok = sc_cond_init(&vs->cond);
+    if (!ok) {
+        LOGC("Could not create cond");
+        goto error_mutex_destroy;
+    }
+
+    // FIXME
+    const AVOutputFormat *format = find_muxer("video4linux2,v4l2");
+    if (!format) {
+        LOGE("Could not find v4l2 muxer");
+        goto error_cond_destroy;
+    }
+
+    const AVCodec *encoder = avcodec_find_encoder(AV_CODEC_ID_RAWVIDEO);
+    if (!encoder) {
+        LOGE("Raw video encoder not found");
+        return false;
+    }
+
+    vs->format_ctx = avformat_alloc_context();
+    if (!vs->format_ctx) {
+        LOGE("Could not allocate v4l2 output context");
+        return false;
+    }
+
+    // contrary to the deprecated API (av_oformat_next()), av_muxer_iterate()
+    // returns (on purpose) a pointer-to-const, but AVFormatContext.oformat
+    // still expects a pointer-to-non-const (it has not be updated accordingly)
+    // <https://github.com/FFmpeg/FFmpeg/commit/0694d8702421e7aff1340038559c438b61bb30dd>
+    vs->format_ctx->oformat = (AVOutputFormat *) format;
+    vs->format_ctx->url = strdup(vs->device_name);
+    if (!vs->format_ctx->url) {
+        LOGE("Could not strdup v4l2 device name");
+        goto error_avformat_free_context;
+        return false;
+    }
+
+    AVStream *ostream = avformat_new_stream(vs->format_ctx, encoder);
+    if (!ostream) {
+        LOGE("Could not allocate new v4l2 stream");
+        goto error_avformat_free_context;
+        return false;
+    }
+
+    ostream->codecpar->codec_type = AVMEDIA_TYPE_VIDEO;
+    ostream->codecpar->codec_id = encoder->id;
+    ostream->codecpar->format = AV_PIX_FMT_YUV420P;
+    ostream->codecpar->width = vs->frame_size.width;
+    ostream->codecpar->height = vs->frame_size.height;
+
+    int ret = avio_open(&vs->format_ctx->pb, vs->device_name, AVIO_FLAG_WRITE);
+    if (ret < 0) {
+        LOGE("Failed to open output device: %s", vs->device_name);
+        // ostream will be cleaned up during context cleaning
+        goto error_avformat_free_context;
+    }
+
+    vs->encoder_ctx = avcodec_alloc_context3(encoder);
+    if (!vs->encoder_ctx) {
+        LOGC("Could not allocate codec context for v4l2");
+        goto error_avio_close;
+    }
+
+    vs->encoder_ctx->width = vs->frame_size.width;
+    vs->encoder_ctx->height = vs->frame_size.height;
+    vs->encoder_ctx->pix_fmt = AV_PIX_FMT_YUV420P;
+    vs->encoder_ctx->time_base.num = 1;
+    vs->encoder_ctx->time_base.den = 1;
+
+    if (avcodec_open2(vs->encoder_ctx, encoder, NULL) < 0) {
+        LOGE("Could not open codec for v4l2");
+        goto error_avcodec_free_context;
+    }
+
+    vs->frame = av_frame_alloc();
+    if (!vs->frame) {
+        LOGE("Could not create v4l2 frame");
+        goto error_avcodec_close;
+    }
+
+    LOGD("Starting v4l2 thread");
+    ok = sc_thread_create(&vs->thread, run_v4l2_sink, "v4l2", vs);
+    if (!ok) {
+        LOGC("Could not start v4l2 thread");
+        goto error_av_frame_free;
+    }
+
+    vs->header_written = false;
+    vs->stopped = false;
+
+    LOGI("v4l2 sink started to device: %s", vs->device_name);
+
+    return true;
+
+error_av_frame_free:
+    av_frame_free(&vs->frame);
+error_avcodec_close:
+    avcodec_close(vs->encoder_ctx);
+error_avcodec_free_context:
+    avcodec_free_context(&vs->encoder_ctx);
+error_avio_close:
+    avio_close(vs->format_ctx->pb);
+error_avformat_free_context:
+    avformat_free_context(vs->format_ctx);
+error_cond_destroy:
+    sc_cond_destroy(&vs->cond);
+error_mutex_destroy:
+    sc_mutex_destroy(&vs->mutex);
+error_video_buffer_destroy:
+    video_buffer_destroy(&vs->vb);
+
+    return false;
+}
+
+static void
+sc_v4l2_sink_close(struct sc_v4l2_sink *vs) {
+    sc_mutex_lock(&vs->mutex);
+    vs->stopped = true;
+    sc_cond_signal(&vs->cond);
+    sc_mutex_unlock(&vs->mutex);
+
+    sc_thread_join(&vs->thread, NULL);
+
+    av_frame_free(&vs->frame);
+    avcodec_close(vs->encoder_ctx);
+    avcodec_free_context(&vs->encoder_ctx);
+    avio_close(vs->format_ctx->pb);
+    avformat_free_context(vs->format_ctx);
+    sc_cond_destroy(&vs->cond);
+    sc_mutex_destroy(&vs->mutex);
+    video_buffer_destroy(&vs->vb);
+}
+
+static bool
+sc_v4l2_sink_push(struct sc_v4l2_sink *vs, const AVFrame *frame) {
+    bool ok = video_buffer_push(&vs->vb, frame, NULL);
+    if (!ok) {
+        return false;
+    }
+
+    // signal possible change of vs->vb.pending_frame_consumed
+    sc_cond_signal(&vs->cond);
+
+    return true;
+}
+
+static bool
+sc_v4l2_frame_sink_open(struct sc_frame_sink *sink) {
+    struct sc_v4l2_sink *vs = DOWNCAST(sink);
+    return sc_v4l2_sink_open(vs);
+}
+
+static void
+sc_v4l2_frame_sink_close(struct sc_frame_sink *sink) {
+    struct sc_v4l2_sink *vs = DOWNCAST(sink);
+    sc_v4l2_sink_close(vs);
+}
+
+static bool
+sc_v4l2_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
+    struct sc_v4l2_sink *vs = DOWNCAST(sink);
+    return sc_v4l2_sink_push(vs, frame);
+}
+
+bool
+sc_v4l2_sink_init(struct sc_v4l2_sink *vs, const char *device_name,
+                  struct size frame_size) {
+    vs->device_name = strdup(device_name);
+    if (!vs->device_name) {
+        LOGE("Could not strdup v4l2 device name");
+        return false;
+    }
+
+    vs->frame_size = frame_size;
+
+    static const struct sc_frame_sink_ops ops = {
+        .open = sc_v4l2_frame_sink_open,
+        .close = sc_v4l2_frame_sink_close,
+        .push = sc_v4l2_frame_sink_push,
+    };
+
+    vs->frame_sink.ops = &ops;
+
+    return true;
+}
+
+void
+sc_v4l2_sink_destroy(struct sc_v4l2_sink *vs) {
+    free(vs->device_name);
+}

--- a/app/src/v4l2_sink.h
+++ b/app/src/v4l2_sink.h
@@ -1,0 +1,39 @@
+#ifndef SC_V4L2_SINK_H
+#define SC_V4L2_SINK_H
+
+#include "common.h"
+
+#include "coords.h"
+#include "trait/frame_sink.h"
+#include "video_buffer.h"
+
+#include <libavformat/avformat.h>
+
+struct sc_v4l2_sink {
+    struct sc_frame_sink frame_sink; // frame sink trait
+
+    struct video_buffer vb;
+    AVFormatContext *format_ctx;
+    AVCodecContext *encoder_ctx;
+
+    char *device_name;
+    struct size frame_size;
+
+    sc_thread thread;
+    sc_mutex mutex;
+    sc_cond cond;
+    bool stopped;
+    bool header_written;
+
+    AVFrame *frame;
+    AVPacket packet;
+};
+
+bool
+sc_v4l2_sink_init(struct sc_v4l2_sink *vs, const char *device_name,
+                  struct size frame_size);
+
+void
+sc_v4l2_sink_destroy(struct sc_v4l2_sink *vs);
+
+#endif

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -33,19 +33,6 @@ struct video_buffer {
     sc_mutex mutex;
 
     bool pending_frame_consumed;
-
-    const struct video_buffer_callbacks *cbs;
-    void *cbs_userdata;
-};
-
-struct video_buffer_callbacks {
-    // Called when a new frame can be consumed.
-    // This callback is mandatory (it must not be NULL).
-    void (*on_frame_available)(struct video_buffer *vb, void *userdata);
-
-    // Called when a pending frame has been overwritten by the producer.
-    // This callback is optional (it may be NULL).
-    void (*on_frame_skipped)(struct video_buffer *vb, void *userdata);
 };
 
 bool
@@ -54,13 +41,8 @@ video_buffer_init(struct video_buffer *vb);
 void
 video_buffer_destroy(struct video_buffer *vb);
 
-void
-video_buffer_set_consumer_callbacks(struct video_buffer *vb,
-                                    const struct video_buffer_callbacks *cbs,
-                                    void *cbs_userdata);
-
 bool
-video_buffer_push(struct video_buffer *vb, const AVFrame *frame);
+video_buffer_push(struct video_buffer *vb, const AVFrame *frame, bool *skipped);
 
 void
 video_buffer_consume(struct video_buffer *vb, AVFrame *dst);

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -34,10 +34,7 @@ struct video_buffer {
     AVFrame *consumer_frame;
 
     sc_mutex mutex;
-    bool wait_consumer; // never overwrite a pending frame if it is not consumed
-    bool interrupted;
 
-    sc_cond pending_frame_consumed_cond;
     bool pending_frame_consumed;
 
     const struct video_buffer_callbacks *cbs;
@@ -56,7 +53,7 @@ struct video_buffer_callbacks {
 };
 
 bool
-video_buffer_init(struct video_buffer *vb, bool wait_consumer);
+video_buffer_init(struct video_buffer *vb);
 
 void
 video_buffer_destroy(struct video_buffer *vb);
@@ -74,9 +71,5 @@ video_buffer_producer_offer_frame(struct video_buffer *vb);
 // the frame is valid until the next call to this function
 const AVFrame *
 video_buffer_consumer_take_frame(struct video_buffer *vb);
-
-// wake up and avoid any blocking call
-void
-video_buffer_interrupt(struct video_buffer *vb);
 
 #endif

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -58,7 +58,6 @@ static void test_options(void) {
         "--push-target", "/sdcard/Movies",
         "--record", "file",
         "--record-format", "mkv",
-        "--render-expired-frames",
         "--serial", "0123456789abcdef",
         "--show-touches",
         "--turn-screen-off",
@@ -87,7 +86,6 @@ static void test_options(void) {
     assert(!strcmp(opts->push_target, "/sdcard/Movies"));
     assert(!strcmp(opts->record_filename, "file"));
     assert(opts->record_format == SC_RECORD_FORMAT_MKV);
-    assert(opts->render_expired_frames);
     assert(!strcmp(opts->serial, "0123456789abcdef"));
     assert(opts->show_touches);
     assert(opts->turn_screen_off);

--- a/app/tests/test_strutil.c
+++ b/app/tests/test_strutil.c
@@ -287,6 +287,18 @@ static void test_parse_integer_with_suffix(void) {
     assert(!ok);
 }
 
+static void test_strlist_contains(void) {
+    assert(strlist_contains("a,bc,def", ',', "bc"));
+    assert(!strlist_contains("a,bc,def", ',', "b"));
+    assert(strlist_contains("", ',', ""));
+    assert(strlist_contains("abc,", ',', ""));
+    assert(strlist_contains(",abc", ',', ""));
+    assert(strlist_contains("abc,,def", ',', ""));
+    assert(!strlist_contains("abc", ',', ""));
+    assert(strlist_contains(",,|x", '|', ",,"));
+    assert(strlist_contains("xyz", '\0', "xyz"));
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -304,5 +316,6 @@ int main(int argc, char *argv[]) {
     test_parse_integer();
     test_parse_integers();
     test_parse_integer_with_suffix();
+    test_strlist_contains();
     return 0;
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -25,6 +25,9 @@ public final class Device {
     public static final int POWER_MODE_OFF = SurfaceControl.POWER_MODE_OFF;
     public static final int POWER_MODE_NORMAL = SurfaceControl.POWER_MODE_NORMAL;
 
+    public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
+    public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
+
     private static final ServiceManager SERVICE_MANAGER = new ServiceManager();
 
     public interface RotationListener {

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenInfo.java
@@ -82,6 +82,12 @@ public final class ScreenInfo {
 
     public static ScreenInfo computeScreenInfo(DisplayInfo displayInfo, Rect crop, int maxSize, int lockedVideoOrientation) {
         int rotation = displayInfo.getRotation();
+
+        if (lockedVideoOrientation == Device.LOCK_VIDEO_ORIENTATION_INITIAL) {
+            // The user requested to lock the video orientation to the current orientation
+            lockedVideoOrientation = rotation;
+        }
+
         Size deviceSize = displayInfo.getSize();
         Rect contentRect = new Rect(0, 0, deviceSize.getWidth(), deviceSize.getHeight());
         if (crop != null) {


### PR DESCRIPTION
This is a follow up for v4l2loopback support (#2232 #2233) implemented by @martinellimarco.

I refactored scrcpy to support this feature properly, then I rebased @martinellimarco's work to use the refactored codebase.

The main purpose is to make the v4l2 component consume frames directly from the decoder, in order to avoid decoding the video stream twice if mirroring display is enabled:

```
                      screen/display
                    /
            decoder
          /         \
         /            v4l2_sink
  stream
         \
           recorder

          \--------/  \-------------/
         packet sinks   frame sinks
```

Here is a summary of the changes:
 - Remove `--render-expired-frames` option (see 8bae1f6b7fc7a82ea2d04c76e21fd127617c97d6 for details)
 - Remove compat with old FFmpeg decodeing and codec params API (deprecated since 2016)
 - Make video_buffer not consume the input frame (to make possible to send it to several sinks)
 - Add two abstractions (traits):
   - `sc_packet_sink`: a component which receives packets. It is implemented by the `decoder` and the `recorder`, and the `stream` now push its packets to the registered packet sinks (without depending on the concrete sink types)
   - `sc_frame_sink`: a component which receives frames. It is implemented by the `screen` (and now `v4l2`), and the `decoder` now pushes its frames to the registered frame sinks (without depending on the concrete sink types)
 - Add a new mode for `--lock-video-orientation`: `initial`. This locks the video in the orientation the device happens to be on start and avoids to pass an explicit value. This mode is set by default when v4l2 sink is enabled.
 - Rework the v4l2 sink component to implement `sc_frame_sink`, and be registered to the `decoder`.
 - Use a `video_buffer` to always send the very last frame, like for the display (it may skip frames, it's on purpose, is it a problem?)
 - Add some documentation in the README

Here is a usage summary:

```bash
sudo apt install v4l2loopback-dkms   # install v4l2loopback
sudo modprobe v4l2loopback           # create a video device
scrcpy --v4l2-sink /dev/video1       # mirror + v4l2
scrcpy --v4l2-sink /dev/video1 -N    # v4l2 only
ffplay -i /dev/video1                # test
```

The video stream could also be captured from [OBS](https://obsproject.com/).

Thank you for your review/feedbacks.