### PR TITLE
Fix adb server hang

### DIFF
--- a/app/src/sys/unix/process.c
+++ b/app/src/sys/unix/process.c
@@ -119,6 +119,13 @@ sc_process_execute_p(const char *const argv[], sc_pid *pid, unsigned flags,
 
         close(internal[0]);
         enum sc_process_result err;
+
+        // Somehow SDL masks many signals - undo them for other processes
+        // https://github.com/libsdl-org/SDL/blob/release-2.0.18/src/thread/pthread/SDL_systhread.c#L167
+        sigset_t mask;
+        sigemptyset(&mask);
+        sigprocmask(SIG_SETMASK, &mask, NULL);
+
         if (fcntl(internal[1], F_SETFD, FD_CLOEXEC) == 0) {
             execvp(argv[0], (char *const *) argv);
             perror("exec");


### PR DESCRIPTION
Since commit 04267085441d6fcd05eff7df0118708f7622e237, the server is run
in a dedicated thread. For SDL, many signals, including SIGINT and
SIGTERM, are masked for new threads. As a result, if the adb server is
not already running, adb commands invoked by scrcpy will start an adb
server that ignores those signals and cannot be terminated at system
shutdown.