### PR TITLE
Implement (optional) buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,24 @@ For example, you could capture the video within [OBS].
 [OBS]: https://obsproject.com/fr
 
 
+#### Buffering
+
+It is possible to add buffering. This increases latency but reduces jitter (see
+#2464).
+
+The option is available for display buffering:
+
+```bash
+scrcpy --display-buffer=50  # add 50 ms buffering for display
+```
+
+and V4L2 sink:
+
+```bash
+scrcpy --v4l2-buffer=500    # add 500 ms buffering for v4l2 sink
+```
+
+
 ### Connection
 
 #### Wireless

--- a/app/meson.build
+++ b/app/meson.build
@@ -10,6 +10,7 @@ src = [
     'src/event_converter.c',
     'src/file_handler.c',
     'src/fps_counter.c',
+    'src/frame_buffer.c',
     'src/input_manager.c',
     'src/opengl.c',
     'src/receiver.c',

--- a/app/meson.build
+++ b/app/meson.build
@@ -25,6 +25,7 @@ src = [
     'src/util/process.c',
     'src/util/str_util.c',
     'src/util/thread.c',
+    'src/util/tick.c',
 ]
 
 if host_machine.system() == 'windows'

--- a/app/meson.build
+++ b/app/meson.build
@@ -2,6 +2,7 @@ src = [
     'src/main.c',
     'src/adb.c',
     'src/cli.c',
+    'src/clock.c',
     'src/compat.c',
     'src/control_msg.c',
     'src/controller.c',

--- a/app/meson.build
+++ b/app/meson.build
@@ -168,6 +168,10 @@ if get_option('buildtype') == 'debug'
             'src/cli.c',
             'src/util/str_util.c',
         ]],
+        ['test_clock', [
+            'tests/test_clock.c',
+            'src/clock.c',
+        ]],
         ['test_control_msg_serialize', [
             'tests/test_control_msg_serialize.c',
             'src/control_msg.c',

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -57,6 +57,12 @@ The list of possible display ids can be listed by "adb shell dumpsys display"
 Default is 0.
 
 .TP
+.BI "\-\-display\-buffer ms
+Add a buffering delay (in milliseconds) before displaying. This increases latency to compensate for jitter.
+
+Default is 0 (no buffering).
+
+.TP
 .BI "\-\-encoder " name
 Use a specific MediaCodec encoder (must be a H.264 encoder).
 
@@ -190,6 +196,14 @@ It only shows physical touches (not clicks from scrcpy).
 Output to v4l2loopback device.
 
 It requires to lock the video orientation (see \fB\-\-lock\-video\-orientation\fR).
+
+.TP
+.BI "\-\-v4l2-buffer " ms
+Add a buffering delay (in milliseconds) before pushing frames. This increases latency to compensate for jitter.
+
+This option is similar to \fB\-\-display\-buffer\fR, but specific to V4L2 sink.
+
+Default is 0 (no buffering).
 
 .TP
 .BI "\-V, \-\-verbosity " value

--- a/app/src/clock.c
+++ b/app/src/clock.c
@@ -1,0 +1,90 @@
+#include "clock.h"
+
+void
+sc_clock_init(struct sc_clock *clock) {
+    clock->count = 0;
+    clock->head = 0;
+    clock->left_sum.system = 0;
+    clock->left_sum.stream = 0;
+    clock->right_sum.system = 0;
+    clock->right_sum.stream = 0;
+}
+
+// Estimate the affine function f(stream) = slope * stream + offset
+static void
+sc_clock_estimate(struct sc_clock *clock,
+                  double *out_slope, sc_tick *out_offset) {
+    assert(clock->count > 1); // two points are necessary
+    struct sc_clock_point left_avg = {
+        .system = clock->left_sum.system / (clock->count / 2),
+        .stream = clock->left_sum.stream / (clock->count / 2),
+    };
+    struct sc_clock_point right_avg = {
+        .system = clock->right_sum.system / ((clock->count + 1) / 2),
+        .stream = clock->right_sum.stream / ((clock->count + 1) / 2),
+    };
+    struct sc_clock_point global_avg = {
+        .system = (clock->left_sum.system + clock->right_sum.system)
+                 / clock->count,
+        .stream = (clock->left_sum.stream + clock->right_sum.stream)
+                 / clock->count,
+    };
+
+    double slope = (double) (right_avg.system - left_avg.system)
+                 / (right_avg.stream - left_avg.stream);
+    sc_tick offset = global_avg.system - (sc_tick) (global_avg.stream * slope);
+
+    *out_slope = slope;
+    *out_offset = offset;
+}
+
+void
+sc_clock_update(struct sc_clock *clock, sc_tick system, sc_tick stream) {
+    struct sc_clock_point *point = &clock->points[clock->head];
+
+    if (clock->count == SC_CLOCK_RANGE || clock->count & 1) {
+        // One point passes from the right sum to the left sum
+
+        unsigned mid;
+        if (clock->count == SC_CLOCK_RANGE) {
+            mid = (clock->head + SC_CLOCK_RANGE / 2) % SC_CLOCK_RANGE;
+        } else {
+            // Only for the first frames
+            mid = clock->count / 2;
+        }
+
+        struct sc_clock_point *mid_point = &clock->points[mid];
+        clock->left_sum.system += mid_point->system;
+        clock->left_sum.stream += mid_point->stream;
+        clock->right_sum.system -= mid_point->system;
+        clock->right_sum.stream -= mid_point->stream;
+    }
+
+    if (clock->count == SC_CLOCK_RANGE) {
+        // The current point overwrites the previous value in the circular
+        // array, update the left sum accordingly
+        clock->left_sum.system -= point->system;
+        clock->left_sum.stream -= point->stream;
+    } else {
+        ++clock->count;
+    }
+
+    point->system = system;
+    point->stream = stream;
+
+    clock->right_sum.system += system;
+    clock->right_sum.stream += stream;
+
+    clock->head = (clock->head + 1) % SC_CLOCK_RANGE;
+
+    if (clock->count > 1) {
+        // Update estimation
+        sc_clock_estimate(clock, &clock->slope, &clock->offset);
+    }
+}
+
+sc_tick
+sc_clock_to_system_time(struct sc_clock *clock, sc_tick stream) {
+    assert(clock->count > 1); // sc_clock_update() must have been called
+    return (sc_tick) (stream * clock->slope) + clock->offset;
+}

--- a/app/src/clock.c
+++ b/app/src/clock.c
@@ -1,5 +1,9 @@
 #include "clock.h"
 
+#include "util/log.h"
+
+#define SC_CLOCK_NDEBUG // comment to debug
+
 void
 sc_clock_init(struct sc_clock *clock) {
     clock->count = 0;
@@ -80,6 +84,11 @@ sc_clock_update(struct sc_clock *clock, sc_tick system, sc_tick stream) {
     if (clock->count > 1) {
         // Update estimation
         sc_clock_estimate(clock, &clock->slope, &clock->offset);
+
+#ifndef SC_CLOCK_NDEBUG
+        LOGD("Clock estimation: %g * pts + %" PRItick,
+             clock->slope, clock->offset);
+#endif
     }
 }
 

--- a/app/src/clock.h
+++ b/app/src/clock.h
@@ -1,0 +1,70 @@
+#ifndef SC_CLOCK_H
+#define SC_CLOCK_H
+
+#include "common.h"
+
+#include <assert.h>
+
+#include "util/tick.h"
+
+#define SC_CLOCK_RANGE 32
+static_assert(!(SC_CLOCK_RANGE & 1), "SC_CLOCK_RANGE must be even");
+
+struct sc_clock_point {
+    sc_tick system;
+    sc_tick stream;
+};
+
+/**
+ * The clock aims to estimate the affine relation between the stream (device)
+ * time and the system time:
+ *
+ *     f(stream) = slope * stream + offset
+ *
+ * To that end, it stores the SC_CLOCK_RANGE last clock points (the timestamps
+ * of a frame expressed both in stream time and system time) in a circular
+ * array.
+ *
+ * To estimate the slope, it splits the last SC_CLOCK_RANGE points into two
+ * sets of SC_CLOCK_RANGE/2 points, and compute their centroid ("average
+ * point"). The slope of the estimated affine function is that of the line
+ * passing through these two points.
+ *
+ * To estimate the offset, it computes the centroid of all the SC_CLOCK_RANGE
+ * points. The resulting affine function passes by this centroid.
+ *
+ * With a circular array, the rolling sums (and average) are quick to compute.
+ * In practice, the estimation is stable and the evolution is smooth.
+ */
+struct sc_clock {
+    // Circular array
+    struct sc_clock_point points[SC_CLOCK_RANGE];
+
+    // Number of points in the array (count <= SC_CLOCK_RANGE)
+    unsigned count;
+
+    // Index of the next point to write
+    unsigned head;
+
+    // Sum of the first count/2 points
+    struct sc_clock_point left_sum;
+
+    // Sum of the last (count+1)/2 points
+    struct sc_clock_point right_sum;
+
+    // Estimated slope and offset
+    // (computed on sc_clock_update(), used by sc_clock_to_system_time())
+    double slope;
+    sc_tick offset;
+};
+
+void
+sc_clock_init(struct sc_clock *clock);
+
+void
+sc_clock_update(struct sc_clock *clock, sc_tick system, sc_tick stream);
+
+sc_tick
+sc_clock_to_system_time(struct sc_clock *clock, sc_tick stream);
+
+#endif

--- a/app/src/fps_counter.c
+++ b/app/src/fps_counter.c
@@ -1,11 +1,10 @@
 #include "fps_counter.h"
 
 #include <assert.h>
-#include <SDL2/SDL_timer.h>
 
 #include "util/log.h"
 
-#define FPS_COUNTER_INTERVAL_MS 1000
+#define FPS_COUNTER_INTERVAL SC_TICK_FROM_SEC(1)
 
 bool
 fps_counter_init(struct fps_counter *counter) {
@@ -47,7 +46,7 @@ set_started(struct fps_counter *counter, bool started) {
 static void
 display_fps(struct fps_counter *counter) {
     unsigned rendered_per_second =
-        counter->nr_rendered * 1000 / FPS_COUNTER_INTERVAL_MS;
+        counter->nr_rendered * SC_TICK_FREQ / FPS_COUNTER_INTERVAL;
     if (counter->nr_skipped) {
         LOGI("%u fps (+%u frames skipped)", rendered_per_second,
                                             counter->nr_skipped);
@@ -68,8 +67,8 @@ check_interval_expired(struct fps_counter *counter, uint32_t now) {
     counter->nr_skipped = 0;
     // add a multiple of the interval
     uint32_t elapsed_slices =
-        (now - counter->next_timestamp) / FPS_COUNTER_INTERVAL_MS + 1;
-    counter->next_timestamp += FPS_COUNTER_INTERVAL_MS * elapsed_slices;
+        (now - counter->next_timestamp) / FPS_COUNTER_INTERVAL + 1;
+    counter->next_timestamp += FPS_COUNTER_INTERVAL * elapsed_slices;
 }
 
 static int
@@ -82,11 +81,11 @@ run_fps_counter(void *data) {
             sc_cond_wait(&counter->state_cond, &counter->mutex);
         }
         while (!counter->interrupted && is_started(counter)) {
-            uint32_t now = SDL_GetTicks();
+            sc_tick now = sc_tick_now();
             check_interval_expired(counter, now);
 
             assert(counter->next_timestamp > now);
-            uint32_t remaining = counter->next_timestamp - now;
+            sc_tick remaining = counter->next_timestamp - now;
 
             // ignore the reason (timeout or signaled), we just loop anyway
             sc_cond_timedwait(&counter->state_cond, &counter->mutex, remaining);
@@ -99,7 +98,7 @@ run_fps_counter(void *data) {
 bool
 fps_counter_start(struct fps_counter *counter) {
     sc_mutex_lock(&counter->mutex);
-    counter->next_timestamp = SDL_GetTicks() + FPS_COUNTER_INTERVAL_MS;
+    counter->next_timestamp = sc_tick_now() + FPS_COUNTER_INTERVAL;
     counter->nr_rendered = 0;
     counter->nr_skipped = 0;
     sc_mutex_unlock(&counter->mutex);
@@ -165,7 +164,7 @@ fps_counter_add_rendered_frame(struct fps_counter *counter) {
     }
 
     sc_mutex_lock(&counter->mutex);
-    uint32_t now = SDL_GetTicks();
+    sc_tick now = sc_tick_now();
     check_interval_expired(counter, now);
     ++counter->nr_rendered;
     sc_mutex_unlock(&counter->mutex);
@@ -178,7 +177,7 @@ fps_counter_add_skipped_frame(struct fps_counter *counter) {
     }
 
     sc_mutex_lock(&counter->mutex);
-    uint32_t now = SDL_GetTicks();
+    sc_tick now = sc_tick_now();
     check_interval_expired(counter, now);
     ++counter->nr_skipped;
     sc_mutex_unlock(&counter->mutex);

--- a/app/src/fps_counter.c
+++ b/app/src/fps_counter.c
@@ -84,11 +84,9 @@ run_fps_counter(void *data) {
             sc_tick now = sc_tick_now();
             check_interval_expired(counter, now);
 
-            assert(counter->next_timestamp > now);
-            sc_tick remaining = counter->next_timestamp - now;
-
             // ignore the reason (timeout or signaled), we just loop anyway
-            sc_cond_timedwait(&counter->state_cond, &counter->mutex, remaining);
+            sc_cond_timedwait(&counter->state_cond, &counter->mutex,
+                              counter->next_timestamp);
         }
     }
     sc_mutex_unlock(&counter->mutex);

--- a/app/src/fps_counter.h
+++ b/app/src/fps_counter.h
@@ -24,7 +24,7 @@ struct fps_counter {
     bool interrupted;
     unsigned nr_rendered;
     unsigned nr_skipped;
-    uint32_t next_timestamp;
+    sc_tick next_timestamp;
 };
 
 bool

--- a/app/src/frame_buffer.c
+++ b/app/src/frame_buffer.c
@@ -1,0 +1,88 @@
+#include "frame_buffer.h"
+
+#include <assert.h>
+#include <libavutil/avutil.h>
+#include <libavformat/avformat.h>
+
+#include "util/log.h"
+
+bool
+sc_frame_buffer_init(struct sc_frame_buffer *fb) {
+    fb->pending_frame = av_frame_alloc();
+    if (!fb->pending_frame) {
+        return false;
+    }
+
+    fb->tmp_frame = av_frame_alloc();
+    if (!fb->tmp_frame) {
+        av_frame_free(&fb->pending_frame);
+        return false;
+    }
+
+    bool ok = sc_mutex_init(&fb->mutex);
+    if (!ok) {
+        av_frame_free(&fb->pending_frame);
+        av_frame_free(&fb->tmp_frame);
+        return false;
+    }
+
+    // there is initially no frame, so consider it has already been consumed
+    fb->pending_frame_consumed = true;
+
+    return true;
+}
+
+void
+sc_frame_buffer_destroy(struct sc_frame_buffer *fb) {
+    sc_mutex_destroy(&fb->mutex);
+    av_frame_free(&fb->pending_frame);
+    av_frame_free(&fb->tmp_frame);
+}
+
+static inline void
+swap_frames(AVFrame **lhs, AVFrame **rhs) {
+    AVFrame *tmp = *lhs;
+    *lhs = *rhs;
+    *rhs = tmp;
+}
+
+bool
+sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame,
+                  bool *previous_frame_skipped) {
+    sc_mutex_lock(&fb->mutex);
+
+    // Use a temporary frame to preserve pending_frame in case of error.
+    // tmp_frame is an empty frame, no need to call av_frame_unref() beforehand.
+    int r = av_frame_ref(fb->tmp_frame, frame);
+    if (r) {
+        LOGE("Could not ref frame: %d", r);
+        return false;
+    }
+
+    // Now that av_frame_ref() succeeded, we can replace the previous
+    // pending_frame
+    swap_frames(&fb->pending_frame, &fb->tmp_frame);
+    av_frame_unref(fb->tmp_frame);
+
+    if (previous_frame_skipped) {
+        *previous_frame_skipped = !fb->pending_frame_consumed;
+    }
+    fb->pending_frame_consumed = false;
+
+    sc_mutex_unlock(&fb->mutex);
+
+    return true;
+}
+
+void
+sc_frame_buffer_consume(struct sc_frame_buffer *fb, AVFrame *dst) {
+    sc_mutex_lock(&fb->mutex);
+    assert(!fb->pending_frame_consumed);
+    fb->pending_frame_consumed = true;
+
+    av_frame_move_ref(dst, fb->pending_frame);
+    // av_frame_move_ref() resets its source frame, so no need to call
+    // av_frame_unref()
+
+    sc_mutex_unlock(&fb->mutex);
+}

--- a/app/src/frame_buffer.h
+++ b/app/src/frame_buffer.h
@@ -1,0 +1,44 @@
+#ifndef SC_FRAME_BUFFER_H
+#define SC_FRAME_BUFFER_H
+
+#include "common.h"
+
+#include <stdbool.h>
+
+#include "util/thread.h"
+
+// forward declarations
+typedef struct AVFrame AVFrame;
+
+/**
+ * A frame buffer holds 1 pending frame, which is the last frame received from
+ * the producer (typically, the decoder).
+ *
+ * If a pending frame has not been consumed when the producer pushes a new
+ * frame, then it is lost. The intent is to always provide access to the very
+ * last frame to minimize latency.
+ */
+
+struct sc_frame_buffer {
+    AVFrame *pending_frame;
+    AVFrame *tmp_frame; // To preserve the pending frame on error
+
+    sc_mutex mutex;
+
+    bool pending_frame_consumed;
+};
+
+bool
+sc_frame_buffer_init(struct sc_frame_buffer *fb);
+
+void
+sc_frame_buffer_destroy(struct sc_frame_buffer *fb);
+
+bool
+sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame,
+                     bool *skipped);
+
+void
+sc_frame_buffer_consume(struct sc_frame_buffer *fb, AVFrame *dst);
+
+#endif

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -381,6 +381,7 @@ scrcpy(const struct scrcpy_options *options) {
             .rotation = options->rotation,
             .mipmaps = options->mipmaps,
             .fullscreen = options->fullscreen,
+            .buffering_time = options->display_buffer,
         };
 
         if (!screen_init(&s->screen, &screen_params)) {
@@ -393,7 +394,8 @@ scrcpy(const struct scrcpy_options *options) {
 
 #ifdef HAVE_V4L2
     if (options->v4l2_device) {
-        if (!sc_v4l2_sink_init(&s->v4l2_sink, options->v4l2_device, frame_size)) {
+        if (!sc_v4l2_sink_init(&s->v4l2_sink, options->v4l2_device, frame_size,
+                               options->v4l2_buffer)) {
             goto end;
         }
 

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -7,6 +7,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "util/tick.h"
+
 enum sc_log_level {
     SC_LOG_LEVEL_VERBOSE,
     SC_LOG_LEVEL_DEBUG,
@@ -78,6 +80,8 @@ struct scrcpy_options {
     uint16_t window_width;
     uint16_t window_height;
     uint32_t display_id;
+    sc_tick display_buffer;
+    sc_tick v4l2_buffer;
     bool show_touches;
     bool fullscreen;
     bool always_on_top;
@@ -126,6 +130,8 @@ struct scrcpy_options {
     .window_width = 0, \
     .window_height = 0, \
     .display_id = 0, \
+    .display_buffer = 0, \
+    .v4l2_buffer = 0, \
     .show_touches = false, \
     .fullscreen = false, \
     .always_on_top = false, \

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -276,7 +276,7 @@ screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
     struct screen *screen = DOWNCAST(sink);
 
     bool previous_frame_skipped;
-    bool ok = video_buffer_push(&screen->vb, frame, &previous_frame_skipped);
+    bool ok = sc_video_buffer_push(&screen->vb, frame, &previous_frame_skipped);
     if (!ok) {
         return false;
     }
@@ -304,7 +304,7 @@ screen_init(struct screen *screen, const struct screen_params *params) {
     screen->fullscreen = false;
     screen->maximized = false;
 
-    bool ok = video_buffer_init(&screen->vb);
+    bool ok = sc_video_buffer_init(&screen->vb);
     if (!ok) {
         LOGE("Could not initialize video buffer");
         return false;
@@ -454,7 +454,7 @@ error_destroy_window:
 error_destroy_fps_counter:
     fps_counter_destroy(&screen->fps_counter);
 error_destroy_video_buffer:
-    video_buffer_destroy(&screen->vb);
+    sc_video_buffer_destroy(&screen->vb);
 
     return false;
 }
@@ -489,7 +489,7 @@ screen_destroy(struct screen *screen) {
     SDL_DestroyRenderer(screen->renderer);
     SDL_DestroyWindow(screen->window);
     fps_counter_destroy(&screen->fps_counter);
-    video_buffer_destroy(&screen->vb);
+    sc_video_buffer_destroy(&screen->vb);
 }
 
 static void
@@ -595,7 +595,7 @@ update_texture(struct screen *screen, const AVFrame *frame) {
 static bool
 screen_update_frame(struct screen *screen) {
     av_frame_unref(screen->frame);
-    video_buffer_consume(&screen->vb, screen->frame);
+    sc_video_buffer_consume(&screen->vb, screen->frame);
     AVFrame *frame = screen->frame;
 
     fps_counter_add_rendered_frame(&screen->fps_counter);

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -274,14 +274,16 @@ screen_frame_sink_close(struct sc_frame_sink *sink) {
 static bool
 screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
     struct screen *screen = DOWNCAST(sink);
+    return sc_video_buffer_push(&screen->vb, frame);
+}
 
-    bool previous_frame_skipped;
-    bool ok = sc_video_buffer_push(&screen->vb, frame, &previous_frame_skipped);
-    if (!ok) {
-        return false;
-    }
+static void
+sc_video_buffer_on_new_frame(struct sc_video_buffer *vb, bool previous_skipped,
+                             void *userdata) {
+    (void) vb;
+    struct screen *screen = userdata;
 
-    if (previous_frame_skipped) {
+    if (previous_skipped) {
         fps_counter_add_skipped_frame(&screen->fps_counter);
         // The EVENT_NEW_FRAME triggered for the previous frame will consume
         // this new frame instead
@@ -293,8 +295,6 @@ screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
         // Post the event on the UI thread
         SDL_PushEvent(&new_frame_event);
     }
-
-    return true;
 }
 
 bool
@@ -304,7 +304,11 @@ screen_init(struct screen *screen, const struct screen_params *params) {
     screen->fullscreen = false;
     screen->maximized = false;
 
-    bool ok = sc_video_buffer_init(&screen->vb);
+    static const struct sc_video_buffer_callbacks cbs = {
+        .on_new_frame = sc_video_buffer_on_new_frame,
+    };
+
+    bool ok = sc_video_buffer_init(&screen->vb, &cbs, screen);
     if (!ok) {
         LOGE("Could not initialize video buffer");
         return false;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -308,7 +308,8 @@ screen_init(struct screen *screen, const struct screen_params *params) {
         .on_new_frame = sc_video_buffer_on_new_frame,
     };
 
-    bool ok = sc_video_buffer_init(&screen->vb, 0, &cbs, screen);
+    bool ok = sc_video_buffer_init(&screen->vb, params->buffering_time, &cbs,
+                                   screen);
     if (!ok) {
         LOGE("Could not initialize video buffer");
         return false;

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -20,7 +20,7 @@ struct screen {
     bool open; // track the open/close state to assert correct behavior
 #endif
 
-    struct video_buffer vb;
+    struct sc_video_buffer vb;
     struct fps_counter fps_counter;
 
     SDL_Window *window;

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -63,6 +63,8 @@ struct screen_params {
     bool mipmaps;
 
     bool fullscreen;
+
+    sc_tick buffering_time;
 };
 
 // initialize screen, create window, renderer and texture (window is hidden)

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -554,10 +554,10 @@ server_stop(struct server *server) {
     sc_mutex_lock(&server->mutex);
     bool signaled = false;
     if (!server->process_terminated) {
-#define WATCHDOG_DELAY_MS 1000
+#define WATCHDOG_DELAY SC_TICK_FROM_SEC(1)
         signaled = sc_cond_timedwait(&server->process_terminated_cond,
                                      &server->mutex,
-                                     WATCHDOG_DELAY_MS);
+                                     WATCHDOG_DELAY);
     }
     sc_mutex_unlock(&server->mutex);
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -557,7 +557,7 @@ server_stop(struct server *server) {
 #define WATCHDOG_DELAY SC_TICK_FROM_SEC(1)
         signaled = sc_cond_timedwait(&server->process_terminated_cond,
                                      &server->mutex,
-                                     WATCHDOG_DELAY);
+                                     sc_tick_now() + WATCHDOG_DELAY);
     }
     sc_mutex_unlock(&server->mutex);
 

--- a/app/src/util/thread.c
+++ b/app/src/util/thread.c
@@ -123,12 +123,13 @@ sc_cond_wait(sc_cond *cond, sc_mutex *mutex) {
 }
 
 bool
-sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, sc_tick delay) {
-    if (delay < 0) {
+sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, sc_tick deadline) {
+    sc_tick now = sc_tick_now();
+    if (deadline <= now) {
         return false; // timeout
     }
 
-    uint32_t ms = SC_TICK_TO_MS(delay);
+    uint32_t ms = SC_TICK_TO_MS(deadline - now);
     int r = SDL_CondWaitTimeout(cond->cond, mutex->mutex, ms);
 #ifndef NDEBUG
     if (r < 0) {

--- a/app/src/util/thread.c
+++ b/app/src/util/thread.c
@@ -123,7 +123,12 @@ sc_cond_wait(sc_cond *cond, sc_mutex *mutex) {
 }
 
 bool
-sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, uint32_t ms) {
+sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, sc_tick delay) {
+    if (delay < 0) {
+        return false; // timeout
+    }
+
+    uint32_t ms = SC_TICK_TO_MS(delay);
     int r = SDL_CondWaitTimeout(cond->cond, mutex->mutex, ms);
 #ifndef NDEBUG
     if (r < 0) {

--- a/app/src/util/thread.h
+++ b/app/src/util/thread.h
@@ -5,7 +5,8 @@
 
 #include <stdatomic.h>
 #include <stdbool.h>
-#include <stdint.h>
+
+#include "tick.h"
 
 /* Forward declarations */
 typedef struct SDL_Thread SDL_Thread;
@@ -72,7 +73,7 @@ sc_cond_wait(sc_cond *cond, sc_mutex *mutex);
 
 // return true on signaled, false on timeout
 bool
-sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, uint32_t ms);
+sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, sc_tick ms);
 
 void
 sc_cond_signal(sc_cond *cond);

--- a/app/src/util/thread.h
+++ b/app/src/util/thread.h
@@ -73,7 +73,7 @@ sc_cond_wait(sc_cond *cond, sc_mutex *mutex);
 
 // return true on signaled, false on timeout
 bool
-sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, sc_tick ms);
+sc_cond_timedwait(sc_cond *cond, sc_mutex *mutex, sc_tick deadline);
 
 void
 sc_cond_signal(sc_cond *cond);

--- a/app/src/util/tick.c
+++ b/app/src/util/tick.c
@@ -1,0 +1,16 @@
+#include "tick.h"
+
+#include <SDL2/SDL_timer.h>
+
+sc_tick
+sc_tick_now(void) {
+    // SDL_GetTicks() resolution is in milliseconds, but sc_tick are expressed
+    // in microseconds to store PTS without precision loss.
+    //
+    // As an alternative, SDL_GetPerformanceCounter() and
+    // SDL_GetPerformanceFrequency() could be used, but:
+    //  - the conversions (avoiding overflow) are expansive, since the
+    //    frequency is not known at compile time;
+    //  - in practice, we don't need more precision for now.
+    return (sc_tick) SDL_GetTicks() * 1000;
+}

--- a/app/src/util/tick.h
+++ b/app/src/util/tick.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 typedef int64_t sc_tick;
+#define PRItick PRIi64
 #define SC_TICK_FREQ 1000000 // microsecond
 
 // To be adapted if SC_TICK_FREQ changes

--- a/app/src/util/tick.h
+++ b/app/src/util/tick.h
@@ -1,0 +1,20 @@
+#ifndef SC_TICK_H
+#define SC_TICK_H
+
+#include <stdint.h>
+
+typedef int64_t sc_tick;
+#define SC_TICK_FREQ 1000000 // microsecond
+
+// To be adapted if SC_TICK_FREQ changes
+#define SC_TICK_TO_US(tick) (tick)
+#define SC_TICK_TO_MS(tick) ((tick) / 1000)
+#define SC_TICK_TO_SEC(tick) ((tick) / 1000000)
+#define SC_TICK_FROM_US(us) (us)
+#define SC_TICK_FROM_MS(ms) ((ms) * 1000)
+#define SC_TICK_FROM_SEC(sec) ((sec) * 1000000)
+
+sc_tick
+sc_tick_now(void);
+
+#endif

--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -159,7 +159,7 @@ sc_v4l2_sink_open(struct sc_v4l2_sink *vs) {
         .on_new_frame = sc_video_buffer_on_new_frame,
     };
 
-    bool ok = sc_video_buffer_init(&vs->vb, 0, &cbs, vs);
+    bool ok = sc_video_buffer_init(&vs->vb, vs->buffering_time, &cbs, vs);
     if (!ok) {
         LOGE("Could not initialize video buffer");
         return false;
@@ -356,7 +356,7 @@ sc_v4l2_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
 
 bool
 sc_v4l2_sink_init(struct sc_v4l2_sink *vs, const char *device_name,
-                  struct size frame_size) {
+                  struct size frame_size, sc_tick buffering_time) {
     vs->device_name = strdup(device_name);
     if (!vs->device_name) {
         LOGE("Could not strdup v4l2 device name");
@@ -364,6 +364,7 @@ sc_v4l2_sink_init(struct sc_v4l2_sink *vs, const char *device_name,
     }
 
     vs->frame_size = frame_size;
+    vs->buffering_time = buffering_time;
 
     static const struct sc_frame_sink_ops ops = {
         .open = sc_v4l2_frame_sink_open,

--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -124,7 +124,7 @@ run_v4l2_sink(void *data) {
         vs->has_frame = false;
         sc_mutex_unlock(&vs->mutex);
 
-        video_buffer_consume(&vs->vb, vs->frame);
+        sc_video_buffer_consume(&vs->vb, vs->frame);
 
         bool ok = encode_and_write_frame(vs, vs->frame);
         av_frame_unref(vs->frame);
@@ -141,7 +141,7 @@ run_v4l2_sink(void *data) {
 
 static bool
 sc_v4l2_sink_open(struct sc_v4l2_sink *vs) {
-    bool ok = video_buffer_init(&vs->vb);
+    bool ok = sc_video_buffer_init(&vs->vb);
     if (!ok) {
         LOGE("Could not initialize video buffer");
         return false;
@@ -276,7 +276,7 @@ error_cond_destroy:
 error_mutex_destroy:
     sc_mutex_destroy(&vs->mutex);
 error_video_buffer_destroy:
-    video_buffer_destroy(&vs->vb);
+    sc_video_buffer_destroy(&vs->vb);
 
     return false;
 }
@@ -298,13 +298,13 @@ sc_v4l2_sink_close(struct sc_v4l2_sink *vs) {
     avformat_free_context(vs->format_ctx);
     sc_cond_destroy(&vs->cond);
     sc_mutex_destroy(&vs->mutex);
-    video_buffer_destroy(&vs->vb);
+    sc_video_buffer_destroy(&vs->vb);
 }
 
 static bool
 sc_v4l2_sink_push(struct sc_v4l2_sink *vs, const AVFrame *frame) {
     bool previous_skipped;
-    bool ok = video_buffer_push(&vs->vb, frame, &previous_skipped);
+    bool ok = sc_video_buffer_push(&vs->vb, frame, &previous_skipped);
     if (!ok) {
         return false;
     }

--- a/app/src/v4l2_sink.h
+++ b/app/src/v4l2_sink.h
@@ -6,6 +6,7 @@
 #include "coords.h"
 #include "trait/frame_sink.h"
 #include "video_buffer.h"
+#include "util/tick.h"
 
 #include <libavformat/avformat.h>
 
@@ -18,6 +19,7 @@ struct sc_v4l2_sink {
 
     char *device_name;
     struct size frame_size;
+    sc_tick buffering_time;
 
     sc_thread thread;
     sc_mutex mutex;
@@ -32,7 +34,7 @@ struct sc_v4l2_sink {
 
 bool
 sc_v4l2_sink_init(struct sc_v4l2_sink *vs, const char *device_name,
-                  struct size frame_size);
+                  struct size frame_size, sc_tick buffering_time);
 
 void
 sc_v4l2_sink_destroy(struct sc_v4l2_sink *vs);

--- a/app/src/v4l2_sink.h
+++ b/app/src/v4l2_sink.h
@@ -12,7 +12,7 @@
 struct sc_v4l2_sink {
     struct sc_frame_sink frame_sink; // frame sink trait
 
-    struct video_buffer vb;
+    struct sc_video_buffer vb;
     AVFormatContext *format_ctx;
     AVCodecContext *encoder_ctx;
 

--- a/app/src/video_buffer.c
+++ b/app/src/video_buffer.c
@@ -8,81 +8,21 @@
 
 bool
 sc_video_buffer_init(struct sc_video_buffer *vb) {
-    vb->pending_frame = av_frame_alloc();
-    if (!vb->pending_frame) {
-        return false;
-    }
-
-    vb->tmp_frame = av_frame_alloc();
-    if (!vb->tmp_frame) {
-        av_frame_free(&vb->pending_frame);
-        return false;
-    }
-
-    bool ok = sc_mutex_init(&vb->mutex);
-    if (!ok) {
-        av_frame_free(&vb->pending_frame);
-        av_frame_free(&vb->tmp_frame);
-        return false;
-    }
-
-    // there is initially no frame, so consider it has already been consumed
-    vb->pending_frame_consumed = true;
-
-    return true;
+    return sc_frame_buffer_init(&vb->fb);
 }
 
 void
 sc_video_buffer_destroy(struct sc_video_buffer *vb) {
-    sc_mutex_destroy(&vb->mutex);
-    av_frame_free(&vb->pending_frame);
-    av_frame_free(&vb->tmp_frame);
-}
-
-static inline void
-swap_frames(AVFrame **lhs, AVFrame **rhs) {
-    AVFrame *tmp = *lhs;
-    *lhs = *rhs;
-    *rhs = tmp;
+    sc_frame_buffer_destroy(&vb->fb);
 }
 
 bool
 sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame,
                   bool *previous_frame_skipped) {
-    sc_mutex_lock(&vb->mutex);
-
-    // Use a temporary frame to preserve pending_frame in case of error.
-    // tmp_frame is an empty frame, no need to call av_frame_unref() beforehand.
-    int r = av_frame_ref(vb->tmp_frame, frame);
-    if (r) {
-        LOGE("Could not ref frame: %d", r);
-        return false;
-    }
-
-    // Now that av_frame_ref() succeeded, we can replace the previous
-    // pending_frame
-    swap_frames(&vb->pending_frame, &vb->tmp_frame);
-    av_frame_unref(vb->tmp_frame);
-
-    if (previous_frame_skipped) {
-        *previous_frame_skipped = !vb->pending_frame_consumed;
-    }
-    vb->pending_frame_consumed = false;
-
-    sc_mutex_unlock(&vb->mutex);
-
-    return true;
+    return sc_frame_buffer_push(&vb->fb, frame, previous_frame_skipped);
 }
 
 void
 sc_video_buffer_consume(struct sc_video_buffer *vb, AVFrame *dst) {
-    sc_mutex_lock(&vb->mutex);
-    assert(!vb->pending_frame_consumed);
-    vb->pending_frame_consumed = true;
-
-    av_frame_move_ref(dst, vb->pending_frame);
-    // av_frame_move_ref() resets its source frame, so no need to call
-    // av_frame_unref()
-
-    sc_mutex_unlock(&vb->mutex);
+    sc_frame_buffer_consume(&vb->fb, dst);
 }

--- a/app/src/video_buffer.c
+++ b/app/src/video_buffer.c
@@ -1,35 +1,44 @@
 #include "video_buffer.h"
 
 #include <assert.h>
+#include <stdlib.h>
+
 #include <libavutil/avutil.h>
 #include <libavformat/avformat.h>
 
 #include "util/log.h"
 
-bool
-sc_video_buffer_init(struct sc_video_buffer *vb,
-                     const struct sc_video_buffer_callbacks *cbs,
-                     void *cbs_userdata) {
-    bool ok = sc_frame_buffer_init(&vb->fb);
-    if (!ok) {
-        return false;
+static struct sc_video_buffer_frame *
+sc_video_buffer_frame_new(const AVFrame *frame) {
+    struct sc_video_buffer_frame *vb_frame = malloc(sizeof(*vb_frame));
+    if (!vb_frame) {
+        return NULL;
     }
 
-    assert(cbs);
-    assert(cbs->on_new_frame);
+    vb_frame->frame = av_frame_alloc();
+    if (!vb_frame->frame) {
+        free(vb_frame);
+        return NULL;
+    }
 
-    vb->cbs = cbs;
-    vb->cbs_userdata = cbs_userdata;
-    return true;
+    if (av_frame_ref(vb_frame->frame, frame)) {
+        av_frame_free(&vb_frame->frame);
+        free(vb_frame);
+        return NULL;
+    }
+
+    return vb_frame;
 }
 
-void
-sc_video_buffer_destroy(struct sc_video_buffer *vb) {
-    sc_frame_buffer_destroy(&vb->fb);
+static void
+sc_video_buffer_frame_delete(struct sc_video_buffer_frame *vb_frame) {
+    av_frame_unref(vb_frame->frame);
+    av_frame_free(&vb_frame->frame);
+    free(vb_frame);
 }
 
-bool
-sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame) {
+static bool
+sc_video_buffer_offer(struct sc_video_buffer *vb, const AVFrame *frame) {
     bool previous_skipped;
     bool ok = sc_frame_buffer_push(&vb->fb, frame, &previous_skipped);
     if (!ok) {
@@ -37,6 +46,196 @@ sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame) {
     }
 
     vb->cbs->on_new_frame(vb, previous_skipped, vb->cbs_userdata);
+    return true;
+}
+
+static int
+run_buffering(void *data) {
+    struct sc_video_buffer *vb = data;
+
+    assert(vb->buffering_time > 0);
+
+    for (;;) {
+        sc_mutex_lock(&vb->b.mutex);
+
+        while (!vb->b.stopped && sc_queue_is_empty(&vb->b.queue)) {
+            sc_cond_wait(&vb->b.queue_cond, &vb->b.mutex);
+        }
+
+        if (vb->b.stopped) {
+            sc_mutex_unlock(&vb->b.mutex);
+            goto stopped;
+        }
+
+        struct sc_video_buffer_frame *vb_frame;
+        sc_queue_take(&vb->b.queue, next, &vb_frame);
+
+        sc_tick max_deadline = sc_tick_now() + vb->buffering_time;
+        // PTS (written by the server) are expressed in microseconds
+        sc_tick pts = SC_TICK_TO_US(vb_frame->frame->pts);
+
+        bool timed_out = false;
+        while (!vb->b.stopped && !timed_out) {
+            sc_tick deadline = sc_clock_to_system_time(&vb->b.clock, pts)
+                             + vb->buffering_time;
+            if (deadline > max_deadline) {
+                deadline = max_deadline;
+            }
+
+            timed_out =
+                !sc_cond_timedwait(&vb->b.wait_cond, &vb->b.mutex, deadline);
+        }
+
+        if (vb->b.stopped) {
+            sc_video_buffer_frame_delete(vb_frame);
+            sc_mutex_unlock(&vb->b.mutex);
+            goto stopped;
+        }
+
+        sc_mutex_unlock(&vb->b.mutex);
+
+        sc_video_buffer_offer(vb, vb_frame->frame);
+
+        sc_video_buffer_frame_delete(vb_frame);
+    }
+
+stopped:
+    // Flush queue
+    while (!sc_queue_is_empty(&vb->b.queue)) {
+        struct sc_video_buffer_frame *vb_frame;
+        sc_queue_take(&vb->b.queue, next, &vb_frame);
+        sc_video_buffer_frame_delete(vb_frame);
+    }
+
+    LOGD("Buffering thread ended");
+
+    return 0;
+}
+
+bool
+sc_video_buffer_init(struct sc_video_buffer *vb, sc_tick buffering_time,
+                     const struct sc_video_buffer_callbacks *cbs,
+                     void *cbs_userdata) {
+    bool ok = sc_frame_buffer_init(&vb->fb);
+    if (!ok) {
+        return false;
+    }
+
+    assert(buffering_time >= 0);
+    if (buffering_time) {
+        ok = sc_mutex_init(&vb->b.mutex);
+        if (!ok) {
+            LOGC("Could not create mutex");
+            sc_frame_buffer_destroy(&vb->fb);
+            return false;
+        }
+
+        ok = sc_cond_init(&vb->b.queue_cond);
+        if (!ok) {
+            LOGC("Could not create cond");
+            sc_mutex_destroy(&vb->b.mutex);
+            sc_frame_buffer_destroy(&vb->fb);
+            return false;
+        }
+
+        ok = sc_cond_init(&vb->b.wait_cond);
+        if (!ok) {
+            LOGC("Could not create wait cond");
+            sc_cond_destroy(&vb->b.queue_cond);
+            sc_mutex_destroy(&vb->b.mutex);
+            sc_frame_buffer_destroy(&vb->fb);
+            return false;
+        }
+
+        sc_clock_init(&vb->b.clock);
+        sc_queue_init(&vb->b.queue);
+    }
+
+    assert(cbs);
+    assert(cbs->on_new_frame);
+
+    vb->buffering_time = buffering_time;
+    vb->cbs = cbs;
+    vb->cbs_userdata = cbs_userdata;
+    return true;
+}
+
+bool
+sc_video_buffer_start(struct sc_video_buffer *vb) {
+    if (vb->buffering_time) {
+        bool ok =
+            sc_thread_create(&vb->b.thread, run_buffering, "buffering", vb);
+        if (!ok) {
+            LOGE("Could not start buffering thread");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void
+sc_video_buffer_stop(struct sc_video_buffer *vb) {
+    if (vb->buffering_time) {
+        sc_mutex_lock(&vb->b.mutex);
+        vb->b.stopped = true;
+        sc_cond_signal(&vb->b.queue_cond);
+        sc_cond_signal(&vb->b.wait_cond);
+        sc_mutex_unlock(&vb->b.mutex);
+    }
+}
+
+void
+sc_video_buffer_join(struct sc_video_buffer *vb) {
+    if (vb->buffering_time) {
+        sc_thread_join(&vb->b.thread, NULL);
+    }
+}
+
+void
+sc_video_buffer_destroy(struct sc_video_buffer *vb) {
+    sc_frame_buffer_destroy(&vb->fb);
+    if (vb->buffering_time) {
+        sc_cond_destroy(&vb->b.wait_cond);
+        sc_cond_destroy(&vb->b.queue_cond);
+        sc_mutex_destroy(&vb->b.mutex);
+    }
+}
+
+bool
+sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame) {
+    if (!vb->buffering_time) {
+        // No buffering
+        return sc_video_buffer_offer(vb, frame);
+    }
+
+    sc_mutex_lock(&vb->b.mutex);
+
+    sc_tick pts = SC_TICK_FROM_US(frame->pts);
+    sc_clock_update(&vb->b.clock, sc_tick_now(), pts);
+    sc_cond_signal(&vb->b.wait_cond);
+
+    if (vb->b.clock.count == 1) {
+        sc_mutex_unlock(&vb->b.mutex);
+        // First frame, offer it immediately, for two reasons:
+        //  - not to delay the opening of the scrcpy window
+        //  - the buffering estimation needs at least two clock points, so it
+        //  could not handle the first frame
+        return sc_video_buffer_offer(vb, frame);
+    }
+
+    struct sc_video_buffer_frame *vb_frame = sc_video_buffer_frame_new(frame);
+    if (!vb_frame) {
+        sc_mutex_unlock(&vb->b.mutex);
+        LOGE("Could not allocate frame");
+        return false;
+    }
+
+    sc_queue_push(&vb->b.queue, next, vb_frame);
+    sc_cond_signal(&vb->b.queue_cond);
+
+    sc_mutex_unlock(&vb->b.mutex);
+
     return true;
 }
 

--- a/app/src/video_buffer.c
+++ b/app/src/video_buffer.c
@@ -7,7 +7,7 @@
 #include "util/log.h"
 
 bool
-video_buffer_init(struct video_buffer *vb) {
+sc_video_buffer_init(struct sc_video_buffer *vb) {
     vb->pending_frame = av_frame_alloc();
     if (!vb->pending_frame) {
         return false;
@@ -33,7 +33,7 @@ video_buffer_init(struct video_buffer *vb) {
 }
 
 void
-video_buffer_destroy(struct video_buffer *vb) {
+sc_video_buffer_destroy(struct sc_video_buffer *vb) {
     sc_mutex_destroy(&vb->mutex);
     av_frame_free(&vb->pending_frame);
     av_frame_free(&vb->tmp_frame);
@@ -47,7 +47,7 @@ swap_frames(AVFrame **lhs, AVFrame **rhs) {
 }
 
 bool
-video_buffer_push(struct video_buffer *vb, const AVFrame *frame,
+sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame,
                   bool *previous_frame_skipped) {
     sc_mutex_lock(&vb->mutex);
 
@@ -75,7 +75,7 @@ video_buffer_push(struct video_buffer *vb, const AVFrame *frame,
 }
 
 void
-video_buffer_consume(struct video_buffer *vb, AVFrame *dst) {
+sc_video_buffer_consume(struct sc_video_buffer *vb, AVFrame *dst) {
     sc_mutex_lock(&vb->mutex);
     assert(!vb->pending_frame_consumed);
     vb->pending_frame_consumed = true;

--- a/app/src/video_buffer.c
+++ b/app/src/video_buffer.c
@@ -8,6 +8,8 @@
 
 #include "util/log.h"
 
+#define SC_BUFFERING_NDEBUG // comment to debug
+
 static struct sc_video_buffer_frame *
 sc_video_buffer_frame_new(const AVFrame *frame) {
     struct sc_video_buffer_frame *vb_frame = malloc(sizeof(*vb_frame));
@@ -93,6 +95,11 @@ run_buffering(void *data) {
         }
 
         sc_mutex_unlock(&vb->b.mutex);
+
+#ifndef SC_BUFFERING_NDEBUG
+        LOGD("Buffering: %" PRItick ";%" PRItick ";%" PRItick,
+             pts, vb_frame->push_date, sc_tick_now());
+#endif
 
         sc_video_buffer_offer(vb, vb_frame->frame);
 
@@ -231,6 +238,9 @@ sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame) {
         return false;
     }
 
+#ifndef SC_BUFFERING_NDEBUG
+    vb_frame->push_date = sc_tick_now();
+#endif
     sc_queue_push(&vb->b.queue, next, vb_frame);
     sc_cond_signal(&vb->b.queue_cond);
 

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -12,17 +12,26 @@ typedef struct AVFrame AVFrame;
 
 struct sc_video_buffer {
     struct sc_frame_buffer fb;
+
+    const struct sc_video_buffer_callbacks *cbs;
+    void *cbs_userdata;
+};
+
+struct sc_video_buffer_callbacks {
+    void (*on_new_frame)(struct sc_video_buffer *vb, bool previous_skipped,
+                         void *userdata);
 };
 
 bool
-sc_video_buffer_init(struct sc_video_buffer *vb);
+sc_video_buffer_init(struct sc_video_buffer *vb,
+                     const struct sc_video_buffer_callbacks *cbs,
+                     void *cbs_userdata);
 
 void
 sc_video_buffer_destroy(struct sc_video_buffer *vb);
 
 bool
-sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame,
-                     bool *skipped);
+sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame);
 
 void
 sc_video_buffer_consume(struct sc_video_buffer *vb, AVFrame *dst);

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -5,27 +5,13 @@
 
 #include <stdbool.h>
 
-#include "util/thread.h"
+#include "frame_buffer.h"
 
 // forward declarations
 typedef struct AVFrame AVFrame;
 
-/**
- * A video buffer holds 1 pending frame, which is the last frame received from
- * the producer (typically, the decoder).
- *
- * If a pending frame has not been consumed when the producer pushes a new
- * frame, then it is lost. The intent is to always provide access to the very
- * last frame to minimize latency.
- */
-
 struct sc_video_buffer {
-    AVFrame *pending_frame;
-    AVFrame *tmp_frame; // To preserve the pending frame on error
-
-    sc_mutex mutex;
-
-    bool pending_frame_consumed;
+    struct sc_frame_buffer fb;
 };
 
 bool

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -1,5 +1,5 @@
-#ifndef VIDEO_BUFFER_H
-#define VIDEO_BUFFER_H
+#ifndef SC_VIDEO_BUFFER_H
+#define SC_VIDEO_BUFFER_H
 
 #include "common.h"
 
@@ -19,7 +19,7 @@ typedef struct AVFrame AVFrame;
  * last frame to minimize latency.
  */
 
-struct video_buffer {
+struct sc_video_buffer {
     AVFrame *pending_frame;
     AVFrame *tmp_frame; // To preserve the pending frame on error
 
@@ -29,15 +29,16 @@ struct video_buffer {
 };
 
 bool
-video_buffer_init(struct video_buffer *vb);
+sc_video_buffer_init(struct sc_video_buffer *vb);
 
 void
-video_buffer_destroy(struct video_buffer *vb);
+sc_video_buffer_destroy(struct sc_video_buffer *vb);
 
 bool
-video_buffer_push(struct video_buffer *vb, const AVFrame *frame, bool *skipped);
+sc_video_buffer_push(struct sc_video_buffer *vb, const AVFrame *frame,
+                     bool *skipped);
 
 void
-video_buffer_consume(struct video_buffer *vb, AVFrame *dst);
+sc_video_buffer_consume(struct sc_video_buffer *vb, AVFrame *dst);
 
 #endif

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -17,6 +17,9 @@ typedef struct AVFrame AVFrame;
 struct sc_video_buffer_frame {
     AVFrame *frame;
     struct sc_video_buffer_frame *next;
+#ifndef NDEBUG
+    sc_tick push_date;
+#endif
 };
 
 struct sc_video_buffer_frame_queue SC_QUEUE(struct sc_video_buffer_frame);

--- a/app/src/video_buffer.h
+++ b/app/src/video_buffer.h
@@ -5,13 +5,38 @@
 
 #include <stdbool.h>
 
+#include "clock.h"
 #include "frame_buffer.h"
+#include "util/queue.h"
+#include "util/thread.h"
+#include "util/tick.h"
 
 // forward declarations
 typedef struct AVFrame AVFrame;
 
+struct sc_video_buffer_frame {
+    AVFrame *frame;
+    struct sc_video_buffer_frame *next;
+};
+
+struct sc_video_buffer_frame_queue SC_QUEUE(struct sc_video_buffer_frame);
+
 struct sc_video_buffer {
     struct sc_frame_buffer fb;
+
+    sc_tick buffering_time;
+
+    // only if buffering_time > 0
+    struct {
+        sc_thread thread;
+        sc_mutex mutex;
+        sc_cond queue_cond;
+        sc_cond wait_cond;
+
+        struct sc_clock clock;
+        struct sc_video_buffer_frame_queue queue;
+        bool stopped;
+    } b; // buffering
 
     const struct sc_video_buffer_callbacks *cbs;
     void *cbs_userdata;
@@ -23,9 +48,18 @@ struct sc_video_buffer_callbacks {
 };
 
 bool
-sc_video_buffer_init(struct sc_video_buffer *vb,
+sc_video_buffer_init(struct sc_video_buffer *vb, sc_tick buffering_time,
                      const struct sc_video_buffer_callbacks *cbs,
                      void *cbs_userdata);
+
+bool
+sc_video_buffer_start(struct sc_video_buffer *vb);
+
+void
+sc_video_buffer_stop(struct sc_video_buffer *vb);
+
+void
+sc_video_buffer_join(struct sc_video_buffer *vb);
 
 void
 sc_video_buffer_destroy(struct sc_video_buffer *vb);

--- a/app/tests/test_clock.c
+++ b/app/tests/test_clock.c
@@ -1,0 +1,79 @@
+#include "common.h"
+
+#include <assert.h>
+
+#include "clock.h"
+
+void test_small_rolling_sum(void) {
+    struct sc_clock clock;
+    sc_clock_init(&clock);
+
+    assert(clock.count == 0);
+    assert(clock.left_sum.system == 0);
+    assert(clock.left_sum.stream == 0);
+    assert(clock.right_sum.system == 0);
+    assert(clock.right_sum.stream == 0);
+
+    sc_clock_update(&clock, 2, 3);
+    assert(clock.count == 1);
+    assert(clock.left_sum.system == 0);
+    assert(clock.left_sum.stream == 0);
+    assert(clock.right_sum.system == 2);
+    assert(clock.right_sum.stream == 3);
+
+    sc_clock_update(&clock, 10, 20);
+    assert(clock.count == 2);
+    assert(clock.left_sum.system == 2);
+    assert(clock.left_sum.stream == 3);
+    assert(clock.right_sum.system == 10);
+    assert(clock.right_sum.stream == 20);
+
+    sc_clock_update(&clock, 40, 80);
+    assert(clock.count == 3);
+    assert(clock.left_sum.system == 2);
+    assert(clock.left_sum.stream == 3);
+    assert(clock.right_sum.system == 50);
+    assert(clock.right_sum.stream == 100);
+
+    sc_clock_update(&clock, 400, 800);
+    assert(clock.count == 4);
+    assert(clock.left_sum.system == 12);
+    assert(clock.left_sum.stream == 23);
+    assert(clock.right_sum.system == 440);
+    assert(clock.right_sum.stream == 880);
+}
+
+void test_large_rolling_sum(void) {
+    const unsigned half_range = SC_CLOCK_RANGE / 2;
+
+    struct sc_clock clock1;
+    sc_clock_init(&clock1);
+    for (unsigned i = 0; i < 5 * half_range; ++i) {
+        sc_clock_update(&clock1, i, 2 * i + 1);
+    }
+
+    struct sc_clock clock2;
+    sc_clock_init(&clock2);
+    for (unsigned i = 3 * half_range; i < 5 * half_range; ++i) {
+        sc_clock_update(&clock2, i, 2 * i + 1);
+    }
+
+    assert(clock1.count == SC_CLOCK_RANGE);
+    assert(clock2.count == SC_CLOCK_RANGE);
+
+    // The values before the last SC_CLOCK_RANGE points in clock1 should have
+    // no impact
+    assert(clock1.left_sum.system == clock2.left_sum.system);
+    assert(clock1.left_sum.stream == clock2.left_sum.stream);
+    assert(clock1.right_sum.system == clock2.right_sum.system);
+    assert(clock1.right_sum.stream == clock2.right_sum.stream);
+}
+
+int main(int argc, char *argv[]) {
+    (void) argc;
+    (void) argv;
+
+    test_small_rolling_sum();
+    test_large_rolling_sum();
+    return 0;
+};


### PR DESCRIPTION
To minimize latency, scrcpy always displays a frame as soon as it is available, without waiting. This design decision is (on purpose) at the cost of jitter: the delay between frames is not constant.

In an ideal world, every frame produced by the device would be displayed some constant time later on the device (for simplicity, the schema assumes a constant framerate):

![nojitter](https://user-images.githubusercontent.com/543275/124643682-a5e7fb00-de91-11eb-9101-874a34124b2f.png)

However, in reality, the delay is not constant; the encoding time, transfer time and decoding time may vary from frame to frame:

![jitter](https://user-images.githubusercontent.com/543275/124643679-a5e7fb00-de91-11eb-9663-9c4f9ff65c11.png)

In practice, this is not a problem for many real-time use cases. It is slightly noticeable when playing a video on the device (or anything involving regular movement) while mirroring.

On recording (`--record`), scrcpy captures the timestamps on the device and write them in the resulting file, so that the playback is correct without jitter.

However, some real-time use cases might benefit from adding a small latency to compensate for jitter too. For example, few tens of seconds of latency for live-streaming are not important, but jitter is noticeable.

To support this, the principle is to delay the frames to compensate for jitter (notice how the blue circles have the same spacing as the green circles):

![buffering](https://user-images.githubusercontent.com/543275/124643677-a54f6480-de91-11eb-9152-dc76d6e54e60.png)


This PR implements optional buffering:

```bash
scrcpy --display-buffer=50  # add 50 ms buffering for display
scrcpy --v4l2-buffer=500    # add 500 ms buffering for v4l2 sink
```

Display buffering and [v4l2](https://github.com/Genymobile/scrcpy#v4l2loopback) are independent, so that it is possible for example to control it with minimal delay but stream it with a larger delay.

In practice, here is a graph showing the difference in smoothness (after a small initialization phase) with a buffer of 50ms on a wireless connection:

![capture_graph3](https://user-images.githubusercontent.com/543275/125527579-dc506790-51c5-4af2-a87e-41fd86b5a280.png)
([graph_old_impl](https://user-images.githubusercontent.com/543275/124667050-29641500-deaf-11eb-8796-6e2403c2bceb.png))

Fixes #2417