### PR TITLE
Add HID mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Its features include:
  - device screen [as a webcam (V4L2)](#v4l2loopback) (Linux-only)
  - [physical keyboard simulation (HID)](#physical-keyboard-simulation-hid)
    (Linux-only)
+ - [physical mouse simulation (HID)](#physical-mouse-simulation-hid)
+   (Linux-only)
  - and more…
 
 ## Requirements
@@ -814,6 +816,35 @@ However, the option is only available when the HID keyboard is enabled (or when
 a physical keyboard is connected).
 
 [Physical keyboard]: https://github.com/Genymobile/scrcpy/pull/2632#issuecomment-923756915
+
+#### Physical mouse simulation (HID)
+
+Similarly to the physical keyboard simulation, it is possible to simulate a
+physical mouse. Likewise, it only works if the device is connected by USB, and
+is currently only supported on Linux.
+
+By default, scrcpy uses Android mouse events injection, using absolute
+coordinates. By simulating a physical mouse, a mouse pointer appears on the
+Android device, and relative mouse motion, clicks and scrolls are injected.
+
+To enable this mode:
+
+```bash
+scrcpy --hid-mouse
+scrcpy -M  # short version
+```
+
+You could also add `--forward-all-clicks` to [forward all mouse
+buttons][forward_all_clicks].
+
+[forward_all_clicks]: #right-click-and-middle-click
+
+When this mode is enabled, the computer mouse is "captured" (the mouse pointer
+disappears from the computer and appears on the Android device instead).
+
+Special capture keys, either <kbd>Alt</kbd> or <kbd>Super</kbd>, toggle
+(disable or enable) the mouse capture. Use one of them to give the control of
+the mouse back to the computer.
 
 
 #### Text injection preference

--- a/app/meson.build
+++ b/app/meson.build
@@ -77,6 +77,7 @@ if aoa_hid_support
     src += [
         'src/aoa_hid.c',
         'src/hid_keyboard.c',
+        'src/hid_mouse.c',
     ]
 endif
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -96,6 +96,8 @@ The keyboard layout must be configured (once and for all) on the device, via Set
 
 However, the option is only available when the HID keyboard is enabled (or a physical keyboard is connected).
 
+Also see \fB\-\-hid\-mouse\fR.
+
 .TP
 .B \-\-legacy\-paste
 Inject computer clipboard text as a sequence of key events on Ctrl+v (like MOD+Shift+v).
@@ -119,6 +121,18 @@ Limit the framerate of screen capture (officially supported since Android 10, bu
 Limit both the width and height of the video to \fIvalue\fR. The other dimension is computed so that the device aspect\-ratio is preserved.
 
 Default is 0 (unlimited).
+
+.TP
+.B \-M, \-\-hid\-mouse
+Simulate a physical mouse by using HID over AOAv2.
+
+In this mode, the computer mouse is captured to control the device directly (relative mouse mode).
+
+LAlt, LSuper or RSuper toggle the capture mode, to give control of the mouse back to the computer.
+
+It may only work over USB, and is currently only supported on Linux.
+
+Also see \fB\-\-hid\-keyboard\fR.
 
 .TP
 .B \-\-no\-clipboard\-autosync

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -178,7 +178,8 @@ static const struct sc_option options[] = {
                 "directly: `adb shell am start -a "
                 "android.settings.HARD_KEYBOARD_SETTINGS`.\n"
                 "However, the option is only available when the HID keyboard "
-                "is enabled (or a physical keyboard is connected).",
+                "is enabled (or a physical keyboard is connected).\n"
+                "Also see --hid-mouse.",
     },
     {
         .shortopt = 'h',
@@ -213,6 +214,18 @@ static const struct sc_option options[] = {
         .argdesc = "value",
         .text = "Limit the frame rate of screen capture (officially supported "
                 "since Android 10, but may work on earlier versions).",
+    },
+    {
+        .shortopt = 'M',
+        .longopt = "hid-mouse",
+        .text = "Simulate a physical mouse by using HID over AOAv2.\n"
+                "In this mode, the computer mouse is captured to control the "
+                "device directly (relative mouse mode).\n"
+                "LAlt, LSuper or RSuper toggle the capture mode, to give "
+                "control of the mouse back to the computer.\n"
+                "It may only work over USB, and is currently only supported "
+                "on Linux.\n"
+                "Also see --hid-keyboard.",
     },
     {
         .shortopt = 'm',
@@ -1314,6 +1327,15 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 if (!parse_max_size(optarg, &opts->max_size)) {
                     return false;
                 }
+                break;
+            case 'M':
+#ifdef HAVE_AOA_HID
+                opts->mouse_input_mode = SC_MOUSE_INPUT_MODE_HID;
+#else
+                LOGE("HID over AOA (-M/--hid-mouse) is not supported on this"
+                     "platform. It is only available on Linux.");
+                return false;
+#endif
                 break;
             case OPT_LOCK_VIDEO_ORIENTATION:
                 if (!parse_lock_video_orientation(optarg,

--- a/app/src/common.h
+++ b/app/src/common.h
@@ -7,6 +7,7 @@
 #define ARRAY_LEN(a) (sizeof(a) / sizeof(a[0]))
 #define MIN(X,Y) (X) < (Y) ? (X) : (Y)
 #define MAX(X,Y) (X) > (Y) ? (X) : (Y)
+#define CLAMP(V,X,Y) MIN( MAX((V),(X)), (Y) )
 
 #define container_of(ptr, type, member) \
     ((type *) (((char *) (ptr)) - offsetof(type, member)))

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -119,7 +119,8 @@ control_msg_serialize(const struct control_msg *msg, unsigned char *buf) {
                              (uint32_t) msg->inject_scroll_event.hscroll);
             buffer_write32be(&buf[17],
                              (uint32_t) msg->inject_scroll_event.vscroll);
-            return 21;
+            buffer_write32be(&buf[21], msg->inject_scroll_event.buttons);
+            return 25;
         case CONTROL_MSG_TYPE_BACK_OR_SCREEN_ON:
             buf[1] = msg->inject_keycode.action;
             return 2;
@@ -192,11 +193,12 @@ control_msg_log(const struct control_msg *msg) {
         }
         case CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT:
             LOG_CMSG("scroll position=%" PRIi32 ",%" PRIi32 " hscroll=%" PRIi32
-                         " vscroll=%" PRIi32,
+                         " vscroll=%" PRIi32 " buttons=%06lx",
                      msg->inject_scroll_event.position.point.x,
                      msg->inject_scroll_event.position.point.y,
                      msg->inject_scroll_event.hscroll,
-                     msg->inject_scroll_event.vscroll);
+                     msg->inject_scroll_event.vscroll,
+                     (long) msg->inject_scroll_event.buttons);
             break;
         case CONTROL_MSG_TYPE_BACK_OR_SCREEN_ON:
             LOG_CMSG("back-or-screen-on %s",

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -70,6 +70,7 @@ struct control_msg {
             struct sc_position position;
             int32_t hscroll;
             int32_t vscroll;
+            enum android_motionevent_buttons buttons;
         } inject_scroll_event;
         struct {
             enum android_keyevent_action action; // action for the BACK key

--- a/app/src/hid_mouse.c
+++ b/app/src/hid_mouse.c
@@ -1,0 +1,267 @@
+#include "hid_mouse.h"
+
+#include <assert.h>
+
+#include "input_events.h"
+#include "util/log.h"
+
+/** Downcast mouse processor to hid_mouse */
+#define DOWNCAST(MP) container_of(MP, struct sc_hid_mouse, mouse_processor)
+
+#define HID_MOUSE_ACCESSORY_ID 2
+
+// 1 byte for buttons + padding, 1 byte for X position, 1 byte for Y position
+#define HID_MOUSE_EVENT_SIZE 4
+
+/**
+ * Mouse descriptor from the specification:
+ * <https://www.usb.org/sites/default/files/hid1_11.pdf>
+ *
+ * Appendix E (p71): §E.10 Report Descriptor (Mouse)
+ *
+ * The usage tags (like Wheel) are listed in "HID Usage Tables":
+ * <https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf>
+ * §4 Generic Desktop Page (0x01) (p26)
+ */
+static const unsigned char mouse_report_desc[]  = {
+    // Usage Page (Generic Desktop)
+    0x05, 0x01,
+    // Usage (Mouse)
+    0x09, 0x02,
+
+    // Collection (Application)
+    0xA1, 0x01,
+
+    // Usage (Pointer)
+    0x09, 0x01,
+
+    // Collection (Physical)
+    0xA1, 0x00,
+
+    // Usage Page (Buttons)
+    0x05, 0x09,
+
+    // Usage Minimum (1)
+    0x19, 0x01,
+     // Usage Maximum (5)
+    0x29, 0x05,
+    // Logical Minimum (0)
+    0x15, 0x00,
+    // Logical Maximum (1)
+    0x25, 0x01,
+    // Report Count (5)
+    0x95, 0x05,
+    // Report Size (1)
+    0x75, 0x01,
+    // Input (Data, Variable, Absolute): 5 buttons bits
+    0x81, 0x02,
+
+    // Report Count (1)
+    0x95, 0x01,
+    // Report Size (3)
+    0x75, 0x03,
+    // Input (Constant): 3 bits padding
+    0x81, 0x01,
+
+    // Usage Page (Generic Desktop)
+    0x05, 0x01,
+    // Usage (X)
+    0x09, 0x30,
+    // Usage (Y)
+    0x09, 0x31,
+    // Usage (Wheel)
+    0x09, 0x38,
+    // Local Minimum (-127)
+    0x15, 0x81,
+    // Local Maximum (127)
+    0x25, 0x7F,
+    // Report Size (8)
+    0x75, 0x08,
+    // Report Count (3)
+    0x95, 0x03,
+    // Input (Data, Variable, Relative): 3 position bytes (X, Y, Wheel)
+    0x81, 0x06,
+
+    // End Collection
+    0xC0,
+
+    // End Collection
+    0xC0,
+};
+
+/**
+ * A mouse HID event is 3 bytes long:
+ *
+ *  - byte 0: buttons state
+ *  - byte 1: relative x motion (signed byte from -127 to 127)
+ *  - byte 2: relative y motion (signed byte from -127 to 127)
+ *
+ *                   7 6 5 4 3 2 1 0
+ *                  +---------------+
+ *         byte 0:  |0 0 0 . . . . .| buttons state
+ *                  +---------------+
+ *                         ^ ^ ^ ^ ^
+ *                         | | | | `- left button
+ *                         | | | `--- right button
+ *                         | | `----- middle button
+ *                         | `------- button 4
+ *                         `--------- button 5
+ *
+ *                  +---------------+
+ *         byte 1:  |. . . . . . . .| relative x motion
+ *                  +---------------+
+ *         byte 2:  |. . . . . . . .| relative y motion
+ *                  +---------------+
+ *         byte 3:  |. . . . . . . .| wheel motion (-1, 0 or 1)
+ *                  +---------------+
+ *
+ * As an example, here is the report for a motion of (x=5, y=-4) with left
+ * button pressed:
+ *
+ *                  +---------------+
+ *                  |0 0 0 0 0 0 0 1| left button pressed
+ *                  +---------------+
+ *                  |0 0 0 0 0 1 0 1| horizontal motion (x = 5)
+ *                  +---------------+
+ *                  |1 1 1 1 1 1 0 0| relative y motion (y = -4)
+ *                  +---------------+
+ *                  |0 0 0 0 0 0 0 0| wheel motion
+ *                  +---------------+
+ */
+
+static bool
+sc_hid_mouse_event_init(struct sc_hid_event *hid_event) {
+    unsigned char *buffer = calloc(1, HID_MOUSE_EVENT_SIZE);
+    if (!buffer) {
+        LOG_OOM();
+        return false;
+    }
+
+    sc_hid_event_init(hid_event, HID_MOUSE_ACCESSORY_ID, buffer,
+                      HID_MOUSE_EVENT_SIZE);
+    return true;
+}
+
+static unsigned char
+buttons_state_to_hid_buttons(uint8_t buttons_state) {
+    unsigned char c = 0;
+    if (buttons_state & SC_MOUSE_BUTTON_LEFT) {
+        c |= 1 << 0;
+    }
+    if (buttons_state & SC_MOUSE_BUTTON_RIGHT) {
+        c |= 1 << 1;
+    }
+    if (buttons_state & SC_MOUSE_BUTTON_MIDDLE) {
+        c |= 1 << 2;
+    }
+    if (buttons_state & SC_MOUSE_BUTTON_X1) {
+        c |= 1 << 3;
+    }
+    if (buttons_state & SC_MOUSE_BUTTON_X2) {
+        c |= 1 << 4;
+    }
+    return c;
+}
+
+static void
+sc_mouse_processor_process_mouse_motion(struct sc_mouse_processor *mp,
+                                    const struct sc_mouse_motion_event *event) {
+    struct sc_hid_mouse *mouse = DOWNCAST(mp);
+
+    struct sc_hid_event hid_event;
+    if (!sc_hid_mouse_event_init(&hid_event)) {
+        return;
+    }
+
+    unsigned char *buffer = hid_event.buffer;
+    buffer[0] = buttons_state_to_hid_buttons(event->buttons_state);
+    buffer[1] = CLAMP(event->xrel, -127, 127);
+    buffer[2] = CLAMP(event->yrel, -127, 127);
+    buffer[3] = 0; // wheel coordinates only used for scrolling
+
+    if (!sc_aoa_push_hid_event(mouse->aoa, &hid_event)) {
+        sc_hid_event_destroy(&hid_event);
+        LOGW("Could request HID event");
+    }
+}
+
+static void
+sc_mouse_processor_process_mouse_click(struct sc_mouse_processor *mp,
+                                   const struct sc_mouse_click_event *event) {
+    struct sc_hid_mouse *mouse = DOWNCAST(mp);
+
+    struct sc_hid_event hid_event;
+    if (!sc_hid_mouse_event_init(&hid_event)) {
+        return;
+    }
+
+    unsigned char *buffer = hid_event.buffer;
+    buffer[0] = buttons_state_to_hid_buttons(event->buttons_state);
+    buffer[1] = 0; // no x motion
+    buffer[2] = 0; // no y motion
+    buffer[3] = 0; // wheel coordinates only used for scrolling
+
+    if (!sc_aoa_push_hid_event(mouse->aoa, &hid_event)) {
+        sc_hid_event_destroy(&hid_event);
+        LOGW("Could request HID event");
+    }
+}
+
+static void
+sc_mouse_processor_process_mouse_scroll(struct sc_mouse_processor *mp,
+                                    const struct sc_mouse_scroll_event *event) {
+    struct sc_hid_mouse *mouse = DOWNCAST(mp);
+
+    struct sc_hid_event hid_event;
+    if (!sc_hid_mouse_event_init(&hid_event)) {
+        return;
+    }
+
+    unsigned char *buffer = hid_event.buffer;
+    buffer[0] = 0; // buttons state irrelevant (and unknown)
+    buffer[1] = 0; // no x motion
+    buffer[2] = 0; // no y motion
+    // In practice, vscroll is always -1, 0 or 1, but in theory other values
+    // are possible
+    buffer[3] = CLAMP(event->vscroll, -127, 127);
+    // Horizontal scrolling ignored
+
+    if (!sc_aoa_push_hid_event(mouse->aoa, &hid_event)) {
+        sc_hid_event_destroy(&hid_event);
+        LOGW("Could request HID event");
+    }
+}
+
+bool
+sc_hid_mouse_init(struct sc_hid_mouse *mouse, struct sc_aoa *aoa) {
+    mouse->aoa = aoa;
+
+    bool ok = sc_aoa_setup_hid(aoa, HID_MOUSE_ACCESSORY_ID, mouse_report_desc,
+                               ARRAY_LEN(mouse_report_desc));
+    if (!ok) {
+        LOGW("Register HID mouse failed");
+        return false;
+    }
+
+    static const struct sc_mouse_processor_ops ops = {
+        .process_mouse_motion = sc_mouse_processor_process_mouse_motion,
+        .process_mouse_click = sc_mouse_processor_process_mouse_click,
+        .process_mouse_scroll = sc_mouse_processor_process_mouse_scroll,
+        // Touch events not supported (coordinates are not relative)
+        .process_touch = NULL,
+    };
+
+    mouse->mouse_processor.ops = &ops;
+
+    mouse->mouse_processor.relative_mode = true;
+
+    return true;
+}
+
+void
+sc_hid_mouse_destroy(struct sc_hid_mouse *mouse) {
+    bool ok = sc_aoa_unregister_hid(mouse->aoa, HID_MOUSE_ACCESSORY_ID);
+    if (!ok) {
+        LOGW("Could not unregister HID");
+    }
+}

--- a/app/src/hid_mouse.h
+++ b/app/src/hid_mouse.h
@@ -1,0 +1,23 @@
+#ifndef HID_MOUSE_H
+#define HID_MOUSE_H
+
+#include "common.h"
+
+#include <stdbool.h>
+
+#include "aoa_hid.h"
+#include "trait/mouse_processor.h"
+
+struct sc_hid_mouse {
+    struct sc_mouse_processor mouse_processor; // mouse processor trait
+
+    struct sc_aoa *aoa;
+};
+
+bool
+sc_hid_mouse_init(struct sc_hid_mouse *mouse, struct sc_aoa *aoa);
+
+void
+sc_hid_mouse_destroy(struct sc_hid_mouse *mouse);
+
+#endif

--- a/app/src/input_events.h
+++ b/app/src/input_events.h
@@ -360,6 +360,7 @@ struct sc_mouse_scroll_event {
     struct sc_position position;
     int32_t hscroll;
     int32_t vscroll;
+    uint8_t buttons_state; // bitwise-OR of sc_mouse_button values
 };
 
 struct sc_mouse_motion_event {

--- a/app/src/input_events.h
+++ b/app/src/input_events.h
@@ -365,6 +365,8 @@ struct sc_mouse_scroll_event {
 
 struct sc_mouse_motion_event {
     struct sc_position position;
+    int32_t xrel;
+    int32_t yrel;
     uint8_t buttons_state; // bitwise-OR of sc_mouse_button values
 };
 

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -659,7 +659,11 @@ input_manager_process_mouse_motion(struct input_manager *im,
     assert(im->mp->ops->process_mouse_motion);
     im->mp->ops->process_mouse_motion(im->mp, &evt);
 
+    // vfinger must never be used in relative mode
+    assert(!im->mp->relative_mode || !im->vfinger_down);
+
     if (im->vfinger_down) {
+        assert(!im->mp->relative_mode); // assert one more time
         struct sc_point mouse =
             screen_convert_window_to_frame_coords(im->screen, event->x,
                                                   event->y);
@@ -771,6 +775,12 @@ input_manager_process_mouse_button(struct input_manager *im,
 
     assert(im->mp->ops->process_mouse_click);
     im->mp->ops->process_mouse_click(im->mp, &evt);
+
+    if (im->mp->relative_mode) {
+        assert(!im->vfinger_down); // vfinger must not be used in relative mode
+        // No pinch-to-zoom simulation
+        return;
+    }
 
     // Pinch-to-zoom simulation.
     //

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -4,6 +4,7 @@
 #include <SDL2/SDL_keycode.h>
 
 #include "input_events.h"
+#include "screen.h"
 #include "util/log.h"
 
 static inline uint16_t

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -121,24 +121,22 @@ is_shortcut_mod(struct input_manager *im, uint16_t sdl_mod) {
 }
 
 void
-input_manager_init(struct input_manager *im, struct controller *controller,
-                   struct screen *screen, struct sc_key_processor *kp,
-                   struct sc_mouse_processor *mp,
-                   const struct scrcpy_options *options) {
-    assert(!options->control || (kp && kp->ops));
-    assert(!options->control || (mp && mp->ops));
+input_manager_init(struct input_manager *im,
+                   const struct input_manager_params *params) {
+    assert(!params->control || (params->kp && params->kp->ops));
+    assert(!params->control || (params->mp && params->mp->ops));
 
-    im->controller = controller;
-    im->screen = screen;
-    im->kp = kp;
-    im->mp = mp;
+    im->controller = params->controller;
+    im->screen = params->screen;
+    im->kp = params->kp;
+    im->mp = params->mp;
 
-    im->control = options->control;
-    im->forward_all_clicks = options->forward_all_clicks;
-    im->legacy_paste = options->legacy_paste;
-    im->clipboard_autosync = options->clipboard_autosync;
+    im->control = params->control;
+    im->forward_all_clicks = params->forward_all_clicks;
+    im->legacy_paste = params->legacy_paste;
+    im->clipboard_autosync = params->clipboard_autosync;
 
-    const struct sc_shortcut_mods *shortcut_mods = &options->shortcut_mods;
+    const struct sc_shortcut_mods *shortcut_mods = params->shortcut_mods;
     assert(shortcut_mods->count);
     assert(shortcut_mods->count < SC_MAX_SHORTCUT_MODS);
     for (unsigned i = 0; i < shortcut_mods->count; ++i) {

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -651,6 +651,8 @@ input_manager_process_mouse_motion(struct input_manager *im,
             .point = screen_convert_window_to_frame_coords(im->screen,
                                                            event->x, event->y),
         },
+        .xrel = event->xrel,
+        .yrel = event->yrel,
         .buttons_state =
             sc_mouse_buttons_state_from_sdl(event->state,
                                             im->forward_all_clicks),

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -810,7 +810,7 @@ input_manager_process_mouse_wheel(struct input_manager *im,
     // mouse_x and mouse_y are expressed in pixels relative to the window
     int mouse_x;
     int mouse_y;
-    SDL_GetMouseState(&mouse_x, &mouse_y);
+    uint32_t buttons = SDL_GetMouseState(&mouse_x, &mouse_y);
 
     struct sc_mouse_scroll_event evt = {
         .position = {
@@ -820,6 +820,8 @@ input_manager_process_mouse_wheel(struct input_manager *im,
         },
         .hscroll = event->x,
         .vscroll = event->y,
+        .buttons_state =
+            sc_mouse_buttons_state_from_sdl(buttons, im->forward_all_clicks),
     };
 
     im->mp->ops->process_mouse_scroll(im->mp, &evt);

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -632,14 +632,6 @@ static void
 input_manager_process_mouse_motion(struct input_manager *im,
                                    const SDL_MouseMotionEvent *event) {
 
-    uint32_t mask = SDL_BUTTON_LMASK;
-    if (im->forward_all_clicks) {
-        mask |= SDL_BUTTON_MMASK | SDL_BUTTON_RMASK;
-    }
-    if (!(event->state & mask)) {
-        // do not send motion events when no click is pressed
-        return;
-    }
     if (event->which == SDL_TOUCH_MOUSEID) {
         // simulated from touch events, so it's a duplicate
         return;

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -43,11 +43,22 @@ struct input_manager {
     uint64_t next_sequence; // used for request acknowledgements
 };
 
+struct input_manager_params {
+    struct controller *controller;
+    struct screen *screen;
+    struct sc_key_processor *kp;
+    struct sc_mouse_processor *mp;
+
+    bool control;
+    bool forward_all_clicks;
+    bool legacy_paste;
+    bool clipboard_autosync;
+    const struct sc_shortcut_mods *shortcut_mods;
+};
+
 void
-input_manager_init(struct input_manager *im, struct controller *controller,
-                   struct screen *screen, struct sc_key_processor *kp,
-                   struct sc_mouse_processor *mp,
-                   const struct scrcpy_options *options);
+input_manager_init(struct input_manager *im,
+                   const struct input_manager_params *params);
 
 bool
 input_manager_handle_event(struct input_manager *im, SDL_Event *event);

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -10,7 +10,6 @@
 #include "controller.h"
 #include "fps_counter.h"
 #include "options.h"
-#include "screen.h"
 #include "trait/key_processor.h"
 #include "trait/mouse_processor.h"
 

--- a/app/src/mouse_inject.c
+++ b/app/src/mouse_inject.c
@@ -151,4 +151,6 @@ sc_mouse_inject_init(struct sc_mouse_inject *mi,
     };
 
     mi->mouse_processor.ops = &ops;
+
+    mi->mouse_processor.relative_mode = false;
 }

--- a/app/src/mouse_inject.c
+++ b/app/src/mouse_inject.c
@@ -58,6 +58,11 @@ convert_touch_action(enum sc_touch_action action) {
 static void
 sc_mouse_processor_process_mouse_motion(struct sc_mouse_processor *mp,
                                     const struct sc_mouse_motion_event *event) {
+    if (!event->buttons_state) {
+        // Do not send motion events when no click is pressed
+        return;
+    }
+
     struct sc_mouse_inject *mi = DOWNCAST(mp);
 
     struct control_msg msg = {

--- a/app/src/mouse_inject.c
+++ b/app/src/mouse_inject.c
@@ -108,6 +108,7 @@ sc_mouse_processor_process_mouse_scroll(struct sc_mouse_processor *mp,
             .position = event->position,
             .hscroll = event->hscroll,
             .vscroll = event->vscroll,
+            .buttons = convert_mouse_buttons(event->buttons_state),
         },
     };
 

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -38,6 +38,11 @@ enum sc_keyboard_input_mode {
     SC_KEYBOARD_INPUT_MODE_HID,
 };
 
+enum sc_mouse_input_mode {
+    SC_MOUSE_INPUT_MODE_INJECT,
+    SC_MOUSE_INPUT_MODE_HID,
+};
+
 enum sc_key_inject_mode {
     // Inject special keys, letters and space as key events.
     // Inject numbers and punctuation as text events.
@@ -90,6 +95,7 @@ struct scrcpy_options {
     enum sc_log_level log_level;
     enum sc_record_format record_format;
     enum sc_keyboard_input_mode keyboard_input_mode;
+    enum sc_mouse_input_mode mouse_input_mode;
     struct sc_port_range port_range;
     uint32_t tunnel_host;
     uint16_t tunnel_port;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -456,8 +456,6 @@ scrcpy(struct scrcpy_options *options) {
 
             acksync = &s->acksync;
 
-            bool aoa_hid_ok = false;
-
             ok = sc_aoa_init(&s->aoa, serial, acksync);
             if (!ok) {
                 goto aoa_hid_end;
@@ -474,13 +472,12 @@ scrcpy(struct scrcpy_options *options) {
                 goto aoa_hid_end;
             }
 
-            aoa_hid_ok = true;
             kp = &s->keyboard_hid.key_processor;
 
             aoa_hid_initialized = true;
 
 aoa_hid_end:
-            if (!aoa_hid_ok) {
+            if (!aoa_hid_initialized) {
                 LOGE("Failed to enable HID over AOA, "
                      "fallback to default keyboard injection method "
                      "(-K/--hid-keyboard ignored)");

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -454,25 +454,27 @@ scrcpy(struct scrcpy_options *options) {
                 goto end;
             }
 
-            acksync = &s->acksync;
-
             ok = sc_aoa_init(&s->aoa, serial, acksync);
             if (!ok) {
+                sc_acksync_destroy(&s->acksync);
                 goto aoa_hid_end;
             }
 
             if (!sc_hid_keyboard_init(&s->keyboard_hid, &s->aoa)) {
+                sc_acksync_destroy(&s->acksync);
                 sc_aoa_destroy(&s->aoa);
                 goto aoa_hid_end;
             }
 
             if (!sc_aoa_start(&s->aoa)) {
+                sc_acksync_destroy(&s->acksync);
                 sc_hid_keyboard_destroy(&s->keyboard_hid);
                 sc_aoa_destroy(&s->aoa);
                 goto aoa_hid_end;
             }
 
             kp = &s->keyboard_hid.key_processor;
+            acksync = &s->acksync;
 
             aoa_hid_initialized = true;
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -455,34 +455,10 @@ scrcpy(struct scrcpy_options *options) {
             }
 
             acksync = &s->acksync;
-        }
-#endif
-        if (!controller_init(&s->controller, s->server.control_socket,
-                             acksync)) {
-            goto end;
-        }
-        controller_initialized = true;
 
-        if (!controller_start(&s->controller)) {
-            goto end;
-        }
-        controller_started = true;
-
-        if (options->turn_screen_off) {
-            struct control_msg msg;
-            msg.type = CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE;
-            msg.set_screen_power_mode.mode = SCREEN_POWER_MODE_OFF;
-
-            if (!controller_push_msg(&s->controller, &msg)) {
-                LOGW("Could not request 'set screen power mode'");
-            }
-        }
-
-#ifdef HAVE_AOA_HID
-        if (options->keyboard_input_mode == SC_KEYBOARD_INPUT_MODE_HID) {
             bool aoa_hid_ok = false;
 
-            bool ok = sc_aoa_init(&s->aoa, serial, acksync);
+            ok = sc_aoa_init(&s->aoa, serial, acksync);
             if (!ok) {
                 goto aoa_hid_end;
             }
@@ -524,6 +500,28 @@ aoa_hid_end:
 
         sc_mouse_inject_init(&s->mouse_inject, &s->controller);
         mp = &s->mouse_inject.mouse_processor;
+
+        if (!controller_init(&s->controller, s->server.control_socket,
+                             acksync)) {
+            goto end;
+        }
+        controller_initialized = true;
+
+        if (!controller_start(&s->controller)) {
+            goto end;
+        }
+        controller_started = true;
+
+        if (options->turn_screen_off) {
+            struct control_msg msg;
+            msg.type = CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE;
+            msg.set_screen_power_mode.mode = SCREEN_POWER_MODE_OFF;
+
+            if (!controller_push_msg(&s->controller, &msg)) {
+                LOGW("Could not request 'set screen power mode'");
+            }
+        }
+
     }
 
     if (options->display) {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -19,6 +19,7 @@
 #include "file_handler.h"
 #ifdef HAVE_AOA_HID
 # include "hid_keyboard.h"
+# include "hid_mouse.h"
 #endif
 #include "keyboard_inject.h"
 #include "mouse_inject.h"
@@ -55,7 +56,12 @@ struct scrcpy {
         struct sc_hid_keyboard keyboard_hid;
 #endif
     };
-    struct sc_mouse_inject mouse_inject;
+    union {
+        struct sc_mouse_inject mouse_inject;
+#ifdef HAVE_AOA_HID
+        struct sc_hid_mouse mouse_hid;
+#endif
+    };
 };
 
 static inline void
@@ -330,6 +336,7 @@ scrcpy(struct scrcpy_options *options) {
 #ifdef HAVE_AOA_HID
     bool aoa_hid_initialized = false;
     bool hid_keyboard_initialized = false;
+    bool hid_mouse_initialized = false;
 #endif
     bool controller_initialized = false;
     bool controller_started = false;
@@ -451,7 +458,9 @@ scrcpy(struct scrcpy_options *options) {
 #ifdef HAVE_AOA_HID
         bool use_hid_keyboard =
             options->keyboard_input_mode == SC_KEYBOARD_INPUT_MODE_HID;
-        if (use_hid_keyboard) {
+        bool use_hid_mouse =
+            options->mouse_input_mode == SC_MOUSE_INPUT_MODE_HID;
+        if (use_hid_keyboard || use_hid_mouse) {
             bool ok = sc_acksync_init(&s->acksync);
             if (!ok) {
                 goto end;
@@ -473,7 +482,16 @@ scrcpy(struct scrcpy_options *options) {
                 }
             }
 
-            bool need_aoa = hid_keyboard_initialized;
+            if (use_hid_mouse) {
+                if (sc_hid_mouse_init(&s->mouse_hid, &s->aoa)) {
+                    hid_mouse_initialized = true;
+                    mp = &s->mouse_hid.mouse_processor;
+                } else {
+                    LOGE("Could not initialized HID mouse");
+                }
+            }
+
+            bool need_aoa = hid_keyboard_initialized || hid_mouse_initialized;
 
             if (!need_aoa || !sc_aoa_start(&s->aoa)) {
                 sc_acksync_destroy(&s->acksync);
@@ -491,6 +509,10 @@ aoa_hid_end:
                     sc_hid_keyboard_destroy(&s->keyboard_hid);
                     hid_keyboard_initialized = false;
                 }
+                if (hid_mouse_initialized) {
+                    sc_hid_mouse_destroy(&s->mouse_hid);
+                    hid_mouse_initialized = false;
+                }
             }
 
             if (use_hid_keyboard && !hid_keyboard_initialized) {
@@ -498,9 +520,16 @@ aoa_hid_end:
                      "(-K/--hid-keyboard ignored)");
                 options->keyboard_input_mode = SC_KEYBOARD_INPUT_MODE_INJECT;
             }
+
+            if (use_hid_mouse && !hid_mouse_initialized) {
+                LOGE("Fallback to default mouse injection method "
+                     "(-M/--hid-mouse ignored)");
+                options->mouse_input_mode = SC_MOUSE_INPUT_MODE_INJECT;
+            }
         }
 #else
         assert(options->keyboard_input_mode != SC_KEYBOARD_INPUT_MODE_HID);
+        assert(options->mouse_input_mode != SC_MOUSE_INPUT_MODE_HID);
 #endif
 
         // keyboard_input_mode may have been reset if HID mode failed
@@ -510,8 +539,11 @@ aoa_hid_end:
             kp = &s->keyboard_inject.key_processor;
         }
 
-        sc_mouse_inject_init(&s->mouse_inject, &s->controller);
-        mp = &s->mouse_inject.mouse_processor;
+        // mouse_input_mode may have been reset if HID mode failed
+        if (options->mouse_input_mode == SC_MOUSE_INPUT_MODE_INJECT) {
+            sc_mouse_inject_init(&s->mouse_inject, &s->controller);
+            mp = &s->mouse_inject.mouse_processor;
+        }
 
         if (!controller_init(&s->controller, s->server.control_socket,
                              acksync)) {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -582,8 +582,19 @@ aoa_hid_end:
         mp = &s->mouse_inject.mouse_processor;
     }
 
-    input_manager_init(&s->input_manager, &s->controller, &s->screen, kp, mp,
-                       options);
+    struct input_manager_params im_params = {
+        .controller = &s->controller,
+        .screen = &s->screen,
+        .kp = kp,
+        .mp = mp,
+        .control = options->control,
+        .forward_all_clicks = options->forward_all_clicks,
+        .legacy_paste = options->legacy_paste,
+        .clipboard_autosync = options->clipboard_autosync,
+        .shortcut_mods = &options->shortcut_mods,
+    };
+
+    input_manager_init(&s->input_manager, &im_params);
 
     ret = event_loop(s, options);
     LOGD("quit...");

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -470,6 +470,20 @@ screen_init(struct screen *screen, const struct screen_params *params) {
         goto error_destroy_texture;
     }
 
+    struct input_manager_params im_params = {
+        .controller = params->controller,
+        .screen = screen,
+        .kp = params->kp,
+        .mp = params->mp,
+        .control = params->control,
+        .forward_all_clicks = params->forward_all_clicks,
+        .legacy_paste = params->legacy_paste,
+        .clipboard_autosync = params->clipboard_autosync,
+        .shortcut_mods = params->shortcut_mods,
+    };
+
+    input_manager_init(&screen->im, &im_params);
+
     // Reset the window size to trigger a SIZE_CHANGED event, to workaround
     // HiDPI issues with some SDL renderers when several displays having
     // different HiDPI scaling are connected
@@ -773,7 +787,7 @@ screen_handle_event(struct screen *screen, SDL_Event *event) {
             return true;
     }
 
-    return false;
+    return input_manager_handle_event(&screen->im, event);
 }
 
 struct sc_point

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -51,6 +51,11 @@ struct screen {
 
     bool event_failed; // in case SDL_PushEvent() returned an error
 
+    bool mouse_captured; // only relevant in relative mouse mode
+    // To enable/disable mouse capture, a mouse capture key (LALT, LGUI or
+    // RGUI) must be pressed. This variable tracks the pressed capture key.
+    SDL_Keycode mouse_capture_key_pressed;
+
     AVFrame *frame;
 };
 

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -7,10 +7,14 @@
 #include <SDL2/SDL.h>
 #include <libavformat/avformat.h>
 
+#include "controller.h"
 #include "coords.h"
 #include "fps_counter.h"
+#include "input_manager.h"
 #include "opengl.h"
+#include "trait/key_processor.h"
 #include "trait/frame_sink.h"
+#include "trait/mouse_processor.h"
 #include "video_buffer.h"
 
 struct screen {
@@ -20,6 +24,7 @@ struct screen {
     bool open; // track the open/close state to assert correct behavior
 #endif
 
+    struct input_manager im;
     struct sc_video_buffer vb;
     struct fps_counter fps_counter;
 
@@ -50,6 +55,16 @@ struct screen {
 };
 
 struct screen_params {
+    struct controller *controller;
+    struct sc_key_processor *kp;
+    struct sc_mouse_processor *mp;
+
+    bool control;
+    bool forward_all_clicks;
+    bool legacy_paste;
+    bool clipboard_autosync;
+    const struct sc_shortcut_mods *shortcut_mods;
+
     const char *window_title;
     struct sc_size frame_size;
     bool always_on_top;

--- a/app/src/trait/mouse_processor.h
+++ b/app/src/trait/mouse_processor.h
@@ -16,6 +16,13 @@
  */
 struct sc_mouse_processor {
     const struct sc_mouse_processor_ops *ops;
+
+    /**
+     * If set, the mouse processor works in relative mode (the absolute
+     * position is irrelevant). In particular, it indicates that the mouse
+     * pointer must be "captured" by the UI.
+     */
+    bool relative_mode;
 };
 
 struct sc_mouse_processor_ops {

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -126,12 +126,13 @@ static void test_serialize_inject_scroll_event(void) {
             },
             .hscroll = 1,
             .vscroll = -1,
+            .buttons = 1,
         },
     };
 
     unsigned char buf[CONTROL_MSG_MAX_SIZE];
     size_t size = control_msg_serialize(&msg, buf);
-    assert(size == 21);
+    assert(size == 25);
 
     const unsigned char expected[] = {
         CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT,
@@ -139,6 +140,7 @@ static void test_serialize_inject_scroll_event(void) {
         0x04, 0x38, 0x07, 0x80, // 1080 1920
         0x00, 0x00, 0x00, 0x01, // 1
         0xFF, 0xFF, 0xFF, 0xFF, // -1
+        0x00, 0x00, 0x00, 0x01, // 1
     };
     assert(!memcmp(buf, expected, sizeof(expected)));
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
@@ -71,12 +71,13 @@ public final class ControlMessage {
         return msg;
     }
 
-    public static ControlMessage createInjectScrollEvent(Position position, int hScroll, int vScroll) {
+    public static ControlMessage createInjectScrollEvent(Position position, int hScroll, int vScroll, int buttons) {
         ControlMessage msg = new ControlMessage();
         msg.type = TYPE_INJECT_SCROLL_EVENT;
         msg.position = position;
         msg.hScroll = hScroll;
         msg.vScroll = vScroll;
+        msg.buttons = buttons;
         return msg;
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
@@ -10,7 +10,7 @@ public class ControlMessageReader {
 
     static final int INJECT_KEYCODE_PAYLOAD_LENGTH = 13;
     static final int INJECT_TOUCH_EVENT_PAYLOAD_LENGTH = 27;
-    static final int INJECT_SCROLL_EVENT_PAYLOAD_LENGTH = 20;
+    static final int INJECT_SCROLL_EVENT_PAYLOAD_LENGTH = 24;
     static final int BACK_OR_SCREEN_ON_LENGTH = 1;
     static final int SET_SCREEN_POWER_MODE_PAYLOAD_LENGTH = 1;
     static final int GET_CLIPBOARD_LENGTH = 1;
@@ -154,7 +154,8 @@ public class ControlMessageReader {
         Position position = readPosition(buffer);
         int hScroll = buffer.getInt();
         int vScroll = buffer.getInt();
-        return ControlMessage.createInjectScrollEvent(position, hScroll, vScroll);
+        int buttons = buffer.getInt();
+        return ControlMessage.createInjectScrollEvent(position, hScroll, vScroll, buttons);
     }
 
     private ControlMessage parseBackOrScreenOnEvent() {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -98,7 +98,7 @@ public class Controller {
                 break;
             case ControlMessage.TYPE_INJECT_SCROLL_EVENT:
                 if (device.supportsInputEvents()) {
-                    injectScroll(msg.getPosition(), msg.getHScroll(), msg.getVScroll());
+                    injectScroll(msg.getPosition(), msg.getHScroll(), msg.getVScroll(), msg.getButtons());
                 }
                 break;
             case ControlMessage.TYPE_BACK_OR_SCREEN_ON:
@@ -221,7 +221,7 @@ public class Controller {
         return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
     }
 
-    private boolean injectScroll(Position position, int hScroll, int vScroll) {
+    private boolean injectScroll(Position position, int hScroll, int vScroll, int buttons) {
         long now = SystemClock.uptimeMillis();
         Point point = device.getPhysicalPoint(position);
         if (point == null) {
@@ -239,7 +239,7 @@ public class Controller {
         coords.setAxisValue(MotionEvent.AXIS_VSCROLL, vScroll);
 
         MotionEvent event = MotionEvent
-                .obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, 0, 1f, 1f, DEFAULT_DEVICE_ID, 0,
+                .obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0,
                         InputDevice.SOURCE_MOUSE, 0);
         return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
     }

--- a/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
@@ -128,6 +128,7 @@ public class ControlMessageReaderTest {
         dos.writeShort(1920);
         dos.writeInt(1);
         dos.writeInt(-1);
+        dos.writeInt(1);
 
         byte[] packet = bos.toByteArray();
 
@@ -144,6 +145,7 @@ public class ControlMessageReaderTest {
         Assert.assertEquals(1920, event.getPosition().getScreenSize().getHeight());
         Assert.assertEquals(1, event.getHScroll());
         Assert.assertEquals(-1, event.getVScroll());
+        Assert.assertEquals(1, event.getButtons());
     }
 
     @Test


### PR DESCRIPTION
Similar to the `--hid-keyboard` (or `-K`) added in scrcpy v1.20 (#2632), add a new option `--hid-mouse` (or `-M`).

Basically, you can run `scrcpy` with both HID keyboard and mouse with:

```bash
scrcpy -KM
```

The mouse is "captured": the mouse pointer disappears from the computer and appears on the Android device.

Special captures keys, either <kbd>Alt</kbd> or <kbd>Super</kbd>, toggle (disable or enable) the mouse capture. Use one of them to give the control of the mouse back to the computer.

These capture keys do not conflict with shortcuts, since a shortcut is always a combination of the <kbd>MOD</kbd> key and some other key, while the capture key triggers an action only if it is pressed and released alone.

Like HID keyboard, it works only when the device is connected via USB, and is only supported on Linux.

Tests and feedback welcome.

cc @AlynxZhou (author of #2632)
cc @JonasLoeffelholz (author of #2653)
cc @chldbwnstm (https://github.com/Genymobile/scrcpy/pull/2632#issuecomment-951942015)

---

This PR is based on previous refactors I already pushed to `dev` branch to support the feature properly.

When run with `-KM --forward-all-clicks`, on Firefox/Android, mouse button 4 works as expected (previous page), but mouse button 5 does not (I'd expect to go to the next page). I don't know if I did something wrong or if it is not expected to go to the next page.