### PR TITLE
 Upgrade SDL (2.0.16) for Windows

### DIFF
--- a/cross_win32.txt
+++ b/cross_win32.txt
@@ -17,4 +17,4 @@ endian = 'little'
 [properties]
 prebuilt_ffmpeg_shared = 'ffmpeg-4.3.1-win32-shared'
 prebuilt_ffmpeg_dev = 'ffmpeg-4.3.1-win32-dev'
-prebuilt_sdl2 = 'SDL2-2.0.14/i686-w64-mingw32'
+prebuilt_sdl2 = 'SDL2-2.0.16/i686-w64-mingw32'

--- a/cross_win64.txt
+++ b/cross_win64.txt
@@ -17,4 +17,4 @@ endian = 'little'
 [properties]
 prebuilt_ffmpeg_shared = 'ffmpeg-4.3.1-win64-shared'
 prebuilt_ffmpeg_dev = 'ffmpeg-4.3.1-win64-dev'
-prebuilt_sdl2 = 'SDL2-2.0.14/x86_64-w64-mingw32'
+prebuilt_sdl2 = 'SDL2-2.0.16/x86_64-w64-mingw32'

--- a/prebuilt-deps/Makefile
+++ b/prebuilt-deps/Makefile
@@ -30,9 +30,9 @@ prepare-ffmpeg-dev-win64:
 		ffmpeg-4.3.1-win64-dev
 
 prepare-sdl2:
-	@./prepare-dep https://libsdl.org/release/SDL2-devel-2.0.14-mingw.tar.gz \
-		405eaff3eb18f2e08fe669ef9e63bc9a8710b7d343756f238619761e9b60407d \
-		SDL2-2.0.14
+	@./prepare-dep https://libsdl.org/release/SDL2-devel-2.0.16-mingw.tar.gz \
+		2bfe48628aa9635c12eac7d421907e291525de1d0b04b3bca4a5bd6e6c881a6f \
+		SDL2-2.0.16
 
 prepare-adb:
 	@./prepare-dep https://dl.google.com/android/repository/platform-tools_r31.0.2-windows.zip \

--- a/release.mk
+++ b/release.mk
@@ -102,7 +102,7 @@ dist-win32: build-server build-win32
 	cp prebuilt-deps/platform-tools/adb.exe "$(DIST)/$(WIN32_TARGET_DIR)/"
 	cp prebuilt-deps/platform-tools/AdbWinApi.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
 	cp prebuilt-deps/platform-tools/AdbWinUsbApi.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp prebuilt-deps/SDL2-2.0.14/i686-w64-mingw32/bin/SDL2.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
+	cp prebuilt-deps/SDL2-2.0.16/i686-w64-mingw32/bin/SDL2.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
 
 dist-win64: build-server build-win64
 	mkdir -p "$(DIST)/$(WIN64_TARGET_DIR)"
@@ -118,7 +118,7 @@ dist-win64: build-server build-win64
 	cp prebuilt-deps/platform-tools/adb.exe "$(DIST)/$(WIN64_TARGET_DIR)/"
 	cp prebuilt-deps/platform-tools/AdbWinApi.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
 	cp prebuilt-deps/platform-tools/AdbWinUsbApi.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp prebuilt-deps/SDL2-2.0.14/x86_64-w64-mingw32/bin/SDL2.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
+	cp prebuilt-deps/SDL2-2.0.16/x86_64-w64-mingw32/bin/SDL2.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
 
 zip-win32: dist-win32
 	cd "$(DIST)/$(WIN32_TARGET_DIR)"; \


### PR DESCRIPTION
Include the latest version of SDL in Windows releases.