### PR TITLE
Read/write settings via command on Android >= 12

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -1,6 +1,5 @@
 package com.genymobile.scrcpy;
 
-import com.genymobile.scrcpy.wrappers.ContentProvider;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
 import android.os.Parcel;
@@ -166,15 +165,14 @@ public final class CleanUp {
 
         if (config.disableShowTouches || config.restoreStayOn != -1) {
             ServiceManager serviceManager = new ServiceManager();
-            try (ContentProvider settings = serviceManager.getActivityManager().createSettingsProvider()) {
-                if (config.disableShowTouches) {
-                    Ln.i("Disabling \"show touches\"");
-                    settings.putValue(ContentProvider.TABLE_SYSTEM, "show_touches", "0");
-                }
-                if (config.restoreStayOn != -1) {
-                    Ln.i("Restoring \"stay awake\"");
-                    settings.putValue(ContentProvider.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(config.restoreStayOn));
-                }
+            Settings settings = new Settings(serviceManager);
+            if (config.disableShowTouches) {
+                Ln.i("Disabling \"show touches\"");
+                settings.putValue(Settings.TABLE_SYSTEM, "show_touches", "0");
+            }
+            if (config.restoreStayOn != -1) {
+                Ln.i("Restoring \"stay awake\"");
+                settings.putValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(config.restoreStayOn));
             }
         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -168,11 +168,19 @@ public final class CleanUp {
             Settings settings = new Settings(serviceManager);
             if (config.disableShowTouches) {
                 Ln.i("Disabling \"show touches\"");
-                settings.putValue(Settings.TABLE_SYSTEM, "show_touches", "0");
+                try {
+                    settings.putValue(Settings.TABLE_SYSTEM, "show_touches", "0");
+                } catch (SettingsException e) {
+                    Ln.e("Could not restore \"show_touches\"", e);
+                }
             }
             if (config.restoreStayOn != -1) {
                 Ln.i("Restoring \"stay awake\"");
-                settings.putValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(config.restoreStayOn));
+                try {
+                    settings.putValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(config.restoreStayOn));
+                } catch (SettingsException e) {
+                    Ln.e("Could not restore \"stay_on_while_plugged_in\"", e);
+                }
             }
         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/Command.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Command.java
@@ -1,0 +1,33 @@
+package com.genymobile.scrcpy;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Scanner;
+
+public final class Command {
+    private Command() {
+        // not instantiable
+    }
+
+    public static void exec(String... cmd) throws IOException, InterruptedException {
+        Process process = Runtime.getRuntime().exec(cmd);
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IOException("Command " + Arrays.toString(cmd) + " returned with value " + exitCode);
+        }
+    }
+
+    public static String execReadLine(String... cmd) throws IOException, InterruptedException {
+        String result = null;
+        Process process = Runtime.getRuntime().exec(cmd);
+        Scanner scanner = new Scanner(process.getInputStream());
+        if (scanner.hasNextLine()) {
+            result = scanner.nextLine();
+        }
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IOException("Command " + Arrays.toString(cmd) + " returned with value " + exitCode);
+        }
+        return result;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -1,7 +1,6 @@
 package com.genymobile.scrcpy;
 
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
-import com.genymobile.scrcpy.wrappers.ContentProvider;
 import com.genymobile.scrcpy.wrappers.InputManager;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
@@ -29,6 +28,7 @@ public final class Device {
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
 
     private static final ServiceManager SERVICE_MANAGER = new ServiceManager();
+    private static final Settings SETTINGS = new Settings(SERVICE_MANAGER);
 
     public interface RotationListener {
         void onRotationChanged(int rotation);
@@ -296,7 +296,7 @@ public final class Device {
         }
     }
 
-    public static ContentProvider createSettingsProvider() {
-        return SERVICE_MANAGER.getActivityManager().createSettingsProvider();
+    public static Settings getSettings() {
+        return SETTINGS;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Ln.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Ln.java
@@ -57,11 +57,18 @@ public final class Ln {
         }
     }
 
-    public static void w(String message) {
+    public static void w(String message, Throwable throwable) {
         if (isEnabled(Level.WARN)) {
-            Log.w(TAG, message);
+            Log.w(TAG, message, throwable);
             System.out.println(PREFIX + "WARN: " + message);
+            if (throwable != null) {
+                throwable.printStackTrace();
+            }
         }
+    }
+
+    public static void w(String message) {
+        w(message, null);
     }
 
     public static void e(String message, Throwable throwable) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -63,7 +63,7 @@ public final class Server {
         final Device device = new Device(options);
         List<CodecOption> codecOptions = CodecOption.parse(options.getCodecOptions());
 
-        initAndCleanUp(options);
+        Thread initThread = startInitThread(options);
 
         boolean tunnelForward = options.isTunnelForward();
 
@@ -95,6 +95,7 @@ public final class Server {
                 // this is expected on close
                 Ln.d("Screen streaming stopped");
             } finally {
+                initThread.interrupt();
                 if (controllerThread != null) {
                     controllerThread.interrupt();
                 }
@@ -103,6 +104,17 @@ public final class Server {
                 }
             }
         }
+    }
+
+    private static Thread startInitThread(final Options options) {
+        Thread thread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                initAndCleanUp(options);
+            }
+        });
+        thread.start();
+        return thread;
     }
 
     private static Thread startController(final Controller controller) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -17,11 +17,7 @@ public final class Server {
         // not instantiable
     }
 
