### PR TITLE
Mark sockets as non-inheritable on Windows

### DIFF
--- a/app/src/sys/win/process.c
+++ b/app/src/sys/win/process.c
@@ -26,6 +26,8 @@ sc_process_execute_p(const char *const argv[], HANDLE *handle,
                      HANDLE *pin, HANDLE *pout, HANDLE *perr) {
     enum sc_process_result ret = SC_PROCESS_ERROR_GENERIC;
 
+    bool inherit_handles = pin || pout || perr;
+
     SECURITY_ATTRIBUTES sa;
     sa.nLength = sizeof(SECURITY_ATTRIBUTES);
     sa.lpSecurityDescriptor = NULL;
@@ -69,7 +71,7 @@ sc_process_execute_p(const char *const argv[], HANDLE *handle,
     PROCESS_INFORMATION pi;
     memset(&si, 0, sizeof(si));
     si.cb = sizeof(si);
-    if (pin || pout || perr) {
+    if (inherit_handles) {
         si.dwFlags = STARTF_USESTDHANDLES;
         if (pin) {
             si.hStdInput = stdin_read_handle;
@@ -95,8 +97,8 @@ sc_process_execute_p(const char *const argv[], HANDLE *handle,
         goto error_close_stderr;
     }
 
-    if (!CreateProcessW(NULL, wide, NULL, NULL, TRUE, 0, NULL, NULL, &si,
-                        &pi)) {
+    if (!CreateProcessW(NULL, wide, NULL, NULL, inherit_handles, 0, NULL, NULL,
+                        &si, &pi)) {
         free(wide);
         *handle = NULL;
 


### PR DESCRIPTION
To be able to communicate with a child process via stdin, stdout and
stderr, the CreateProcess() parameter bInheritHandles must be set to
TRUE. But this causes *all* handles to be inherited, including sockets.
    
One possibility could be to use an extended API to set extra attributes
on process creation:
 - <https://stackoverflow.com/a/28185363/1987178>
 - <https://devblogs.microsoft.com/oldnewthing/20111216-00/?p=8873>

But it seems that this API is not available on MinGW (it does not
compile).
    
As an alternative, explicitly mark all sockets as non-inheritable.

Fixes #2779

---

Replace these binaries in your v1.20 release:
 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2779/2/scrcpy.exe) _sha256:6ab57110d07088e0793c1e1a8d2caabdc5811ade54bfeb5646778f6563cd7169_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2779/2/scrcpy-server) _sha256:b20aee4951f99b060c4a44000ba94de973f9604758ef62beb253b371aad3df34_