### PR TITLE
Fix wrong package name for libusb dev in BUILD.md

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -15,7 +15,7 @@ First, you need to install the required packages:
 sudo apt install ffmpeg libsdl2-2.0-0 adb wget \
                  gcc git pkg-config meson ninja-build libsdl2-dev \
                  libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev \
-                 libusb-1.0-0 libusb-dev
+                 libusb-1.0-0 libusb-1.0-0-dev
 ```
 
 Then clone the repo and execute the installation script


### PR DESCRIPTION
Fix wrong package to install for Ubuntu/Debian

Without it I was getting:
```
Run-time dependency libusb-1.0 found: NO (tried pkgconfig and cmake)

app/meson.build:88:8: ERROR: Dependency "libusb-1.0" not found, tried pkgconfig and cmake
```