### PR TITLE
Add shake shortcut to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
  | Click on `HOME`                             | <kbd>MOD</kbd>+<kbd>h</kbd> \| _Middle-click_
  | Click on `BACK`                             | <kbd>MOD</kbd>+<kbd>b</kbd> \| _Right-click²_
  | Click on `APP_SWITCH`                       | <kbd>MOD</kbd>+<kbd>s</kbd> \| _4th-click³_
- | Click on `MENU` (unlock screen)             | <kbd>MOD</kbd>+<kbd>m</kbd>
+ | Click on `MENU` (unlock screen)             | <kbd>MOD</kbd>+<kbd>m</kbd>⁵
  | Click on `VOLUME_UP`                        | <kbd>MOD</kbd>+<kbd>↑</kbd> _(up)_
  | Click on `VOLUME_DOWN`                      | <kbd>MOD</kbd>+<kbd>↓</kbd> _(down)_
  | Click on `POWER`                            | <kbd>MOD</kbd>+<kbd>p</kbd>
@@ -961,7 +961,8 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
 _¹Double-click on black borders to remove them._  
 _²Right-click turns the screen on if it was off, presses BACK otherwise._  
 _³4th and 5th mouse buttons, if your mouse has them._  
-_⁴Only on Android >= 7._
+_⁴Only on Android >= 7._  
+_⁵For react-native apps in development, this also triggers development menu._
 
 Shortcuts with repeated keys are executted by releasing and pressing the key a
 second time. For example, to execute "Expand settings panel":


### PR DESCRIPTION
As a react-native developer I was looking for a way trigger the shake gesture (to launch the development menu). Turns out it exists but was missing from the README. This pull request adds the shortcut to the shortcuts table