### PR TITLE
Add --tcpip option to automate TCP/IP (wireless) connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [Read in another language](#translations)
 
 This application provides display and control of Android devices connected via
-USB (or [over TCP/IP](#wireless)). It does not require any _root_ access.
+USB (or [over TCP/IP](#tcpip-wireless)). It does not require any _root_ access.
 It works on _GNU/Linux_, _Windows_ and _macOS_.
 
 ![screenshot](assets/screenshot-debian-600.jpg)
@@ -356,10 +356,38 @@ scrcpy --v4l2-buffer=500    # add 500 ms buffering for v4l2 sink
 
 ### Connection
 
-#### Wireless
+#### TCP/IP (wireless)
 
 _Scrcpy_ uses `adb` to communicate with the device, and `adb` can [connect] to a
-device over TCP/IP:
+device over TCP/IP.
+
+##### Automatic
+
+An option `--tcpip` allows to configure the connection automatically. There are
+two variants.
+
+If the device (accessible at 192.168.1.1 in this example) already listens on a
+port (typically 5555) for incoming adb connections, then run:
+
+```bash
+scrcpy --tcpip=192.168.1.1       # default port is 5555
+scrcpy --tcpip=192.168.1.1:5555
+```
+
+If the device TCP/IP mode is disabled (or if you don't know the IP address),
+connect the device over USB, then run:
+
+```bash
+scrcpy --tcpip    # without arguments
+```
+
+It will automatically find the device IP address, enable TCP/IP mode, then
+connect to the device before starting.
+
+##### Manual
+
+Alternatively, it is possible to enable the TCP/IP connection manually using
+`adb`:
 
 1. Connect the device to the same Wi-Fi as your computer.
 2. Get your device IP address, in Settings → About phone → Status, or by

--- a/app/meson.build
+++ b/app/meson.build
@@ -1,6 +1,7 @@
 src = [
     'src/main.c',
     'src/adb.c',
+    'src/adb_parser.c',
     'src/adb_tunnel.c',
     'src/cli.c',
     'src/clock.c',
@@ -204,8 +205,14 @@ install_data('../data/icon.png',
 # do not build tests in release (assertions would not be executed at all)
 if get_option('buildtype') == 'debug'
     tests = [
+        ['test_adb_parser', [
+            'tests/test_adb_parser.c',
+            'src/adb_parser.c',
+            'src/util/str.c',
+            'src/util/strbuf.c',
+        ]],
         ['test_buffer_util', [
-            'tests/test_buffer_util.c'
+            'tests/test_buffer_util.c',
         ]],
         ['test_cbuf', [
             'tests/test_cbuf.c',

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -200,6 +200,14 @@ For example, to use either LCtrl+LAlt or LSuper for scrcpy shortcuts, pass "lctr
 Default is "lalt,lsuper" (left-Alt or left-Super).
 
 .TP
+.BI "\-\-tcpip[=ip[:port]]
+Configure and reconnect the device over TCP/IP.
+
+If a destination address is provided, then scrcpy connects to this address before starting. The device must listen on the given TCP port (default is 5555).
+
+If no destination address is provided, then scrcpy attempts to find the IP address of the current device (typically connected over USB), enables TCP/IP mode, then connects to this address before starting.
+
+.TP
 .B \-S, \-\-turn\-screen\-off
 Turn the device screen off immediately.
 

--- a/app/src/adb.c
+++ b/app/src/adb.c
@@ -314,6 +314,24 @@ adb_install(struct sc_intr *intr, const char *serial, const char *local,
     return process_check_success_intr(intr, pid, "adb install", flags);
 }
 
+bool
+adb_connect(struct sc_intr *intr, const char *ip_port, unsigned flags) {
+    const char *const adb_cmd[] = {"connect", ip_port};
+
+    sc_pid pid = adb_execute(NULL, adb_cmd, ARRAY_LEN(adb_cmd), flags);
+    return process_check_success_intr(intr, pid, "adb connect", flags);
+}
+
+bool
+adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags) {
+    const char *const adb_cmd[] = {"disconnect", ip_port};
+    size_t len = ip_port ? ARRAY_LEN(adb_cmd)
+                         : ARRAY_LEN(adb_cmd) - 1;
+
+    sc_pid pid = adb_execute(NULL, adb_cmd, len, flags);
+    return process_check_success_intr(intr, pid, "adb disconnect", flags);
+}
+
 char *
 adb_get_serialno(struct sc_intr *intr, unsigned flags) {
     const char *const adb_cmd[] = {"get-serialno"};

--- a/app/src/adb.c
+++ b/app/src/adb.c
@@ -181,7 +181,7 @@ adb_execute_p(const char *serial, const char *const adb_cmd[], size_t len,
 
     sc_pid pid;
     enum sc_process_result r =
-        sc_process_execute_p(argv, &pid, NULL, pout, NULL);
+        sc_process_execute_p(argv, &pid, 0, NULL, pout, NULL);
     if (r != SC_PROCESS_SUCCESS) {
         show_adb_err_msg(r, argv);
         pid = SC_PROCESS_NONE;

--- a/app/src/adb.c
+++ b/app/src/adb.c
@@ -316,6 +316,17 @@ adb_install(struct sc_intr *intr, const char *serial, const char *local,
 }
 
 bool
+adb_tcpip(struct sc_intr *intr, const char *serial, uint16_t port,
+          unsigned flags) {
+    char port_string[5 + 1];
+    sprintf(port_string, "%" PRIu16, port);
+    const char *const adb_cmd[] = {"tcpip", port_string};
+
+    sc_pid pid = adb_execute(serial, adb_cmd, ARRAY_LEN(adb_cmd), flags);
+    return process_check_success_intr(intr, pid, "adb tcpip", flags);
+}
+
+bool
 adb_connect(struct sc_intr *intr, const char *ip_port, unsigned flags) {
     const char *const adb_cmd[] = {"connect", ip_port};
 

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -66,4 +66,13 @@ adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags);
 char *
 adb_get_serialno(struct sc_intr *intr, unsigned flags);
 
+/**
+ * Attempt to retrieve the device IP
+ *
+ * Return the IP as a string of the form "xxx.xxx.xxx.xxx", to be freed by the
+ * caller, or NULL on error.
+ */
+char *
+adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags);
+
 #endif

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -8,31 +8,37 @@
 
 #include "util/intr.h"
 
+#define SC_ADB_NO_STDOUT (1 << 0)
+#define SC_ADB_NO_STDERR (1 << 1)
+
 sc_pid
-adb_execute(const char *serial, const char *const adb_cmd[], size_t len);
+adb_execute(const char *serial, const char *const adb_cmd[], size_t len,
+            unsigned flags);
 
 bool
 adb_forward(struct sc_intr *intr, const char *serial, uint16_t local_port,
-            const char *device_socket_name);
+            const char *device_socket_name, unsigned flags);
 
 bool
 adb_forward_remove(struct sc_intr *intr, const char *serial,
-                   uint16_t local_port);
+                   uint16_t local_port, unsigned flags);
 
 bool
 adb_reverse(struct sc_intr *intr, const char *serial,
-            const char *device_socket_name, uint16_t local_port);
+            const char *device_socket_name, uint16_t local_port,
+            unsigned flags);
 
 bool
 adb_reverse_remove(struct sc_intr *intr, const char *serial,
-                   const char *device_socket_name);
+                   const char *device_socket_name, unsigned flags);
 
 bool
 adb_push(struct sc_intr *intr, const char *serial, const char *local,
-         const char *remote);
+         const char *remote, unsigned flags);
 
 bool
-adb_install(struct sc_intr *intr, const char *serial, const char *local);
+adb_install(struct sc_intr *intr, const char *serial, const char *local,
+            unsigned flags);
 
 /**
  * Execute `adb get-serialno`
@@ -40,6 +46,6 @@ adb_install(struct sc_intr *intr, const char *serial, const char *local);
  * Return the result, to be freed by the caller, or NULL on error.
  */
 char *
-adb_get_serialno(struct sc_intr *intr);
+adb_get_serialno(struct sc_intr *intr, unsigned flags);
 
 #endif

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -66,6 +66,13 @@ bool
 adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags);
 
 /**
+ * Execute `adb getprop <prop>`
+ */
+char *
+adb_getprop(struct sc_intr *intr, const char *serial, const char *prop,
+            unsigned flags);
+
+/**
  * Execute `adb get-serialno`
  *
  * Return the result, to be freed by the caller, or NULL on error.

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -42,6 +42,23 @@ adb_install(struct sc_intr *intr, const char *serial, const char *local,
             unsigned flags);
 
 /**
+ * Execute `adb connect <ip_port>`
+ *
+ * `ip_port` may not be NULL.
+ */
+bool
+adb_connect(struct sc_intr *intr, const char *ip_port, unsigned flags);
+
+/**
+ * Execute `adb disconnect [<ip_port>]`
+ *
+ * If `ip_port` is NULL, execute `adb disconnect`.
+ * Otherwise, execute `adb disconnect <ip_port>`.
+ */
+bool
+adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags);
+
+/**
  * Execute `adb get-serialno`
  *
  * Return the result, to be freed by the caller, or NULL on error.

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -10,6 +10,7 @@
 
 #define SC_ADB_NO_STDOUT (1 << 0)
 #define SC_ADB_NO_STDERR (1 << 1)
+#define SC_ADB_NO_LOGERR (1 << 2)
 
 sc_pid
 adb_execute(const char *serial, const char *const adb_cmd[], size_t len,

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -42,6 +42,13 @@ adb_install(struct sc_intr *intr, const char *serial, const char *local,
             unsigned flags);
 
 /**
+ * Execute `adb tcpip <port>`
+ */
+bool
+adb_tcpip(struct sc_intr *intr, const char *serial, uint16_t port,
+          unsigned flags);
+
+/**
  * Execute `adb connect <ip_port>`
  *
  * `ip_port` may not be NULL.

--- a/app/src/adb.h
+++ b/app/src/adb.h
@@ -12,6 +12,8 @@
 #define SC_ADB_NO_STDERR (1 << 1)
 #define SC_ADB_NO_LOGERR (1 << 2)
 
+#define SC_ADB_SILENT (SC_ADB_NO_STDOUT | SC_ADB_NO_STDERR | SC_ADB_NO_LOGERR)
+
 sc_pid
 adb_execute(const char *serial, const char *const adb_cmd[], size_t len,
             unsigned flags);

--- a/app/src/adb_parser.c
+++ b/app/src/adb_parser.c
@@ -1,0 +1,65 @@
+#include "adb_parser.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include "util/log.h"
+#include "util/str.h"
+
+static char *
+sc_adb_parse_device_ip_from_line(char *line, size_t len) {
+    // One line from "ip route" looks lile:
+    // "192.168.1.0/24 dev wlan0  proto kernel  scope link  src 192.168.1.x"
+
+    // Get the location of the device name (index of "wlan0" in the example)
+    ssize_t idx_dev_name = sc_str_index_of_column(line, 2, " ");
+    if (idx_dev_name == -1) {
+        return NULL;
+    }
+
+    // Get the location of the ip address (column 8, but column 6 if we start
+    // from column 2). Must be computed before truncating individual columns.
+    ssize_t idx_ip = sc_str_index_of_column(&line[idx_dev_name], 6, " ");
+    if (idx_ip == -1) {
+        return NULL;
+    }
+    // idx_ip is searched from &line[idx_dev_name]
+    idx_ip += idx_dev_name;
+
+    char *dev_name = &line[idx_dev_name];
+    sc_str_truncate(dev_name, len - idx_dev_name + 1, " \t");
+
+    char *ip = &line[idx_ip];
+    sc_str_truncate(ip, len - idx_ip + 1, " \t");
+
+    // Only consider lines where the device name starts with "wlan"
+    if (strncmp(dev_name, "wlan", sizeof("wlan") - 1)) {
+        LOGD("Device ip lookup: ignoring %s (%s)", ip, dev_name);
+        return NULL;
+    }
+
+    return strdup(ip);
+}
+
+char *
+sc_adb_parse_device_ip_from_output(char *buf, size_t buf_len) {
+    size_t idx_line = 0;
+    while (idx_line < buf_len && buf[idx_line] != '\0') {
+        char *line = &buf[idx_line];
+        size_t len = sc_str_truncate(line, buf_len - idx_line, "\n");
+
+        // The same, but without any trailing '\r'
+        size_t line_len = sc_str_remove_trailing_cr(line, len);
+
+        char *ip = sc_adb_parse_device_ip_from_line(line, line_len);
+        if (ip) {
+            // Found
+            return ip;
+        }
+
+        // The next line starts after the '\n' (replaced by `\0`)
+        idx_line += len + 1;
+    }
+
+    return NULL;
+}

--- a/app/src/adb_parser.h
+++ b/app/src/adb_parser.h
@@ -1,0 +1,14 @@
+#ifndef SC_ADB_PARSER_H
+#define SC_ADB_PARSER_H
+
+#include "common.h"
+
+#include "stddef.h"
+
+/**
+ * Parse the ip from the output of `adb shell ip route`
+ */
+char *
+sc_adb_parse_device_ip_from_output(char *buf, size_t buf_len);
+
+#endif

--- a/app/src/adb_tunnel.c
+++ b/app/src/adb_tunnel.c
@@ -20,7 +20,8 @@ enable_tunnel_reverse_any_port(struct sc_adb_tunnel *tunnel,
                                struct sc_port_range port_range) {
     uint16_t port = port_range.first;
     for (;;) {
-        if (!adb_reverse(intr, serial, SC_SOCKET_NAME, port)) {
+        if (!adb_reverse(intr, serial, SC_SOCKET_NAME, port,
+                         SC_ADB_NO_STDOUT)) {
             // the command itself failed, it will fail on any port
             return false;
         }
@@ -51,7 +52,8 @@ enable_tunnel_reverse_any_port(struct sc_adb_tunnel *tunnel,
         }
 
         // failure, disable tunnel and try another port
-        if (!adb_reverse_remove(intr, serial, SC_SOCKET_NAME)) {
+        if (!adb_reverse_remove(intr, serial, SC_SOCKET_NAME,
+                                SC_ADB_NO_STDOUT)) {
             LOGW("Could not remove reverse tunnel on port %" PRIu16, port);
         }
 
@@ -81,7 +83,7 @@ enable_tunnel_forward_any_port(struct sc_adb_tunnel *tunnel,
 
     uint16_t port = port_range.first;
     for (;;) {
-        if (adb_forward(intr, serial, port, SC_SOCKET_NAME)) {
+        if (adb_forward(intr, serial, port, SC_SOCKET_NAME, SC_ADB_NO_STDOUT)) {
             // success
             tunnel->local_port = port;
             tunnel->enabled = true;
@@ -146,9 +148,11 @@ sc_adb_tunnel_close(struct sc_adb_tunnel *tunnel, struct sc_intr *intr,
 
     bool ret;
     if (tunnel->forward) {
-        ret = adb_forward_remove(intr, serial, tunnel->local_port);
+        ret = adb_forward_remove(intr, serial, tunnel->local_port,
+                                 SC_ADB_NO_STDOUT);
     } else {
-        ret = adb_reverse_remove(intr, serial, SC_SOCKET_NAME);
+        ret = adb_reverse_remove(intr, serial, SC_SOCKET_NAME,
+                                 SC_ADB_NO_STDOUT);
 
         assert(tunnel->server_socket != SC_SOCKET_NONE);
         if (!net_close(tunnel->server_socket)) {

--- a/app/src/file_handler.c
+++ b/app/src/file_handler.c
@@ -128,7 +128,7 @@ run_file_handler(void *data) {
 
         if (req.action == ACTION_INSTALL_APK) {
             LOGI("Installing %s...", req.file);
-            bool ok = adb_install(intr, serial, req.file);
+            bool ok = adb_install(intr, serial, req.file, 0);
             if (ok) {
                 LOGI("%s successfully installed", req.file);
             } else {
@@ -136,7 +136,7 @@ run_file_handler(void *data) {
             }
         } else {
             LOGI("Pushing %s...", req.file);
-            bool ok = adb_push(intr, serial, req.file, push_target);
+            bool ok = adb_push(intr, serial, req.file, push_target, 0);
             if (ok) {
                 LOGI("%s successfully pushed to %s", req.file, push_target);
             } else {

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -54,4 +54,6 @@ const struct scrcpy_options scrcpy_options_default = {
     .legacy_paste = false,
     .power_off_on_close = false,
     .clipboard_autosync = true,
+    .tcpip = false,
+    .tcpip_dst = NULL,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -109,6 +109,8 @@ struct scrcpy_options {
     bool legacy_paste;
     bool power_off_on_close;
     bool clipboard_autosync;
+    bool tcpip;
+    const char *tcpip_dst;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -365,6 +365,8 @@ scrcpy(struct scrcpy_options *options) {
         .force_adb_forward = options->force_adb_forward,
         .power_off_on_close = options->power_off_on_close,
         .clipboard_autosync = options->clipboard_autosync,
+        .tcpip = options->tcpip,
+        .tcpip_dst = options->tcpip_dst,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -112,7 +112,7 @@ push_server(struct sc_intr *intr, const char *serial) {
         free(server_path);
         return false;
     }
-    bool ok = adb_push(intr, serial, server_path, SC_DEVICE_SERVER_PATH);
+    bool ok = adb_push(intr, serial, server_path, SC_DEVICE_SERVER_PATH, 0);
     free(server_path);
     return ok;
 }
@@ -234,7 +234,8 @@ execute_server(struct sc_server *server,
     //     Port: 5005
     // Then click on "Debug"
 #endif
-    pid = adb_execute(params->serial, cmd, count);
+    // Inherit both stdout and stderr (all server logs are printed to stdout)
+    pid = adb_execute(params->serial, cmd, count, 0);
 
 end:
     for (unsigned i = dyn_idx; i < count; ++i) {
@@ -482,7 +483,7 @@ sc_server_fill_serial(struct sc_server *server) {
     // device/emulator" error)
     if (!server->params.serial) {
         // The serial is owned by sc_server_params, and will be freed on destroy
-        server->params.serial = adb_get_serialno(&server->intr);
+        server->params.serial = adb_get_serialno(&server->intr, 0);
         if (!server->params.serial) {
             LOGE("Could not get device serial");
             return false;

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -42,6 +42,8 @@ struct sc_server_params {
     bool force_adb_forward;
     bool power_off_on_close;
     bool clipboard_autosync;
+    bool tcpip;
+    const char *tcpip_dst;
 };
 
 struct sc_server {

--- a/app/src/util/process.c
+++ b/app/src/util/process.c
@@ -5,8 +5,8 @@
 #include "log.h"
 
 enum sc_process_result
-sc_process_execute(const char *const argv[], sc_pid *pid) {
-    return sc_process_execute_p(argv, pid, NULL, NULL, NULL);
+sc_process_execute(const char *const argv[], sc_pid *pid, unsigned flags) {
+    return sc_process_execute_p(argv, pid, flags, NULL, NULL, NULL);
 }
 
 ssize_t

--- a/app/src/util/process.h
+++ b/app/src/util/process.h
@@ -67,20 +67,32 @@ enum sc_process_result {
     SC_PROCESS_ERROR_MISSING_BINARY,
 };
 
+#define SC_PROCESS_NO_STDOUT (1 << 0)
+#define SC_PROCESS_NO_STDERR (1 << 1)
+
 /**
  * Execute the command and write the process id to `pid`
+ *
+ * The `flags` argument is a bitwise OR of the following values:
+ *  - SC_PROCESS_NO_STDOUT
+ *  - SC_PROCESS_NO_STDERR
+ *
+ * It indicates if stdout and stderr must be inherited from the scrcpy process
+ * (i.e. if the process must output to the scrcpy console).
  */
 enum sc_process_result
-sc_process_execute(const char *const argv[], sc_pid *pid);
+sc_process_execute(const char *const argv[], sc_pid *pid, unsigned flags);
 
 /**
  * Execute the command and write the process id to `pid`
  *
  * If not NULL, provide a pipe for stdin (`pin`), stdout (`pout`) and stderr
  * (`perr`).
+ *
+ * The `flags` argument has the same semantics as in `sc_process_execute()`.
  */
 enum sc_process_result
-sc_process_execute_p(const char *const argv[], sc_pid *pid,
+sc_process_execute_p(const char *const argv[], sc_pid *pid, unsigned flags,
                      sc_pipe *pin, sc_pipe *pout, sc_pipe *perr);
 
 /**

--- a/app/src/util/str.c
+++ b/app/src/util/str.c
@@ -304,3 +304,29 @@ sc_str_truncate(char *data, size_t len, const char *endchars) {
     data[idx] = '\0';
     return idx;
 }
+
+ssize_t
+sc_str_index_of_column(const char *s, unsigned col, const char *seps) {
+    size_t colidx = 0;
+
+    size_t idx = 0;
+    while (s[idx] != '\0' && colidx != col) {
+        size_t r = strcspn(&s[idx], seps);
+        idx += r;
+
+        if (s[idx] == '\0') {
+            // Not found
+            return -1;
+        }
+
+        size_t consecutive_seps = strspn(&s[idx], seps);
+        assert(consecutive_seps); // At least one
+        idx += consecutive_seps;
+
+        if (s[idx] != '\0') {
+            ++colidx;
+        }
+    }
+
+    return col == colidx ? (ssize_t) idx : -1;
+}

--- a/app/src/util/str.c
+++ b/app/src/util/str.c
@@ -330,3 +330,14 @@ sc_str_index_of_column(const char *s, unsigned col, const char *seps) {
 
     return col == colidx ? (ssize_t) idx : -1;
 }
+
+size_t
+sc_str_remove_trailing_cr(char *s, size_t len) {
+    while (len) {
+        if (s[len - 1] != '\r') {
+            break;
+        }
+        s[--len] = '\0';
+    }
+    return len;
+}

--- a/app/src/util/str.h
+++ b/app/src/util/str.h
@@ -114,4 +114,24 @@ sc_str_wrap_lines(const char *input, unsigned columns, unsigned indent);
 size_t
 sc_str_truncate(char *data, size_t len, const char *endchars);
 
+/**
+ * Find the start of a column in a string
+ *
+ * A string may represent several columns, separated by some "spaces"
+ * (separators). This function aims to find the start of the column number
+ * `col`.
+ *
+ * For example, to find the 4th column (column number 3):
+ *
+ *     //                               here
+ *     //                               v
+ *     const char *s = "abc def    ghi  jk";
+ *     ssize_t index = sc_str_index_of_column(s, 3, " ");
+ *     assert(index == 16); // points to "jk"
+ *
+ * Return -1 if no such column exists.
+ */
+ssize_t
+sc_str_index_of_column(const char *s, unsigned col, const char *seps);
+
 #endif

--- a/app/src/util/str.h
+++ b/app/src/util/str.h
@@ -134,4 +134,15 @@ sc_str_truncate(char *data, size_t len, const char *endchars);
 ssize_t
 sc_str_index_of_column(const char *s, unsigned col, const char *seps);
 
+/**
+ * Remove all `\r` at the end of the line
+ *
+ * The line length is provided by `len` (this avoids a call to `strlen()` when
+ * the caller already knows the length).
+ *
+ * Return the new length.
+ */
+size_t
+sc_str_remove_trailing_cr(char *s, size_t len);
+
 #endif

--- a/app/tests/test_adb_parser.c
+++ b/app/tests/test_adb_parser.c
@@ -1,0 +1,83 @@
+#include "common.h"
+
+#include <assert.h>
+
+#include "adb_parser.h"
+
+static void test_get_ip_single_line() {
+    char ip_route[] = "192.168.1.0/24 dev wlan0  proto kernel  scope link  src "
+                      "192.168.12.34\r\r\n";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(ip);
+    assert(!strcmp(ip, "192.168.12.34"));
+}
+
+static void test_get_ip_single_line_without_eol() {
+    char ip_route[] = "192.168.1.0/24 dev wlan0  proto kernel  scope link  src "
+                      "192.168.12.34";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(ip);
+    assert(!strcmp(ip, "192.168.12.34"));
+}
+
+static void test_get_ip_single_line_with_trailing_space() {
+    char ip_route[] = "192.168.1.0/24 dev wlan0  proto kernel  scope link  src "
+                      "192.168.12.34 \n";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(ip);
+    assert(!strcmp(ip, "192.168.12.34"));
+}
+
+static void test_get_ip_multiline_first_ok() {
+    char ip_route[] = "192.168.1.0/24 dev wlan0  proto kernel  scope link  src "
+                      "192.168.1.2\r\n"
+                      "10.0.0.0/24 dev rmnet  proto kernel  scope link  src "
+                      "10.0.0.2\r\n";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(ip);
+    assert(!strcmp(ip, "192.168.1.2"));
+}
+
+static void test_get_ip_multiline_second_ok() {
+    char ip_route[] = "10.0.0.0/24 dev rmnet  proto kernel  scope link  src "
+                      "10.0.0.3\r\n"
+                      "192.168.1.0/24 dev wlan0  proto kernel  scope link  src "
+                      "192.168.1.3\r\n";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(ip);
+    assert(!strcmp(ip, "192.168.1.3"));
+}
+
+static void test_get_ip_no_wlan() {
+    char ip_route[] = "192.168.1.0/24 dev rmnet  proto kernel  scope link  src "
+                      "192.168.12.34\r\r\n";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(!ip);
+}
+
+static void test_get_ip_truncated() {
+    char ip_route[] = "192.168.1.0/24 dev rmnet  proto kernel  scope link  src "
+                      "\n";
+
+    char *ip = sc_adb_parse_device_ip_from_output(ip_route, sizeof(ip_route));
+    assert(!ip);
+}
+
+int main(int argc, char *argv[]) {
+    (void) argc;
+    (void) argv;
+
+    test_get_ip_single_line();
+    test_get_ip_single_line_without_eol();
+    test_get_ip_single_line_with_trailing_space();
+    test_get_ip_multiline_first_ok();
+    test_get_ip_multiline_second_ok();
+    test_get_ip_no_wlan();
+    test_get_ip_truncated();
+}

--- a/app/tests/test_str.c
+++ b/app/tests/test_str.c
@@ -364,6 +364,26 @@ static void test_truncate(void) {
     assert(!strcmp("hello", s4));
 }
 
+static void test_index_of_column(void) {
+    assert(sc_str_index_of_column("a bc  d", 0, " ") == 0);
+    assert(sc_str_index_of_column("a bc  d", 1, " ") == 2);
+    assert(sc_str_index_of_column("a bc  d", 2, " ") == 6);
+    assert(sc_str_index_of_column("a bc  d", 3, " ") == -1);
+
+    assert(sc_str_index_of_column("a  ", 0, " ") == 0);
+    assert(sc_str_index_of_column("a  ", 1, " ") == -1);
+
+    assert(sc_str_index_of_column("", 0, " ") == 0);
+    assert(sc_str_index_of_column("", 1, " ") == -1);
+
+    assert(sc_str_index_of_column("a \t   \t bc  \t  d\t", 0, " \t") == 0);
+    assert(sc_str_index_of_column("a \t   \t bc  \t  d\t", 1, " \t") == 8);
+    assert(sc_str_index_of_column("a \t   \t bc  \t  d\t", 2, " \t") == 15);
+    assert(sc_str_index_of_column("a \t   \t bc  \t  d\t", 3, " \t") == -1);
+
+    assert(sc_str_index_of_column("  a bc  d", 1, " ") == 2);
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -384,5 +404,6 @@ int main(int argc, char *argv[]) {
     test_strlist_contains();
     test_wrap_lines();
     test_truncate();
+    test_index_of_column();
     return 0;
 }

--- a/app/tests/test_str.c
+++ b/app/tests/test_str.c
@@ -384,6 +384,20 @@ static void test_index_of_column(void) {
     assert(sc_str_index_of_column("  a bc  d", 1, " ") == 2);
 }
 
+static void test_remove_trailing_cr() {
+    char s[] = "abc\r";
+    sc_str_remove_trailing_cr(s, sizeof(s) - 1);
+    assert(!strcmp(s, "abc"));
+
+    char s2[] = "def\r\r\r\r";
+    sc_str_remove_trailing_cr(s2, sizeof(s2) - 1);
+    assert(!strcmp(s2, "def"));
+
+    char s3[] = "adb\rdef\r";
+    sc_str_remove_trailing_cr(s3, sizeof(s3) - 1);
+    assert(!strcmp(s3, "adb\rdef"));
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -405,5 +419,6 @@ int main(int argc, char *argv[]) {
     test_wrap_lines();
     test_truncate();
     test_index_of_column();
+    test_remove_trailing_cr();
     return 0;
 }


### PR DESCRIPTION
Add an option to configure the TCP/IP connection automatically. There are two variants.

If the device (accessible at 192.168.1.1 in this example) already listens on a port (typically 5555) for incoming adb connections, then run:

```bash
scrcpy --tcpip=192.168.1.1       # default port is 5555
scrcpy --tcpip=192.168.1.1:5555
```

If the device TCP/IP mode is disabled (or if you don't know the IP address), connect the device over USB, then run:

```bash
scrcpy --tcpip    # without arguments
```

It will automatically find the device IP address (by parsing `adb shell ip route`), enable TCP/IP mode, then connects to the device before starting.

---

Here are binaries so that you can test easily. Please replace these files in your v1.20 release:

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2827/4/scrcpy.exe) _sha256:c3d96408d81d4c3f17259a8d99bd2e343f6c9758dc85e6317b114f6cdc95fd00_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2827/4/scrcpy-server) _sha256:e08e9aa4796c213bf601f6323b5e9f4fce250b1f3b1d46441289824cb4af294a_

<details><summary>old binaries v3</summary>

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2827/3/scrcpy.exe) _sha256:67068f06190a5454ca245290022da84549a8d23c5c90926ddf2a558a20e2d0f8_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2827/3/scrcpy-server) _sha256:e08e9aa4796c213bf601f6323b5e9f4fce250b1f3b1d46441289824cb4af294a_

</details>

<details><summary>old binaries v2</summary>

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2827/2/scrcpy.exe) _sha256:1931c1637fb35c453d35b416cc0bcbefcf25806f79d52eb3cec3d5fc78a26a05_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2827/2/scrcpy-server) _sha256:e08e9aa4796c213bf601f6323b5e9f4fce250b1f3b1d46441289824cb4af294a_

</details>

<details><summary>old binaries v1</summary>

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2827/1/scrcpy.exe) _sha256:e77f3140f90353ad5b724576df9f1223717c24927ea4255714c122d5a956451a_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2827/1/scrcpy-server) _sha256:e08e9aa4796c213bf601f6323b5e9f4fce250b1f3b1d46441289824cb4af294a_

</details>

Please test and report any issue you might encounter. This is also built from the current `dev` branch (so with code which will be in the next release), where I did a lot of refactors recently, so please report any regression. That would help a lot :wink: 

Thank you for your feedback.