### PR TITLE
Fix overflow in memcpy

### DIFF
--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -69,7 +69,7 @@ write_position(uint8_t *buf, const struct sc_position *position) {
     buffer_write16be(&buf[10], position->screen_size.height);
 }
 
-// write length (2 bytes) + string (non nul-terminated)
+// write length (4 bytes) + string (non null-terminated)
 static size_t
 write_string(const char *utf8, size_t max_len, unsigned char *buf) {
     size_t len = sc_str_utf8_truncation_index(utf8, max_len);

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -14,8 +14,8 @@
 #define CONTROL_MSG_MAX_SIZE (1 << 18) // 256k
 
 #define CONTROL_MSG_INJECT_TEXT_MAX_LENGTH 300
-// type: 1 byte; paste flag: 1 byte; length: 4 bytes
-#define CONTROL_MSG_CLIPBOARD_TEXT_MAX_LENGTH (CONTROL_MSG_MAX_SIZE - 6)
+// type: 1 byte; sequence: 8 bytes; paste flag: 1 byte; length: 4 bytes
+#define CONTROL_MSG_CLIPBOARD_TEXT_MAX_LENGTH (CONTROL_MSG_MAX_SIZE - 14)
 
 #define POINTER_ID_MOUSE UINT64_C(-1)
 #define POINTER_ID_VIRTUAL_FINGER UINT64_C(-2)


### PR DESCRIPTION
```
In function ‘memcpy’,                             
    inlined from ‘control_msg_serialize.constprop’ at ../app/src/control_msg.c:77:5,
    inlined from ‘run_controller’ at ../app/src/controller.c:69:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:34:10: warning: ‘__builtin___memcpy_chk’ writing 262138 bytes into a region of
 size 262130 overflows the destination [-Wstringop-overflow=]
   return __builtin___memcpy_chk (__dest, __src, __len, __bos0 (__dest));
          ^
```

When serialize `CONTROL_MSG_TYPE_SET_CLIPBOARD` event, it did not consider the size of sequence which is 8 bytes. So that the buffer size is not enough for memcpy.

