### PR TITLE
Add remote host/port options for use when forwarding.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+UseTab: Never
+TabWidth: 4
+IndentWidth: 4
+AlwaysBreakAfterReturnType: AllDefinitions

--- a/app/meson.build
+++ b/app/meson.build
@@ -137,6 +137,12 @@ foreach f : check_functions
   endif
 endforeach
 
+if host_machine.system() == 'windows' or get_option('crossbuild_windows')
+    # Set the windows version higher than mingw default, needed for inet_pton on windows
+    add_global_arguments('-D_WIN32_WINNT=0x0600', language : 'c')
+	add_global_arguments('-DWINVER=0x0600', language : 'c')
+endif
+
 # the version, updated on release
 conf.set_quoted('SCRCPY_VERSION', meson.project_version())
 

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -19,6 +19,8 @@ const struct scrcpy_options scrcpy_options_default = {
         .first = DEFAULT_LOCAL_PORT_RANGE_FIRST,
         .last = DEFAULT_LOCAL_PORT_RANGE_LAST,
     },
+    .scrcpy_ip = 0,
+    .scrcpy_port = 0,
     .shortcut_mods = {
         .data = {SC_MOD_LALT, SC_MOD_LSUPER},
         .count = 2,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -77,6 +77,8 @@ struct scrcpy_options {
     enum sc_record_format record_format;
     enum sc_keyboard_input_mode keyboard_input_mode;
     struct sc_port_range port_range;
+    uint32_t scrcpy_ip;
+    uint16_t scrcpy_port;
     struct sc_shortcut_mods shortcut_mods;
     uint16_t max_size;
     uint32_t bit_rate;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -345,6 +345,8 @@ scrcpy(struct scrcpy_options *options) {
         .log_level = options->log_level,
         .crop = options->crop,
         .port_range = options->port_range,
+        .scrcpy_ip = options->scrcpy_ip,
+        .scrcpy_port = options->scrcpy_port,
         .max_size = options->max_size,
         .bit_rate = options->bit_rate,
         .max_fps = options->max_fps,

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -29,6 +29,8 @@ struct sc_server_params {
     const char *codec_options;
     const char *encoder_name;
     struct sc_port_range port_range;
+    uint32_t scrcpy_ip;
+    uint16_t scrcpy_port;
     uint16_t max_size;
     uint32_t bit_rate;
     uint16_t max_fps;


### PR DESCRIPTION
Add 2 new options:
--tunnel-host to set the final remote IP address when using --force-adb-forward.
--tunnel-port to set the final remote port  when using --force-adb-forward.

Note that those are different from the forwarding port given through --port(as adb will still forward on that port).
I tried to keep the changes relatively minimal(ie if you don't use the options it will behave as it used to).

I also added a .clang-format file as every C/C++ project should have one.
Another notable change is I forced _WIN32_WINNT and WINVER to 0x0600(from mingw default of 0x0502) through meson to have access to a few more posix inet functions for windows.

Implement https://github.com/Genymobile/scrcpy/issues/2801.