### PR TITLE
Fix option name in error message

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -230,7 +230,7 @@ public final class Server {
             if (encoders != null && encoders.length > 0) {
                 Ln.e("Try to use one of the available encoders:");
                 for (MediaCodecInfo encoder : encoders) {
-                    Ln.e("    scrcpy --encoder-name '" + encoder.getName() + "'");
+                    Ln.e("    scrcpy --encoder '" + encoder.getName() + "'");
                 }
             }
         }


### PR DESCRIPTION
tiny fix

```sh
scrcpy --encoder _
# ...
[server] ERROR: Try to use one of the available encoders:       at com.genymobile.scrcpy.ScreenEncoder.internalStreamScreen(ScreenEncoder.java:77)
        at com.genymobile.scrcpy.ScreenEncoder.streamScreen(ScreenEncoder.java:60)
        at com.genymobile.scrcpy.Server.scrcpy(Server.java:80)
        at com.genymobile.scrcpy.Server.main(Server.java:252)
        at com.android.internal.os.RuntimeInit.nativeFinishInit(Native Method)
        at com.android.internal.os.RuntimeInit.main(RuntimeInit.java:294)

[server] ERROR:     scrcpy --encoder-name 'OMX.MTK.VIDEO.ENCODER.AVC'
[server] ERROR:     scrcpy --encoder-name 'OMX.google.h264.encoder'
```

The option name in error messages should be `--encoder` instead of `--encoder-name`.

```sh
scrcpy --encoder-name 'OMX.google.h264.encoder'
# The option name is invalid
scrcpy: unrecognized option `--encoder-name'
```

```sh
scrcpy --encoder 'OMX.google.h264.encoder'
# success
```