### PR TITLE
Add option to disable clipboard autosync

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,9 @@ of <kbd>Ctrl</kbd>+<kbd>v</kbd> and <kbd>MOD</kbd>+<kbd>v</kbd> so that they
 also inject the computer clipboard text as a sequence of key events (the same
 way as <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd>).
 
+To disable automatic clipboard synchronization, use
+`--no-clipboard-autosync`.
+
 #### Pinch-to-zoom
 
 To simulate "pinch-to-zoom": <kbd>Ctrl</kbd>+_click-and-move_.

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -115,6 +115,12 @@ Limit both the width and height of the video to \fIvalue\fR. The other dimension
 Default is 0 (unlimited).
 
 .TP
+.B \-\-no\-clipboard\-autosync
+By default, scrcpy automatically synchronizes the computer clipboard to the device clipboard before injecting Ctrl+v, and the device clipboard to the computer clipboard whenever it changes.
+
+This option disables this automatic synchronization.
+
+.TP
 .B \-n, \-\-no\-control
 Disable device control (mirror the device in read\-only).
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -49,6 +49,7 @@
 #define OPT_V4L2_BUFFER            1029
 #define OPT_TUNNEL_HOST            1030
 #define OPT_TUNNEL_PORT            1031
+#define OPT_NO_CLIPBOARD_AUTOSYNC  1032
 
 struct sc_option {
     char shortopt;
@@ -207,6 +208,15 @@ static const struct sc_option options[] = {
                 "other dimension is computed so that the device aspect-ratio "
                 "is preserved.\n"
                 "Default is 0 (unlimited).",
+    },
+    {
+        .longopt_id = OPT_NO_CLIPBOARD_AUTOSYNC,
+        .longopt = "no-clipboard-autosync",
+        .text = "By default, scrcpy automatically synchronizes the computer "
+                "clipboard to the device clipboard before injecting Ctrl+v, "
+                "and the device clipboard to the computer clipboard whenever "
+                "it changes.\n"
+                "This option disables this automatic synchronization."
     },
     {
         .shortopt = 'n',
@@ -1363,6 +1373,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 if (!parse_buffering_time(optarg, &opts->display_buffer)) {
                     return false;
                 }
+                break;
+            case OPT_NO_CLIPBOARD_AUTOSYNC:
+                opts->clipboard_autosync = false;
                 break;
 #ifdef HAVE_V4L2
             case OPT_V4L2_SINK:

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -66,6 +66,7 @@ input_manager_init(struct input_manager *im, struct controller *controller,
     im->control = options->control;
     im->forward_all_clicks = options->forward_all_clicks;
     im->legacy_paste = options->legacy_paste;
+    im->clipboard_autosync = options->clipboard_autosync;
 
     const struct sc_shortcut_mods *shortcut_mods = &options->shortcut_mods;
     assert(shortcut_mods->count);
@@ -518,7 +519,7 @@ input_manager_process_key(struct input_manager *im,
 
     uint64_t ack_to_wait = SC_SEQUENCE_INVALID;
     bool is_ctrl_v = ctrl && !shift && keycode == SDLK_v && down && !repeat;
-    if (is_ctrl_v) {
+    if (im->clipboard_autosync && is_ctrl_v) {
         if (im->legacy_paste) {
             // inject the text as input events
             clipboard_paste(controller);

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -24,6 +24,7 @@ struct input_manager {
     bool control;
     bool forward_all_clicks;
     bool legacy_paste;
+    bool clipboard_autosync;
 
     struct {
         unsigned data[SC_MAX_SHORTCUT_MODS];

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -53,4 +53,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .forward_all_clicks = false,
     .legacy_paste = false,
     .power_off_on_close = false,
+    .clipboard_autosync = true,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -108,6 +108,7 @@ struct scrcpy_options {
     bool forward_all_clicks;
     bool legacy_paste;
     bool power_off_on_close;
+    bool clipboard_autosync;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -364,6 +364,7 @@ scrcpy(struct scrcpy_options *options) {
         .encoder_name = options->encoder_name,
         .force_adb_forward = options->force_adb_forward,
         .power_off_on_close = options->power_off_on_close,
+        .clipboard_autosync = options->clipboard_autosync,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -186,6 +186,7 @@ execute_server(struct sc_server *server,
         params->codec_options ? params->codec_options : "-",
         params->encoder_name ? params->encoder_name : "-",
         params->power_off_on_close ? "true" : "false",
+        params->clipboard_autosync ? "true" : "false",
     };
 #ifdef SERVER_DEBUGGER
     LOGI("Server debugger waiting for a client on device port "

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -41,6 +41,7 @@ struct sc_server_params {
     bool stay_awake;
     bool force_adb_forward;
     bool power_off_on_close;
+    bool clipboard_autosync;
 };
 
 struct sc_server {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -82,8 +82,8 @@ public final class Device {
             }
         }, displayId);
 
-        if (options.getControl()) {
-            // If control is enabled, synchronize Android clipboard to the computer automatically
+        if (options.getControl() && options.getClipboardAutosync()) {
+            // If control and autosync are enabled, synchronize Android clipboard to the computer automatically
             ClipboardManager clipboardManager = SERVICE_MANAGER.getClipboardManager();
             if (clipboardManager != null) {
                 clipboardManager.addPrimaryClipChangedListener(new IOnPrimaryClipChangedListener.Stub() {

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -18,6 +18,7 @@ public class Options {
     private String codecOptions;
     private String encoderName;
     private boolean powerOffScreenOnClose;
+    private boolean clipboardAutosync;
 
     public Ln.Level getLogLevel() {
         return logLevel;
@@ -137,5 +138,13 @@ public class Options {
 
     public boolean getPowerOffScreenOnClose() {
         return this.powerOffScreenOnClose;
+    }
+
+    public boolean getClipboardAutosync() {
+        return clipboardAutosync;
+    }
+
+    public void setClipboardAutosync(boolean clipboardAutosync) {
+        this.clipboardAutosync = clipboardAutosync;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -160,7 +160,7 @@ public final class Server {
                     "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "(" + clientVersion + ")");
         }
 
-        final int expectedParameters = 16;
+        final int expectedParameters = 17;
         if (args.length != expectedParameters) {
             throw new IllegalArgumentException("Expecting " + expectedParameters + " parameters");
         }
@@ -212,6 +212,9 @@ public final class Server {
 
         boolean powerOffScreenOnClose = Boolean.parseBoolean(args[15]);
         options.setPowerOffScreenOnClose(powerOffScreenOnClose);
+
+        boolean clipboardAutosync = Boolean.parseBoolean(args[16]);
+        options.setClipboardAutosync(clipboardAutosync);
 
         return options;
     }


### PR DESCRIPTION
By default, scrcpy automatically synchronizes the computer clipboard to the device clipboard before injecting Ctrl+v, and the device clipboard to the computer clipboard whenever it changes.

This new option `--no-clipboard-autosync` disables this automatic synchronization.

Fixes #2228