### PR TITLE
Ensure the return value from get_server_path is freeable

### DIFF
--- a/app/src/server.c
+++ b/app/src/server.c
@@ -61,7 +61,7 @@ get_server_path(void) {
         LOGE("Could not get executable path, "
              "using " SERVER_FILENAME " from current directory");
         // not found, use current directory
-        return SERVER_FILENAME;
+        return SDL_strdup(SERVER_FILENAME);
     }
     char *dir = dirname(executable_path);
     size_t dirlen = strlen(dir);
@@ -73,7 +73,7 @@ get_server_path(void) {
         LOGE("Could not alloc server path string, "
              "using " SERVER_FILENAME " from current directory");
         SDL_free(executable_path);
-        return SERVER_FILENAME;
+        return SDL_strdup(SERVER_FILENAME);
     }
 
     memcpy(server_path, dir, dirlen);


### PR DESCRIPTION
While testing in support of https://github.com/Genymobile/scrcpy/issues/2252 I ran into this crash bug which looks like this:

```
% x/app/scrcpy
2021-04-22 12:50:31.596 scrcpy[82192:39073792] INFO: scrcpy 1.16 <https://github.com/Genymobile/scrcpy>
2021-04-22 12:50:31.596 scrcpy[82192:39073792] ERROR: Could not get executable path, using scrcpy-server from current directory
scrcpy(82192,0x11122fdc0) malloc: *** error for object 0x10a439c2c: pointer being freed was not allocated
scrcpy(82192,0x11122fdc0) malloc: *** set a breakpoint in malloc_error_break to debug
scrcpy-server: 1 file pushed. 4.5 MB/s (33622 bytes in 0.007s)
zsh: abort      x/app/scrcpy --window-borderless
```

The fix is simply that in the case where `get_server_path` returns just `SERVER_FILENAME`, it must be duplicated, because the caller expects to be able to free the returned value. If the duplication fails, we return NULL which indicates failure, so no further error handling is necessary, unless we wanted to log something about that extremely rare situation.