### PR TITLE
Request scan media on push

### DIFF
--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -80,6 +80,13 @@ control_msg_serialize(const struct control_msg *msg, unsigned char *buf) {
         case CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE:
             buf[1] = msg->set_screen_power_mode.mode;
             return 2;
+        case CONTROL_MSG_TYPE_SCAN_MEDIA:
+        {
+            size_t len = write_string(msg->scan_media.path,
+                                      CONTROL_MSG_SCAN_MEDIA_PATH_MAX_LENGTH,
+                                      &buf[1]);
+            return 1 + len;
+        }
         case CONTROL_MSG_TYPE_EXPAND_NOTIFICATION_PANEL:
         case CONTROL_MSG_TYPE_EXPAND_SETTINGS_PANEL:
         case CONTROL_MSG_TYPE_COLLAPSE_PANELS:
@@ -101,6 +108,9 @@ control_msg_destroy(struct control_msg *msg) {
             break;
         case CONTROL_MSG_TYPE_SET_CLIPBOARD:
             free(msg->set_clipboard.text);
+            break;
+        case CONTROL_MSG_TYPE_SCAN_MEDIA:
+            free(msg->scan_media.path);
             break;
         default:
             // do nothing

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -17,6 +17,8 @@
 // type: 1 byte; paste flag: 1 byte; length: 4 bytes
 #define CONTROL_MSG_CLIPBOARD_TEXT_MAX_LENGTH (CONTROL_MSG_MAX_SIZE - 6)
 
+#define CONTROL_MSG_SCAN_MEDIA_PATH_MAX_LENGTH 256
+
 #define POINTER_ID_MOUSE UINT64_C(-1);
 #define POINTER_ID_VIRTUAL_FINGER UINT64_C(-2);
 
@@ -33,6 +35,7 @@ enum control_msg_type {
     CONTROL_MSG_TYPE_SET_CLIPBOARD,
     CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE,
     CONTROL_MSG_TYPE_ROTATE_DEVICE,
+    CONTROL_MSG_TYPE_SCAN_MEDIA,
 };
 
 enum screen_power_mode {
@@ -76,6 +79,9 @@ struct control_msg {
         struct {
             enum screen_power_mode mode;
         } set_screen_power_mode;
+        struct {
+            char *path; // owned, to be freed by free()
+        } scan_media;
     };
 };
 

--- a/app/src/file_handler.h
+++ b/app/src/file_handler.h
@@ -22,6 +22,7 @@ struct file_handler_request {
 struct file_handler_request_queue CBUF(struct file_handler_request, 16);
 
 struct file_handler {
+    struct controller *controller;
     char *serial;
     const char *push_target;
     sc_thread thread;
@@ -34,7 +35,8 @@ struct file_handler {
 };
 
 bool
-file_handler_init(struct file_handler *file_handler, const char *serial,
+file_handler_init(struct file_handler *file_handler,
+                  struct controller *controller, const char *serial,
                   const char *push_target);
 
 void

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -346,8 +346,8 @@ scrcpy(const struct scrcpy_options *options) {
             }
             controller_started = true;
 
-            if (!file_handler_init(&s->file_handler, s->server.serial,
-                                   options->push_target)) {
+            if (!file_handler_init(&s->file_handler, &s->controller,
+                                   s->server.serial, options->push_target)) {
                 goto end;
             }
             file_handler_initialized = true;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -297,14 +297,6 @@ scrcpy(const struct scrcpy_options *options) {
         goto end;
     }
 
-    if (options->display && options->control) {
-        if (!file_handler_init(&s->file_handler, s->server.serial,
-                               options->push_target)) {
-            goto end;
-        }
-        file_handler_initialized = true;
-    }
-
     struct decoder *dec = NULL;
     bool needs_decoder = options->display;
 #ifdef HAVE_V4L2
@@ -353,6 +345,12 @@ scrcpy(const struct scrcpy_options *options) {
                 goto end;
             }
             controller_started = true;
+
+            if (!file_handler_init(&s->file_handler, s->server.serial,
+                                   options->push_target)) {
+                goto end;
+            }
+            file_handler_initialized = true;
         }
 
         const char *window_title =

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -278,6 +278,28 @@ static void test_serialize_rotate_device(void) {
     assert(!memcmp(buf, expected, sizeof(expected)));
 }
 
+static void test_serialize_scan_media(void) {
+    struct control_msg msg = {
+        .type = CONTROL_MSG_TYPE_SCAN_MEDIA,
+        .scan_media = {
+            .path = "/sdcard/Download/",
+        },
+    };
+
+    unsigned char buf[CONTROL_MSG_MAX_SIZE];
+    size_t size = control_msg_serialize(&msg, buf);
+    assert(size == 22);
+
+    const unsigned char expected[] = {
+        CONTROL_MSG_TYPE_SCAN_MEDIA,
+        0x00, 0x00, 0x00, 0x11, // path length
+        '/', 's', 'd', 'c', 'a', 'r', 'd', '/',
+        'D', 'o', 'w', 'n', 'l', 'o', 'a', 'd',
+        '/' // path
+    };
+    assert(!memcmp(buf, expected, sizeof(expected)));
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -295,5 +317,6 @@ int main(int argc, char *argv[]) {
     test_serialize_set_clipboard();
     test_serialize_set_screen_power_mode();
     test_serialize_rotate_device();
+    test_serialize_scan_media();
     return 0;
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
@@ -17,6 +17,7 @@ public final class ControlMessage {
     public static final int TYPE_SET_CLIPBOARD = 9;
     public static final int TYPE_SET_SCREEN_POWER_MODE = 10;
     public static final int TYPE_ROTATE_DEVICE = 11;
+    public static final int TYPE_SCAN_MEDIA = 12;
 
     private int type;
     private String text;
@@ -94,6 +95,13 @@ public final class ControlMessage {
         ControlMessage msg = new ControlMessage();
         msg.type = TYPE_SET_SCREEN_POWER_MODE;
         msg.action = mode;
+        return msg;
+    }
+
+    public static ControlMessage createScanMedia(String path) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_SCAN_MEDIA;
+        msg.text = path;
         return msg;
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
@@ -76,6 +76,9 @@ public class ControlMessageReader {
             case ControlMessage.TYPE_SET_SCREEN_POWER_MODE:
                 msg = parseSetScreenPowerMode();
                 break;
+            case ControlMessage.TYPE_SCAN_MEDIA:
+                msg = parseScanMedia();
+                break;
             case ControlMessage.TYPE_EXPAND_NOTIFICATION_PANEL:
             case ControlMessage.TYPE_EXPAND_SETTINGS_PANEL:
             case ControlMessage.TYPE_COLLAPSE_PANELS:
@@ -180,6 +183,14 @@ public class ControlMessageReader {
         }
         int mode = buffer.get();
         return ControlMessage.createSetScreenPowerMode(mode);
+    }
+
+    private ControlMessage parseScanMedia() {
+        String path = parseString();
+        if (path == null) {
+            return null;
+        }
+        return ControlMessage.createScanMedia(path);
     }
 
     private static Position readPosition(ByteBuffer buffer) {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -1,5 +1,7 @@
 package com.genymobile.scrcpy;
 
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.SystemClock;
 import android.view.InputDevice;
@@ -7,6 +9,7 @@ import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -134,6 +137,13 @@ public class Controller {
                 break;
             case ControlMessage.TYPE_ROTATE_DEVICE:
                 Device.rotateDevice();
+                break;
+            case ControlMessage.TYPE_SCAN_MEDIA:
+                String path = msg.getText();
+                @SuppressWarnings("deprecation")
+                Intent intent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
+                intent.setData(Uri.fromFile(new File(path)));
+                Device.sendBroadcast(intent);
                 break;
             default:
                 // do nothing

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -8,6 +8,7 @@ import com.genymobile.scrcpy.wrappers.SurfaceControl;
 import com.genymobile.scrcpy.wrappers.WindowManager;
 
 import android.content.IOnPrimaryClipChangedListener;
+import android.content.Intent;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
@@ -298,5 +299,9 @@ public final class Device {
 
     public static ContentProvider createSettingsProvider() {
         return SERVICE_MANAGER.getActivityManager().createSettingsProvider();
+    }
+
+    public static void sendBroadcast(Intent intent) {
+        SERVICE_MANAGER.getActivityManager().sendBroadcast(intent);
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
@@ -315,6 +315,26 @@ public class ControlMessageReaderTest {
     }
 
     @Test
+    public void testScanMedia() throws IOException {
+        ControlMessageReader reader = new ControlMessageReader();
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeByte(ControlMessage.TYPE_SCAN_MEDIA);
+        byte[] text = "/sdcard/Download/".getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(text.length);
+        dos.write(text);
+
+        byte[] packet = bos.toByteArray();
+
+        reader.readFrom(new ByteArrayInputStream(packet));
+        ControlMessage event = reader.next();
+
+        Assert.assertEquals(ControlMessage.TYPE_SCAN_MEDIA, event.getType());
+        Assert.assertEquals("/sdcard/Download/", event.getText());
+    }
+
+    @Test
     public void testMultiEvents() throws IOException {
         ControlMessageReader reader = new ControlMessageReader();
 


### PR DESCRIPTION
After a file is pushed (by drag&drop), send a broadcast to request the media scanner to scan the "push target" directory.
    
In practice, this allows some apps to detect the new file immediately.

---

Refs https://github.com/Genymobile/scrcpy/pull/2265#issuecomment-860182404 cc @brunoais 

In the end, I'm not convinced by the feature, for two reasons:
 - [`ACTION_MEDIA_SCANNER_SCAN_FILE`](https://developer.android.com/reference/android/content/Intent?hl=en#ACTION_MEDIA_SCANNER_SCAN_FILE) is now deprecated
 - in practice, I tested some apps, either they refresh immediately on file push (with or without the change), either they don't (with or without the change)

In the past, it was useful, but here even on a test device with Android 6, it does not seem very useful (maybe I should test more).