### PR TITLE
fix 'Could not found v4l2 muxer' on linux

### DIFF
--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -21,7 +21,7 @@ find_muxer(const char *name) {
         oformat = av_oformat_next(oformat);
 #endif
         // until null or containing the requested name
-    } while (oformat && !strlist_contains(oformat->name, ',', name));
+    } while (oformat && !strlist_contains(name, ',', oformat->name));
     return oformat;
 }
 


### PR DESCRIPTION
on ubuntu 20.04, test scrcpy with v4l2, it can't work

```
$ ./run x --v4l2-sink /dev/video2 -N
INFO: Video orientation is locked for v4l2 sink. See --lock-video-orientation.
INFO: scrcpy 1.19 <https://github.com/Genymobile/scrcpy>
x/server/scrcpy-server: 1 file pushed, 0 skipped. 9.7 MB/s (37330 bytes in 0.004s)
[server] INFO: Device: HUAWEI NOH-AN00 (Android 10)
ERROR: Could not find v4l2 muxer
ERROR: Could not open frame sink 0
ERROR: Could not open decoder sinks
ERROR: Could not open packet sink 0
ERROR: Could not open stream sinks
WARN: Device disconnected
WARN: Killing the server...
```