-    private static void scrcpy(Options options) throws IOException {
-        Ln.i("Device: " + Build.MANUFACTURER + " " + Build.MODEL + " (Android " + Build.VERSION.RELEASE + ")");
-        final Device device = new Device(options);
-        List<CodecOption> codecOptions = CodecOption.parse(options.getCodecOptions());
-
+    private static void initAndCleanUp(Options options) throws IOException {
         boolean mustDisableShowTouchesOnCleanUp = false;
         int restoreStayOn = -1;
         if (options.getShowTouches() || options.getStayAwake()) {
@@ -56,6 +52,14 @@ public final class Server {
         }
 
         CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, true, options.getPowerOffScreenOnClose());
+    }
+
+    private static void scrcpy(Options options) throws IOException {
+        Ln.i("Device: " + Build.MANUFACTURER + " " + Build.MODEL + " (Android " + Build.VERSION.RELEASE + ")");
+        final Device device = new Device(options);
+        List<CodecOption> codecOptions = CodecOption.parse(options.getCodecOptions());
+
+        initAndCleanUp(options);
 
         boolean tunnelForward = options.isTunnelForward();
 

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -1,7 +1,5 @@
 package com.genymobile.scrcpy;
 
-import com.genymobile.scrcpy.wrappers.ContentProvider;
-
 import android.graphics.Rect;
 import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
@@ -27,25 +25,24 @@ public final class Server {
         boolean mustDisableShowTouchesOnCleanUp = false;
         int restoreStayOn = -1;
         if (options.getShowTouches() || options.getStayAwake()) {
-            try (ContentProvider settings = Device.createSettingsProvider()) {
-                if (options.getShowTouches()) {
-                    String oldValue = settings.getAndPutValue(ContentProvider.TABLE_SYSTEM, "show_touches", "1");
-                    // If "show touches" was disabled, it must be disabled back on clean up
-                    mustDisableShowTouchesOnCleanUp = !"1".equals(oldValue);
-                }
+            Settings settings = Device.getSettings();
+            if (options.getShowTouches()) {
+                String oldValue = settings.getAndPutValue(Settings.TABLE_SYSTEM, "show_touches", "1");
+                // If "show touches" was disabled, it must be disabled back on clean up
+                mustDisableShowTouchesOnCleanUp = !"1".equals(oldValue);
+            }
 
-                if (options.getStayAwake()) {
-                    int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB | BatteryManager.BATTERY_PLUGGED_WIRELESS;
-                    String oldValue = settings.getAndPutValue(ContentProvider.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
-                    try {
-                        restoreStayOn = Integer.parseInt(oldValue);
-                        if (restoreStayOn == stayOn) {
-                            // No need to restore
-                            restoreStayOn = -1;
-                        }
-                    } catch (NumberFormatException e) {
-                        restoreStayOn = 0;
+            if (options.getStayAwake()) {
+                int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB | BatteryManager.BATTERY_PLUGGED_WIRELESS;
+                String oldValue = settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
+                try {
+                    restoreStayOn = Integer.parseInt(oldValue);
+                    if (restoreStayOn == stayOn) {
+                        // No need to restore
+                        restoreStayOn = -1;
                     }
+                } catch (NumberFormatException e) {
+                    restoreStayOn = 0;
                 }
             }
         }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -17,7 +17,7 @@ public final class Server {
         // not instantiable
     }
 
-    private static void initAndCleanUp(Options options) throws IOException {
+    private static void initAndCleanUp(Options options) {
         boolean mustDisableShowTouchesOnCleanUp = false;
         int restoreStayOn = -1;
         if (options.getShowTouches() || options.getStayAwake()) {
@@ -51,7 +51,11 @@ public final class Server {
             }
         }
 
-        CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, true, options.getPowerOffScreenOnClose());
+        try {
+            CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, true, options.getPowerOffScreenOnClose());
+        } catch (IOException e) {
+            Ln.e("Could not configure cleanup", e);
+        }
     }
 
     private static void scrcpy(Options options) throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -27,22 +27,30 @@ public final class Server {
         if (options.getShowTouches() || options.getStayAwake()) {
             Settings settings = Device.getSettings();
             if (options.getShowTouches()) {
-                String oldValue = settings.getAndPutValue(Settings.TABLE_SYSTEM, "show_touches", "1");
-                // If "show touches" was disabled, it must be disabled back on clean up
-                mustDisableShowTouchesOnCleanUp = !"1".equals(oldValue);
+                try {
+                    String oldValue = settings.getAndPutValue(Settings.TABLE_SYSTEM, "show_touches", "1");
+                    // If "show touches" was disabled, it must be disabled back on clean up
+                    mustDisableShowTouchesOnCleanUp = !"1".equals(oldValue);
+                } catch (SettingsException e) {
+                    Ln.e("Could not change \"show_touches\"", e);
+                }
             }
 
             if (options.getStayAwake()) {
                 int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB | BatteryManager.BATTERY_PLUGGED_WIRELESS;
-                String oldValue = settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
                 try {
-                    restoreStayOn = Integer.parseInt(oldValue);
-                    if (restoreStayOn == stayOn) {
-                        // No need to restore
-                        restoreStayOn = -1;
+                    String oldValue = settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
+                    try {
+                        restoreStayOn = Integer.parseInt(oldValue);
+                        if (restoreStayOn == stayOn) {
+                            // No need to restore
+                            restoreStayOn = -1;
+                        }
+                    } catch (NumberFormatException e) {
+                        restoreStayOn = 0;
                     }
-                } catch (NumberFormatException e) {
-                    restoreStayOn = 0;
+                } catch (SettingsException e) {
+                    Ln.e("Could not change \"stay_on_while_plugged_in\"", e);
                 }
             }
         }

--- a/server/src/main/java/com/genymobile/scrcpy/Settings.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Settings.java
@@ -1,0 +1,39 @@
+package com.genymobile.scrcpy;
+
+import com.genymobile.scrcpy.wrappers.ContentProvider;
+import com.genymobile.scrcpy.wrappers.ServiceManager;
+
+public class Settings {
+
+    public static final String TABLE_SYSTEM = ContentProvider.TABLE_SYSTEM;
+    public static final String TABLE_SECURE = ContentProvider.TABLE_SECURE;
+    public static final String TABLE_GLOBAL = ContentProvider.TABLE_GLOBAL;
+
+    private final ServiceManager serviceManager;
+
+    public Settings(ServiceManager serviceManager) {
+        this.serviceManager = serviceManager;
+    }
+
+    public String getValue(String table, String key) {
+        try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
+            return provider.getValue(table, key);
+        }
+    }
+
+    public void putValue(String table, String key, String value) {
+        try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
+            provider.putValue(table, key, value);
+        }
+    }
+
+    public String getAndPutValue(String table, String key, String value) {
+        try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
+            String oldValue = provider.getValue(table, key);
+            if (!value.equals(oldValue)) {
+                provider.putValue(table, key, value);
+            }
+            return oldValue;
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/Settings.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Settings.java
@@ -15,19 +15,19 @@ public class Settings {
         this.serviceManager = serviceManager;
     }
 
-    public String getValue(String table, String key) {
+    public String getValue(String table, String key) throws SettingsException {
         try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
             return provider.getValue(table, key);
         }
     }
 
-    public void putValue(String table, String key, String value) {
+    public void putValue(String table, String key, String value) throws SettingsException {
         try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
             provider.putValue(table, key, value);
         }
     }
 
-    public String getAndPutValue(String table, String key, String value) {
+    public String getAndPutValue(String table, String key, String value) throws SettingsException {
         try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
             String oldValue = provider.getValue(table, key);
             if (!value.equals(oldValue)) {

--- a/server/src/main/java/com/genymobile/scrcpy/Settings.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Settings.java
@@ -3,6 +3,10 @@ package com.genymobile.scrcpy;
 import com.genymobile.scrcpy.wrappers.ContentProvider;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
+import android.os.Build;
+
+import java.io.IOException;
+
 public class Settings {
 
     public static final String TABLE_SYSTEM = ContentProvider.TABLE_SYSTEM;
@@ -15,25 +19,66 @@ public class Settings {
         this.serviceManager = serviceManager;
     }
 
-    public String getValue(String table, String key) throws SettingsException {
-        try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
-            return provider.getValue(table, key);
+    private static void execSettingsPut(String table, String key, String value) throws SettingsException {
+        try {
+            Command.exec("settings", "put", table, key, value);
+        } catch (IOException | InterruptedException e) {
+            throw new SettingsException("put", table, key, value, e);
         }
+    }
+
+    private static String execSettingsGet(String table, String key) throws SettingsException {
+        try {
+            return Command.execReadLine("settings", "get", table, key);
+        } catch (IOException | InterruptedException e) {
+            throw new SettingsException("get", table, key, null, e);
+        }
+    }
+
+    public String getValue(String table, String key) throws SettingsException {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+            // on Android >= 12, it always fails: <https://github.com/Genymobile/scrcpy/issues/2788>
+            try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
+                return provider.getValue(table, key);
+            } catch (SettingsException e) {
+                Ln.w("Could not get settings value via ContentProvider, fallback to settings process", e);
+            }
+        }
+
+        return execSettingsGet(table, key);
     }
 
     public void putValue(String table, String key, String value) throws SettingsException {
-        try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
-            provider.putValue(table, key, value);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+            // on Android >= 12, it always fails: <https://github.com/Genymobile/scrcpy/issues/2788>
+            try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
+                provider.putValue(table, key, value);
+            } catch (SettingsException e) {
+                Ln.w("Could not put settings value via ContentProvider, fallback to settings process", e);
+            }
         }
+
+        execSettingsPut(table, key, value);
     }
 
     public String getAndPutValue(String table, String key, String value) throws SettingsException {
-        try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
-            String oldValue = provider.getValue(table, key);
-            if (!value.equals(oldValue)) {
-                provider.putValue(table, key, value);
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+            // on Android >= 12, it always fails: <https://github.com/Genymobile/scrcpy/issues/2788>
+            try (ContentProvider provider = serviceManager.getActivityManager().createSettingsProvider()) {
+                String oldValue = provider.getValue(table, key);
+                if (!value.equals(oldValue)) {
+                    provider.putValue(table, key, value);
+                }
+                return oldValue;
+            } catch (SettingsException e) {
+                Ln.w("Could not get and put settings value via ContentProvider, fallback to settings process", e);
             }
-            return oldValue;
         }
+
+        String oldValue = getValue(table, key);
+        if (!value.equals(oldValue)) {
+             putValue(table, key, value);
+        }
+        return oldValue;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/SettingsException.java
+++ b/server/src/main/java/com/genymobile/scrcpy/SettingsException.java
@@ -1,0 +1,11 @@
+package com.genymobile.scrcpy;
+
+public class SettingsException extends Exception {
+    private static String createMessage(String method, String table, String key, String value) {
+        return "Could not access settings: " + method + " " + table + " " + key + (value != null ? " " + value : "");
+    }
+
+    public SettingsException(String method, String table, String key, String value, Throwable cause) {
+        super(createMessage(method, table, key, value), cause);
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ContentProvider.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ContentProvider.java
@@ -160,12 +160,4 @@ public class ContentProvider implements Closeable {
         arg.putString(NAME_VALUE_TABLE_VALUE, value);
         call(method, key, arg);
     }
-
-    public String getAndPutValue(String table, String key, String value) {
-        String oldValue = getValue(table, key);
-        if (!value.equals(oldValue)) {
-            putValue(table, key, value);
-        }
-        return oldValue;
-    }
 }


### PR DESCRIPTION
Before Android 8, executing the "settings" command from a shell was
very slow (~1 second), because it spawned a new app_process to execute
Java code. Therefore, to access settings without performance issues,
scrcpy used private APIs to read from and write to settings.

However, since Android 12, this is not possible anymore, due to
permissions changes.

To make it work again, execute the "settings" command on Android 12 (or
on previous version if the other method failed). This method is faster
than before Android 8 (~100ms).

Fixes #2671
Fixes #2788

---

Replace these binaries in your v1.20 release:
 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2802/1/scrcpy.exe) _sha256:df6ecfdf3f423fb6303f696934f569e8c03dbfeb69be9d06abeaf85093c63b78_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2802/1/scrcpy-server) _sha256:d6c14fdb94c0a3509da5c850271cb0cdfd7df5c072f605e6c09f0353a590c6c8_