### PR TITLE
Log input event details to verbose log

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -20,6 +20,7 @@ src = [
     'src/stream.c',
     'src/tiny_xpm.c',
     'src/video_buffer.c',
+    'src/util/log.c',
     'src/util/net.c',
     'src/util/process.c',
     'src/util/str_util.c',

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -193,7 +193,7 @@ It requires to lock the video orientation (see --lock-video-orientation).
 
 .TP
 .BI "\-V, \-\-verbosity " value
-Set the log level ("debug", "info", "warn" or "error").
+Set the log level ("verbose", "debug", "info", "warn" or "error").
 
 Default is "info" for release builds, "debug" for debug builds.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -184,7 +184,7 @@ scrcpy_print_usage(const char *arg0) {
         "\n"
 #endif
         "    -V, --verbosity value\n"
-        "        Set the log level (debug, info, warn or error).\n"
+        "        Set the log level (verbose, debug, info, warn or error).\n"
 #ifndef NDEBUG
         "        Default is debug.\n"
 #else
@@ -505,6 +505,11 @@ parse_display_id(const char *s, uint32_t *display_id) {
 
 static bool
 parse_log_level(const char *s, enum sc_log_level *log_level) {
+    if (!strcmp(s, "verbose")) {
+        *log_level = SC_LOG_LEVEL_VERBOSE;
+        return true;
+    }
+
     if (!strcmp(s, "debug")) {
         *log_level = SC_LOG_LEVEL_DEBUG;
         return true;

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -170,7 +170,12 @@ control_msg_log(const struct control_msg *msg) {
                          (long) msg->inject_touch_event.buttons);
             } else {
                 // numeric pointer id
-                LOG_CMSG("touch [id=%" PRIu64 "] %-4s position=%" PRIi32 ",%"
+#ifndef __WIN32
+# define PRIu64_ PRIu64
+#else
+# define PRIu64_ "I64u"  // Windows...
+#endif
+                LOG_CMSG("touch [id=%" PRIu64_ "] %-4s position=%" PRIi32 ",%"
                              PRIi32 " pressure=%g buttons=%06lx",
                          id,
                          MOTIONEVENT_ACTION_LABEL(action),

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -17,8 +17,8 @@
 // type: 1 byte; paste flag: 1 byte; length: 4 bytes
 #define CONTROL_MSG_CLIPBOARD_TEXT_MAX_LENGTH (CONTROL_MSG_MAX_SIZE - 6)
 
-#define POINTER_ID_MOUSE UINT64_C(-1);
-#define POINTER_ID_VIRTUAL_FINGER UINT64_C(-2);
+#define POINTER_ID_MOUSE UINT64_C(-1)
+#define POINTER_ID_VIRTUAL_FINGER UINT64_C(-2)
 
 enum control_msg_type {
     CONTROL_MSG_TYPE_INJECT_KEYCODE,

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -85,6 +85,9 @@ size_t
 control_msg_serialize(const struct control_msg *msg, unsigned char *buf);
 
 void
+control_msg_log(const struct control_msg *msg);
+
+void
 control_msg_destroy(struct control_msg *msg);
 
 #endif

--- a/app/src/controller.c
+++ b/app/src/controller.c
@@ -48,6 +48,7 @@ controller_destroy(struct controller *controller) {
 bool
 controller_push_msg(struct controller *controller,
                       const struct control_msg *msg) {
+    control_msg_log(msg);
     sc_mutex_lock(&controller->mutex);
     bool was_empty = cbuf_is_empty(&controller->queue);
     bool res = cbuf_push(&controller->queue, *msg);

--- a/app/src/controller.c
+++ b/app/src/controller.c
@@ -48,7 +48,10 @@ controller_destroy(struct controller *controller) {
 bool
 controller_push_msg(struct controller *controller,
                       const struct control_msg *msg) {
-    control_msg_log(msg);
+    if (sc_get_log_level() <= SC_LOG_LEVEL_VERBOSE) {
+        control_msg_log(msg);
+    }
+
     sc_mutex_lock(&controller->mutex);
     bool was_empty = cbuf_is_empty(&controller->queue);
     bool res = cbuf_push(&controller->queue, *msg);

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -595,8 +595,12 @@ convert_mouse_motion(const SDL_MouseMotionEvent *from, struct screen *screen,
 static void
 input_manager_process_mouse_motion(struct input_manager *im,
                                    const SDL_MouseMotionEvent *event) {
-    if (!event->state) {
-        // do not send motion events when no button is pressed
+    uint32_t mask = SDL_BUTTON_LMASK;
+    if (im->forward_all_clicks) {
+        mask |= SDL_BUTTON_MMASK | SDL_BUTTON_RMASK;
+    }
+    if (!(event->state & mask)) {
+        // do not send motion events when no click is pressed
         return;
     }
     if (event->which == SDL_TOUCH_MOUSEID) {

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -41,6 +41,8 @@ print_version(void) {
 static SDL_LogPriority
 convert_log_level_to_sdl(enum sc_log_level level) {
     switch (level) {
+        case SC_LOG_LEVEL_VERBOSE:
+            return SDL_LOG_PRIORITY_VERBOSE;
         case SC_LOG_LEVEL_DEBUG:
             return SDL_LOG_PRIORITY_DEBUG;
         case SC_LOG_LEVEL_INFO:

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -38,26 +38,6 @@ print_version(void) {
 #endif
 }
 
-static SDL_LogPriority
-convert_log_level_to_sdl(enum sc_log_level level) {
-    switch (level) {
-        case SC_LOG_LEVEL_VERBOSE:
-            return SDL_LOG_PRIORITY_VERBOSE;
-        case SC_LOG_LEVEL_DEBUG:
-            return SDL_LOG_PRIORITY_DEBUG;
-        case SC_LOG_LEVEL_INFO:
-            return SDL_LOG_PRIORITY_INFO;
-        case SC_LOG_LEVEL_WARN:
-            return SDL_LOG_PRIORITY_WARN;
-        case SC_LOG_LEVEL_ERROR:
-            return SDL_LOG_PRIORITY_ERROR;
-        default:
-            assert(!"unexpected log level");
-            return SDL_LOG_PRIORITY_INFO;
-    }
-}
-
-
 int
 main(int argc, char *argv[]) {
 #ifdef __WINDOWS__
@@ -81,8 +61,7 @@ main(int argc, char *argv[]) {
         return 1;
     }
 
-    SDL_LogPriority sdl_log = convert_log_level_to_sdl(args.opts.log_level);
-    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, sdl_log);
+    sc_set_log_level(args.opts.log_level);
 
     if (args.help) {
         scrcpy_print_usage(argv[0]);

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -216,14 +216,15 @@ av_log_callback(void *avcl, int level, const char *fmt, va_list vl) {
     if (priority == 0) {
         return;
     }
-    char *local_fmt = malloc(strlen(fmt) + 10);
+
+    size_t fmt_len = strlen(fmt);
+    char *local_fmt = malloc(fmt_len + 10);
     if (!local_fmt) {
         LOGC("Could not allocate string");
         return;
     }
-    // strcpy is safe here, the destination is large enough
-    strcpy(local_fmt, "[FFmpeg] ");
-    strcpy(local_fmt + 9, fmt);
+    memcpy(local_fmt, "[FFmpeg] ", 9); // do not write the final '\0'
+    memcpy(local_fmt + 9, fmt, fmt_len + 1); // include '\0'
     SDL_LogMessageV(SDL_LOG_CATEGORY_VIDEO, priority, local_fmt, vl);
     free(local_fmt);
 }

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -8,6 +8,7 @@
 #include <stdint.h>
 
 enum sc_log_level {
+    SC_LOG_LEVEL_VERBOSE,
     SC_LOG_LEVEL_DEBUG,
     SC_LOG_LEVEL_INFO,
     SC_LOG_LEVEL_WARN,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -235,6 +235,8 @@ enable_tunnel_any_port(struct server *server, struct sc_port_range port_range,
 static const char *
 log_level_to_server_string(enum sc_log_level level) {
     switch (level) {
+        case SC_LOG_LEVEL_VERBOSE:
+            return "verbose";
         case SC_LOG_LEVEL_DEBUG:
             return "debug";
         case SC_LOG_LEVEL_INFO:

--- a/app/src/util/log.c
+++ b/app/src/util/log.c
@@ -21,8 +21,33 @@ log_level_sc_to_sdl(enum sc_log_level level) {
     }
 }
 
+static enum sc_log_level
+log_level_sdl_to_sc(SDL_LogPriority priority) {
+    switch (priority) {
+        case SDL_LOG_PRIORITY_VERBOSE:
+            return SC_LOG_LEVEL_VERBOSE;
+        case SDL_LOG_PRIORITY_DEBUG:
+            return SC_LOG_LEVEL_DEBUG;
+        case SDL_LOG_PRIORITY_INFO:
+            return SC_LOG_LEVEL_INFO;
+        case SDL_LOG_PRIORITY_WARN:
+            return SC_LOG_LEVEL_WARN;
+        case SDL_LOG_PRIORITY_ERROR:
+            return SC_LOG_LEVEL_ERROR;
+        default:
+            assert(!"unexpected log level");
+            return SC_LOG_LEVEL_INFO;
+    }
+}
+
 void
 sc_set_log_level(enum sc_log_level level) {
     SDL_LogPriority sdl_log = log_level_sc_to_sdl(level);
     SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, sdl_log);
+}
+
+enum sc_log_level
+sc_get_log_level(void) {
+    SDL_LogPriority sdl_log = SDL_LogGetPriority(SDL_LOG_CATEGORY_APPLICATION);
+    return log_level_sdl_to_sc(sdl_log);
 }

--- a/app/src/util/log.c
+++ b/app/src/util/log.c
@@ -1,0 +1,28 @@
+#include "log.h"
+
+#include <assert.h>
+
+static SDL_LogPriority
+log_level_sc_to_sdl(enum sc_log_level level) {
+    switch (level) {
+        case SC_LOG_LEVEL_VERBOSE:
+            return SDL_LOG_PRIORITY_VERBOSE;
+        case SC_LOG_LEVEL_DEBUG:
+            return SDL_LOG_PRIORITY_DEBUG;
+        case SC_LOG_LEVEL_INFO:
+            return SDL_LOG_PRIORITY_INFO;
+        case SC_LOG_LEVEL_WARN:
+            return SDL_LOG_PRIORITY_WARN;
+        case SC_LOG_LEVEL_ERROR:
+            return SDL_LOG_PRIORITY_ERROR;
+        default:
+            assert(!"unexpected log level");
+            return SDL_LOG_PRIORITY_INFO;
+    }
+}
+
+void
+sc_set_log_level(enum sc_log_level level) {
+    SDL_LogPriority sdl_log = log_level_sc_to_sdl(level);
+    SDL_LogSetPriority(SDL_LOG_CATEGORY_APPLICATION, sdl_log);
+}

--- a/app/src/util/log.h
+++ b/app/src/util/log.h
@@ -17,4 +17,7 @@
 void
 sc_set_log_level(enum sc_log_level level);
 
+enum sc_log_level
+sc_get_log_level(void);
+
 #endif

--- a/app/src/util/log.h
+++ b/app/src/util/log.h
@@ -1,7 +1,11 @@
-#ifndef LOG_H
-#define LOG_H
+#ifndef SC_LOG_H
+#define SC_LOG_H
+
+#include "common.h"
 
 #include <SDL2/SDL_log.h>
+
+#include "scrcpy.h"
 
 #define LOGV(...) SDL_LogVerbose(SDL_LOG_CATEGORY_APPLICATION, __VA_ARGS__)
 #define LOGD(...) SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION, __VA_ARGS__)
@@ -9,5 +13,8 @@
 #define LOGW(...) SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, __VA_ARGS__)
 #define LOGE(...) SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, __VA_ARGS__)
 #define LOGC(...) SDL_LogCritical(SDL_LOG_CATEGORY_APPLICATION, __VA_ARGS__)
+
+void
+sc_set_log_level(enum sc_log_level level);
 
 #endif

--- a/server/src/main/java/com/genymobile/scrcpy/Ln.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Ln.java
@@ -12,7 +12,7 @@ public final class Ln {
     private static final String PREFIX = "[server] ";
 
     enum Level {
-        DEBUG, INFO, WARN, ERROR
+        VERBOSE, DEBUG, INFO, WARN, ERROR
     }
 
     private static Level threshold = Level.INFO;
@@ -34,6 +34,13 @@ public final class Ln {
 
     public static boolean isEnabled(Level level) {
         return level.ordinal() >= threshold.ordinal();
+    }
+
+    public static void v(String message) {
+        if (isEnabled(Level.VERBOSE)) {
+            Log.v(TAG, message);
+            System.out.println(PREFIX + "VERBOSE: " + message);
+        }
     }
 
     public static void d(String message) {


### PR DESCRIPTION
I wanted to automate a few actions using 'adb shell input' commands, but
it requires pixel coordinates. Logging input event details from scrcpy is
helpful for achieving that.
