### PR TITLE
Always synchronize clipboard on explicit COPY/CUT

### DIFF
--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -197,7 +197,7 @@ control_msg_log(const struct control_msg *msg) {
         case CONTROL_MSG_TYPE_SET_CLIPBOARD:
             LOG_CMSG("clipboard %" PRIu64_ " %s \"%s\"",
                      msg->set_clipboard.sequence,
-                     msg->set_clipboard.paste ? "paste" : "copy",
+                     msg->set_clipboard.paste ? "paste" : "nopaste",
                      msg->set_clipboard.text);
             break;
         case CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE:

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -41,6 +41,12 @@ enum screen_power_mode {
     SCREEN_POWER_MODE_NORMAL = 2,
 };
 
+enum get_clipboard_copy_key {
+    GET_CLIPBOARD_COPY_KEY_NONE,
+    GET_CLIPBOARD_COPY_KEY_COPY,
+    GET_CLIPBOARD_COPY_KEY_CUT,
+};
+
 struct control_msg {
     enum control_msg_type type;
     union {
@@ -69,6 +75,9 @@ struct control_msg {
             enum android_keyevent_action action; // action for the BACK key
             // screen may only be turned on on ACTION_DOWN
         } back_or_screen_on;
+        struct {
+            enum get_clipboard_copy_key copy_key;
+        } get_clipboard;
         struct {
             uint64_t sequence;
             char *text; // owned, to be freed by free()

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -148,16 +148,6 @@ action_menu(struct controller *controller, int actions) {
     send_keycode(controller, AKEYCODE_MENU, actions, "MENU");
 }
 
-static inline void
-action_copy(struct controller *controller, int actions) {
-    send_keycode(controller, AKEYCODE_COPY, actions, "COPY");
-}
-
-static inline void
-action_cut(struct controller *controller, int actions) {
-    send_keycode(controller, AKEYCODE_CUT, actions, "CUT");
-}
-
 // turn the screen on if it was off, press BACK otherwise
 // If the screen is off, it is turned on only on ACTION_DOWN
 static void
@@ -209,6 +199,21 @@ collapse_panels(struct controller *controller) {
     if (!controller_push_msg(controller, &msg)) {
         LOGW("Could not request 'collapse notification panel'");
     }
+}
+
+static bool
+get_device_clipboard(struct controller *controller,
+                     enum get_clipboard_copy_key copy_key) {
+    struct control_msg msg;
+    msg.type = CONTROL_MSG_TYPE_GET_CLIPBOARD;
+    msg.get_clipboard.copy_key = copy_key;
+
+    if (!controller_push_msg(controller, &msg)) {
+        LOGW("Could not request 'get device clipboard'");
+        return false;
+    }
+
+    return true;
 }
 
 static bool
@@ -450,13 +455,15 @@ input_manager_process_key(struct input_manager *im,
                 }
                 return;
             case SDLK_c:
-                if (control && !shift && !repeat) {
-                    action_copy(controller, action);
+                if (control && !shift && !repeat && down) {
+                    get_device_clipboard(controller,
+                                         GET_CLIPBOARD_COPY_KEY_COPY);
                 }
                 return;
             case SDLK_x:
-                if (control && !shift && !repeat) {
-                    action_cut(controller, action);
+                if (control && !shift && !repeat && down) {
+                    get_device_clipboard(controller,
+                                         GET_CLIPBOARD_COPY_KEY_CUT);
                 }
                 return;
             case SDLK_v:

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -210,14 +210,18 @@ static void test_serialize_collapse_panels(void) {
 static void test_serialize_get_clipboard(void) {
     struct control_msg msg = {
         .type = CONTROL_MSG_TYPE_GET_CLIPBOARD,
+        .get_clipboard = {
+            .copy_key = GET_CLIPBOARD_COPY_KEY_COPY,
+        },
     };
 
     unsigned char buf[CONTROL_MSG_MAX_SIZE];
     size_t size = control_msg_serialize(&msg, buf);
-    assert(size == 1);
+    assert(size == 2);
 
     const unsigned char expected[] = {
         CONTROL_MSG_TYPE_GET_CLIPBOARD,
+        GET_CLIPBOARD_COPY_KEY_COPY,
     };
     assert(!memcmp(buf, expected, sizeof(expected)));
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
@@ -20,6 +20,10 @@ public final class ControlMessage {
 
     public static final long SEQUENCE_INVALID = 0;
 
+    public static final int COPY_KEY_NONE = 0;
+    public static final int COPY_KEY_COPY = 1;
+    public static final int COPY_KEY_CUT = 2;
+
     private int type;
     private String text;
     private int metaState; // KeyEvent.META_*
@@ -31,6 +35,7 @@ public final class ControlMessage {
     private Position position;
     private int hScroll;
     private int vScroll;
+    private int copyKey;
     private boolean paste;
     private int repeat;
     private long sequence;
@@ -79,6 +84,13 @@ public final class ControlMessage {
         ControlMessage msg = new ControlMessage();
         msg.type = TYPE_BACK_OR_SCREEN_ON;
         msg.action = action;
+        return msg;
+    }
+
+    public static ControlMessage createGetClipboard(int copyKey) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_GET_CLIPBOARD;
+        msg.copyKey = copyKey;
         return msg;
     }
 
@@ -149,6 +161,10 @@ public final class ControlMessage {
 
     public int getVScroll() {
         return vScroll;
+    }
+
+    public int getCopyKey() {
+        return copyKey;
     }
 
     public boolean getPaste() {

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
@@ -13,6 +13,7 @@ public class ControlMessageReader {
     static final int INJECT_SCROLL_EVENT_PAYLOAD_LENGTH = 20;
     static final int BACK_OR_SCREEN_ON_LENGTH = 1;
     static final int SET_SCREEN_POWER_MODE_PAYLOAD_LENGTH = 1;
+    static final int GET_CLIPBOARD_LENGTH = 1;
     static final int SET_CLIPBOARD_FIXED_PAYLOAD_LENGTH = 9;
 
     private static final int MESSAGE_MAX_SIZE = 1 << 18; // 256k
@@ -70,6 +71,9 @@ public class ControlMessageReader {
             case ControlMessage.TYPE_BACK_OR_SCREEN_ON:
                 msg = parseBackOrScreenOnEvent();
                 break;
+            case ControlMessage.TYPE_GET_CLIPBOARD:
+                msg = parseGetClipboard();
+                break;
             case ControlMessage.TYPE_SET_CLIPBOARD:
                 msg = parseSetClipboard();
                 break;
@@ -79,7 +83,6 @@ public class ControlMessageReader {
             case ControlMessage.TYPE_EXPAND_NOTIFICATION_PANEL:
             case ControlMessage.TYPE_EXPAND_SETTINGS_PANEL:
             case ControlMessage.TYPE_COLLAPSE_PANELS:
-            case ControlMessage.TYPE_GET_CLIPBOARD:
             case ControlMessage.TYPE_ROTATE_DEVICE:
                 msg = ControlMessage.createEmpty(type);
                 break;
@@ -160,6 +163,14 @@ public class ControlMessageReader {
         }
         int action = toUnsigned(buffer.get());
         return ControlMessage.createBackOrScreenOn(action);
+    }
+
+    private ControlMessage parseGetClipboard() {
+        if (buffer.remaining() < GET_CLIPBOARD_LENGTH) {
+            return null;
+        }
+        int copyKey = toUnsigned(buffer.get());
+        return ControlMessage.createGetClipboard(copyKey);
     }
 
     private ControlMessage parseSetClipboard() {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -120,12 +120,7 @@ public class Controller {
                 }
                 break;
             case ControlMessage.TYPE_SET_CLIPBOARD:
-                long sequence = msg.getSequence();
-                setClipboard(msg.getText(), msg.getPaste());
-                if (sequence != ControlMessage.SEQUENCE_INVALID) {
-                    // Acknowledgement requested
-                    sender.pushAckClipboard(sequence);
-                }
+                setClipboard(msg.getText(), msg.getPaste(), msg.getSequence());
                 break;
             case ControlMessage.TYPE_SET_SCREEN_POWER_MODE:
                 if (device.supportsInputEvents()) {
@@ -281,7 +276,7 @@ public class Controller {
         return device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER);
     }
 
-    private boolean setClipboard(String text, boolean paste) {
+    private boolean setClipboard(String text, boolean paste, long sequence) {
         boolean ok = device.setClipboardText(text);
         if (ok) {
             Ln.i("Device clipboard set");
@@ -290,6 +285,11 @@ public class Controller {
         // On Android >= 7, also press the PASTE key if requested
         if (paste && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && device.supportsInputEvents()) {
             device.pressReleaseKeycode(KeyEvent.KEYCODE_PASTE);
+        }
+
+        if (sequence != ControlMessage.SEQUENCE_INVALID) {
+            // Acknowledgement requested
+            sender.pushAckClipboard(sequence);
         }
 
         return ok;

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -55,7 +55,7 @@ public class Controller {
     public void control() throws IOException {
         // on start, power on the device
         if (!Device.isScreenOn()) {
-            device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER);
+            device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, Device.INJECT_MODE_ASYNC);
 
             // dirty hack
             // After POWER is injected, the device is powered on asynchronously.
@@ -144,7 +144,7 @@ public class Controller {
         if (keepPowerModeOff && action == KeyEvent.ACTION_UP && (keycode == KeyEvent.KEYCODE_POWER || keycode == KeyEvent.KEYCODE_WAKEUP)) {
             schedulePowerModeOff();
         }
-        return device.injectKeyEvent(action, keycode, repeat, metaState);
+        return device.injectKeyEvent(action, keycode, repeat, metaState, Device.INJECT_MODE_ASYNC);
     }
 
     private boolean injectChar(char c) {
@@ -155,7 +155,7 @@ public class Controller {
             return false;
         }
         for (KeyEvent event : events) {
-            if (!device.injectEvent(event)) {
+            if (!device.injectEvent(event, Device.INJECT_MODE_ASYNC)) {
                 return false;
             }
         }
@@ -219,7 +219,7 @@ public class Controller {
         MotionEvent event = MotionEvent
                 .obtain(lastTouchDown, now, action, pointerCount, pointerProperties, pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0, source,
                         0);
-        return device.injectEvent(event);
+        return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
     }
 
     private boolean injectScroll(Position position, int hScroll, int vScroll) {
@@ -242,7 +242,7 @@ public class Controller {
         MotionEvent event = MotionEvent
                 .obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, 0, 1f, 1f, DEFAULT_DEVICE_ID, 0,
                         InputDevice.SOURCE_MOUSE, 0);
-        return device.injectEvent(event);
+        return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
     }
 
     /**
@@ -260,7 +260,7 @@ public class Controller {
 
     private boolean pressBackOrTurnScreenOn(int action) {
         if (Device.isScreenOn()) {
-            return device.injectKeyEvent(action, KeyEvent.KEYCODE_BACK, 0, 0);
+            return device.injectKeyEvent(action, KeyEvent.KEYCODE_BACK, 0, 0, Device.INJECT_MODE_ASYNC);
         }
 
         // Screen is off
@@ -273,7 +273,7 @@ public class Controller {
         if (keepPowerModeOff) {
             schedulePowerModeOff();
         }
-        return device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER);
+        return device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, Device.INJECT_MODE_ASYNC);
     }
 
     private boolean setClipboard(String text, boolean paste, long sequence) {
@@ -284,7 +284,7 @@ public class Controller {
 
         // On Android >= 7, also press the PASTE key if requested
         if (paste && Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && device.supportsInputEvents()) {
-            device.pressReleaseKeycode(KeyEvent.KEYCODE_PASTE);
+            device.pressReleaseKeycode(KeyEvent.KEYCODE_PASTE, Device.INJECT_MODE_ASYNC);
         }
 
         if (sequence != ControlMessage.SEQUENCE_INVALID) {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -24,6 +24,10 @@ public final class Device {
     public static final int POWER_MODE_OFF = SurfaceControl.POWER_MODE_OFF;
     public static final int POWER_MODE_NORMAL = SurfaceControl.POWER_MODE_NORMAL;
 
+    public static final int INJECT_MODE_ASYNC = InputManager.INJECT_INPUT_EVENT_MODE_ASYNC;
+    public static final int INJECT_MODE_WAIT_FOR_RESULT = InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_RESULT;
+    public static final int INJECT_MODE_WAIT_FOR_FINISH = InputManager.INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH;
+
     public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
 
@@ -164,7 +168,7 @@ public final class Device {
         return supportsInputEvents;
     }
 
-    public static boolean injectEvent(InputEvent inputEvent, int displayId) {
+    public static boolean injectEvent(InputEvent inputEvent, int displayId, int injectMode) {
         if (!supportsInputEvents(displayId)) {
             throw new AssertionError("Could not inject input event if !supportsInputEvents()");
         }
@@ -173,30 +177,31 @@ public final class Device {
             return false;
         }
 
-        return SERVICE_MANAGER.getInputManager().injectInputEvent(inputEvent, InputManager.INJECT_INPUT_EVENT_MODE_ASYNC);
+        return SERVICE_MANAGER.getInputManager().injectInputEvent(inputEvent, injectMode);
     }
 
-    public boolean injectEvent(InputEvent event) {
-        return injectEvent(event, displayId);
+    public boolean injectEvent(InputEvent event, int injectMode) {
+        return injectEvent(event, displayId, injectMode);
     }
 
-    public static boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int displayId) {
+    public static boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int displayId, int injectMode) {
         long now = SystemClock.uptimeMillis();
         KeyEvent event = new KeyEvent(now, now, action, keyCode, repeat, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
                 InputDevice.SOURCE_KEYBOARD);
-        return injectEvent(event, displayId);
+        return injectEvent(event, displayId, injectMode);
     }
 
-    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState) {
-        return injectKeyEvent(action, keyCode, repeat, metaState, displayId);
+    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int injectMode) {
+        return injectKeyEvent(action, keyCode, repeat, metaState, displayId, injectMode);
     }
 
-    public static boolean pressReleaseKeycode(int keyCode, int displayId) {
-        return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0, displayId) && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0, displayId);
+    public static boolean pressReleaseKeycode(int keyCode, int displayId, int injectMode) {
+        return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0, displayId, injectMode)
+                && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0, displayId, injectMode);
     }
 
-    public boolean pressReleaseKeycode(int keyCode) {
-        return pressReleaseKeycode(keyCode, displayId);
+    public boolean pressReleaseKeycode(int keyCode, int injectMode) {
+        return pressReleaseKeycode(keyCode, displayId, injectMode);
     }
 
     public static boolean isScreenOn() {
@@ -272,7 +277,7 @@ public final class Device {
         if (!isScreenOn()) {
             return true;
         }
-        return pressReleaseKeycode(KeyEvent.KEYCODE_POWER, displayId);
+        return pressReleaseKeycode(KeyEvent.KEYCODE_POWER, displayId, Device.INJECT_MODE_ASYNC);
     }
 
     /**

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -74,7 +74,7 @@ public final class Server {
             Thread controllerThread = null;
             Thread deviceMessageSenderThread = null;
             if (options.getControl()) {
-                final Controller controller = new Controller(device, connection);
+                final Controller controller = new Controller(device, connection, options.getClipboardAutosync());
 
                 // asynchronous
                 controllerThread = startController(controller);

--- a/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
@@ -219,6 +219,7 @@ public class ControlMessageReaderTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(bos);
         dos.writeByte(ControlMessage.TYPE_GET_CLIPBOARD);
+        dos.writeByte(ControlMessage.COPY_KEY_COPY);
 
         byte[] packet = bos.toByteArray();
 
@@ -226,6 +227,7 @@ public class ControlMessageReaderTest {
         ControlMessage event = reader.next();
 
         Assert.assertEquals(ControlMessage.TYPE_GET_CLIPBOARD, event.getType());
+        Assert.assertEquals(ControlMessage.COPY_KEY_COPY, event.getCopyKey());
     }
 
     @Test


### PR DESCRIPTION
Always synchronize clipboard on explicit COPY/CUT

If `--no-clipboard-autosync` is enabled, the automatic clipboard synchronization whenever the device clipboard changes is disabled.

But on explicit COPY and CUT scrcpy shortcuts (MOD+c and MOD+x), the clipboard should still be synchronized, so that it remains possible to copy-paste from the device to the computer.

This is consistent with the behavior of MOD+v, which pastes the computer clipboard to the device.

Refs #2228
Refs #2817

---

Here are binaries so that you can test easily. Please replace these files in your v1.20 release:

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2834/1/scrcpy.exe) _sha256:0cee83cb1c44cf159845b16f3a0ad348fea76c75b846f19d1548866db71e275a_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2834/1/scrcpy-server) _sha256:c740e7888cdafb1d2753ee5858e8bd566d26498a79a49fe95a47c6f416130495_