### PR TITLE
Push to /sdcard/Download/ by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,15 +709,15 @@ There is no visual feedback, a log is printed to the console.
 
 #### Push file to device
 
-To push a file to `/sdcard/` on the device, drag & drop a (non-APK) file to the
-_scrcpy_ window.
+To push a file to `/sdcard/Download/` on the device, drag & drop a (non-APK)
+file to the _scrcpy_ window.
 
 There is no visual feedback, a log is printed to the console.
 
 The target directory can be changed on start:
 
 ```bash
-scrcpy --push-target=/sdcard/Download/
+scrcpy --push-target=/sdcard/Movies/
 ```
 
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -133,7 +133,7 @@ but breaks the expected behavior of alpha keys in games (typically WASD).
 .BI "\-\-push\-target " path
 Set the target directory for pushing files to the device by drag & drop. It is passed as\-is to "adb push".
 
-Default is "/sdcard/".
+Default is "/sdcard/Download/".
 
 .TP
 .BI "\-r, \-\-record " file

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -129,7 +129,7 @@ scrcpy_print_usage(const char *arg0) {
         "    --push-target path\n"
         "        Set the target directory for pushing files to the device by\n"
         "        drag & drop. It is passed as-is to \"adb push\".\n"
-        "        Default is \"/sdcard/\".\n"
+        "        Default is \"/sdcard/Download/\".\n"
         "\n"
         "    -r, --record file.mp4\n"
         "        Record screen to file.\n"

--- a/app/src/file_handler.c
+++ b/app/src/file_handler.c
@@ -6,7 +6,7 @@
 #include "adb.h"
 #include "util/log.h"
 
-#define DEFAULT_PUSH_TARGET "/sdcard/"
+#define DEFAULT_PUSH_TARGET "/sdcard/Download/"
 
 static void
 file_handler_request_destroy(struct file_handler_request *req) {


### PR DESCRIPTION
Change the default push target from `/sdcard/` to `/sdcard/Download/`.

Pushing to the root of `/sdcard/ is not very convenient, many apps do not expose its content directly.

It can still be changed by `--push-target`.

---

I would like to change the default push target. What do you think? (cc @brunoais)