### PR TITLE
Add MacPorts Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,15 @@ You can also [build the app manually][BUILD].
 
 ### macOS
 
-The application is available in [Homebrew]. Just install it:
+The application is available in [MacPorts], which sets up adb for you:
+
+```bash
+sudo port install scrcpy
+```
+
+[MacPorts]: https://www.macports.org/
+
+It's also available in [Homebrew]. Just install it:
 
 [Homebrew]: https://brew.sh/
 


### PR DESCRIPTION
It goes without saying that I'm very thankful to the maintainers that put their time into keeping this awesome project running. Thank you for all your work :)

For all those that have various issues with Homebrew: https://github.com/Genymobile/scrcpy/issues/2256 https://github.com/Genymobile/scrcpy/issues/1414 https://github.com/Genymobile/scrcpy/issues/2059 https://github.com/Genymobile/scrcpy/issues/2183 (the list goes on...)

Document the installation instructions for MacPorts, and note that setting up adb is not required.