### PR TITLE
Configure feature test macros in meson

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -44,11 +44,19 @@ if host_machine.system() == 'windows'
         'src/sys/win/file.c',
         'src/sys/win/process.c',
     ]
+    add_project_arguments('-D_WIN32_WINNT=0x0600', language: 'c')
+    add_project_arguments('-DWINVER=0x0600', language: 'c')
 else
     src += [
         'src/sys/unix/file.c',
         'src/sys/unix/process.c',
     ]
+    add_project_arguments('-D_POSIX_C_SOURCE=200809L', language: 'c')
+    add_project_arguments('-D_XOPEN_SOURCE=700', language: 'c')
+    add_project_arguments('-D_GNU_SOURCE', language: 'c')
+    if host_machine.system() == 'darwin'
+        add_project_arguments('-D_DARWIN_C_SOURCE', language: 'c')
+    endif
 endif
 
 v4l2_support = host_machine.system() == 'linux'

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -1,13 +1,6 @@
 #ifndef COMPAT_H
 #define COMPAT_H
 
-#define _POSIX_C_SOURCE 200809L
-#define _XOPEN_SOURCE 700
-#define _GNU_SOURCE
-#ifdef __APPLE__
-# define _DARWIN_C_SOURCE
-#endif
-
 #include <libavformat/version.h>
 #include <SDL2/SDL_version.h>
 

--- a/app/src/sys/win/process.c
+++ b/app/src/sys/win/process.c
@@ -1,6 +1,3 @@
-// <https://devblogs.microsoft.com/oldnewthing/20111216-00/?p=8873>
-#define _WIN32_WINNT 0x0600 // For extended process API
-
 #include "util/process.h"
 
 #include <processthreadsapi.h>


### PR DESCRIPTION
Use ~~add_global_arguments() like in PR #2807~~ `add_project_arguments()`.

However, the [documentation](https://mesonbuild.com/Adding-arguments.html) says:

> Compilation tests that are run as part of your project configuration do not use these flags. The reason for that is that you may need to run a test compile with and without a given flag to determine your build setup. For this reason tests do not use these global arguments.

We could like these definitions to be set in tests too. But in practice, they are correctly set on my machine :thinking: 

An alternative could be to add the flags (still from Meson) to the `config.h` generated file. I don't know what is better. Any idea?

@mqiezi Could you confirm that this does not cause a regression for #1960?

cc @RipleyTom