### PR TITLE
Automatically try with a lower definition on MediaCodec error

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -219,6 +219,9 @@ scrcpy -m 1024
 scrcpy -m 800
 ```
 
+Since scrcpy v1.22, scrcpy automatically tries again with a lower definition
+before failing. This behavior can be disabled with `--no-downsize-on-error`.
+
 You could also try another [encoder](README.md#encoder).
 
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -141,6 +141,12 @@ By default, scrcpy automatically synchronizes the computer clipboard to the devi
 This option disables this automatic synchronization.
 
 .TP
+.B \-\-no\-downsize\-on\-error
+By default, on MediaCodec error, scrcpy automatically tries again with a lower definition.
+
+This option disables this behavior.
+
+.TP
 .B \-n, \-\-no\-control
 Disable device control (mirror the device in read\-only).
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -1545,11 +1545,18 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         return false;
     }
 
-    if (opts->v4l2_device && opts->lock_video_orientation
-                             == SC_LOCK_VIDEO_ORIENTATION_UNLOCKED) {
-        LOGI("Video orientation is locked for v4l2 sink. "
-             "See --lock-video-orientation.");
-        opts->lock_video_orientation = SC_LOCK_VIDEO_ORIENTATION_INITIAL;
+    if (opts->v4l2_device) {
+        if (opts->lock_video_orientation ==
+                SC_LOCK_VIDEO_ORIENTATION_UNLOCKED) {
+            LOGI("Video orientation is locked for v4l2 sink. "
+                 "See --lock-video-orientation.");
+            opts->lock_video_orientation = SC_LOCK_VIDEO_ORIENTATION_INITIAL;
+        }
+
+        // V4L2 could not handle size change.
+        // Do not log because downsizing on error is the default behavior,
+        // not an explicit request from the user.
+        opts->downsize_on_error = false;
     }
 
     if (opts->v4l2_buffer && !opts->v4l2_device) {

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -52,6 +52,7 @@
 #define OPT_NO_CLIPBOARD_AUTOSYNC  1032
 #define OPT_TCPIP                  1033
 #define OPT_RAW_KEY_EVENTS         1034
+#define OPT_NO_DOWNSIZE_ON_ERROR   1035
 
 struct sc_option {
     char shortopt;
@@ -235,6 +236,13 @@ static const struct sc_option options[] = {
                 "other dimension is computed so that the device aspect-ratio "
                 "is preserved.\n"
                 "Default is 0 (unlimited).",
+    },
+    {
+        .longopt_id = OPT_NO_DOWNSIZE_ON_ERROR,
+        .longopt = "no-downsize-on-error",
+        .text = "By default, on MediaCodec error, scrcpy automatically tries "
+                "again with a lower definition.\n"
+                "This option disables this behavior.",
     },
     {
         .longopt_id = OPT_NO_CLIPBOARD_AUTOSYNC,
@@ -1488,6 +1496,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_TCPIP:
                 opts->tcpip = true;
                 opts->tcpip_dst = optarg;
+                break;
+            case OPT_NO_DOWNSIZE_ON_ERROR:
+                opts->downsize_on_error = false;
                 break;
             case OPT_V4L2_SINK:
 #ifdef HAVE_V4L2

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -54,6 +54,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .legacy_paste = false,
     .power_off_on_close = false,
     .clipboard_autosync = true,
+    .downsize_on_error = true,
     .tcpip = false,
     .tcpip_dst = NULL,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -129,6 +129,7 @@ struct scrcpy_options {
     bool legacy_paste;
     bool power_off_on_close;
     bool clipboard_autosync;
+    bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
 };

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -364,6 +364,7 @@ scrcpy(struct scrcpy_options *options) {
         .force_adb_forward = options->force_adb_forward,
         .power_off_on_close = options->power_off_on_close,
         .clipboard_autosync = options->clipboard_autosync,
+        .downsize_on_error = options->downsize_on_error,
         .tcpip = options->tcpip,
         .tcpip_dst = options->tcpip_dst,
     };

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -693,6 +693,12 @@ sc_screen_update_frame(struct sc_screen *screen) {
     }
     update_texture(screen, frame);
 
+    if (!screen->has_frame) {
+        screen->has_frame = true;
+        // this is the very first frame, show the window
+        sc_screen_show_window(screen);
+    }
+
     sc_screen_render(screen, false);
     return true;
 }
@@ -763,17 +769,13 @@ sc_screen_is_mouse_capture_key(SDL_Keycode key) {
 bool
 sc_screen_handle_event(struct sc_screen *screen, SDL_Event *event) {
     switch (event->type) {
-        case EVENT_NEW_FRAME:
-            if (!screen->has_frame) {
-                screen->has_frame = true;
-                // this is the very first frame, show the window
-                sc_screen_show_window(screen);
-            }
+        case EVENT_NEW_FRAME: {
             bool ok = sc_screen_update_frame(screen);
             if (!ok) {
                 LOGW("Frame update failed\n");
             }
             return true;
+        }
         case SDL_WINDOWEVENT:
             if (!screen->has_frame) {
                 // Do nothing

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -28,6 +28,15 @@ struct sc_screen {
     struct sc_video_buffer vb;
     struct fps_counter fps_counter;
 
+    // The initial requested window properties
+    struct {
+        int16_t x;
+        int16_t y;
+        uint16_t width;
+        uint16_t height;
+        bool fullscreen;
+    } req;
+
     SDL_Window *window;
     SDL_Renderer *renderer;
     SDL_Texture *texture;

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -74,10 +74,10 @@ struct sc_screen_params {
     struct sc_size frame_size;
     bool always_on_top;
 
-    int16_t window_x;
-    int16_t window_y;
-    uint16_t window_width;  // accepts SC_WINDOW_POSITION_UNDEFINED
-    uint16_t window_height; // accepts SC_WINDOW_POSITION_UNDEFINED
+    int16_t window_x; // accepts SC_WINDOW_POSITION_UNDEFINED
+    int16_t window_y; // accepts SC_WINDOW_POSITION_UNDEFINED
+    uint16_t window_width;
+    uint16_t window_height;
 
     bool window_borderless;
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -234,6 +234,10 @@ execute_server(struct sc_server *server,
         // By default, clipboard_autosync is true
         ADD_PARAM("clipboard_autosync=false");
     }
+    if (!params->downsize_on_error) {
+        // By default, downsize_on_error is true
+        ADD_PARAM("downsize_on_error=false");
+    }
 
 #undef ADD_PARAM
 #undef STRBOOL

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -42,6 +42,7 @@ struct sc_server_params {
     bool force_adb_forward;
     bool power_off_on_close;
     bool clipboard_autosync;
+    bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
 };

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -42,6 +42,11 @@ public final class Device {
         void onClipboardTextChanged(String text);
     }
 
+    private final Size deviceSize;
+    private final Rect crop;
+    private final int maxSize;
+    private final int lockVideoOrientation;
+
     private ScreenInfo screenInfo;
     private RotationListener rotationListener;
     private ClipboardListener clipboardListener;
@@ -69,8 +74,12 @@ public final class Device {
 
         int displayInfoFlags = displayInfo.getFlags();
 
-        screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), displayInfo.getSize(), options.getCrop(), options.getMaxSize(),
-                options.getLockVideoOrientation());
+        deviceSize = displayInfo.getSize();
+        crop = options.getCrop();
+        maxSize = options.getMaxSize();
+        lockVideoOrientation = options.getLockVideoOrientation();
+
+        screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), deviceSize, crop, maxSize, lockVideoOrientation);
         layerStack = displayInfo.getLayerStack();
 
         SERVICE_MANAGER.getWindowManager().registerRotationWatcher(new IRotationWatcher.Stub() {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -69,7 +69,8 @@ public final class Device {
 
         int displayInfoFlags = displayInfo.getFlags();
 
-        screenInfo = ScreenInfo.computeScreenInfo(displayInfo, options.getCrop(), options.getMaxSize(), options.getLockVideoOrientation());
+        screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), displayInfo.getSize(), options.getCrop(), options.getMaxSize(),
+                options.getLockVideoOrientation());
         layerStack = displayInfo.getLayerStack();
 
         SERVICE_MANAGER.getWindowManager().registerRotationWatcher(new IRotationWatcher.Stub() {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -44,7 +44,7 @@ public final class Device {
 
     private final Size deviceSize;
     private final Rect crop;
-    private final int maxSize;
+    private int maxSize;
     private final int lockVideoOrientation;
 
     private ScreenInfo screenInfo;
@@ -131,6 +131,11 @@ public final class Device {
         if (!supportsInputEvents) {
             Ln.w("Input events are not supported for secondary displays before Android 10");
         }
+    }
+
+    public synchronized void setMaxSize(int newMaxSize) {
+        maxSize = newMaxSize;
+        screenInfo = ScreenInfo.computeScreenInfo(screenInfo.getReverseVideoRotation(), deviceSize, crop, newMaxSize, lockVideoOrientation);
     }
 
     public synchronized ScreenInfo getScreenInfo() {

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -21,6 +21,7 @@ public class Options {
     private String encoderName;
     private boolean powerOffScreenOnClose;
     private boolean clipboardAutosync = true;
+    private boolean downsizeOnError = true;
 
     public Ln.Level getLogLevel() {
         return logLevel;
@@ -148,5 +149,13 @@ public class Options {
 
     public void setClipboardAutosync(boolean clipboardAutosync) {
         this.clipboardAutosync = clipboardAutosync;
+    }
+
+    public boolean getDownsizeOnError() {
+        return downsizeOnError;
+    }
+
+    public void setDownsizeOnError(boolean downsizeOnError) {
+        this.downsizeOnError = downsizeOnError;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -38,14 +38,17 @@ public class ScreenEncoder implements Device.RotationListener {
     private final int bitRate;
     private final int maxFps;
     private final boolean sendFrameMeta;
+    private final boolean downsizeOnError;
     private long ptsOrigin;
 
-    public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, List<CodecOption> codecOptions, String encoderName) {
+    public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, List<CodecOption> codecOptions, String encoderName,
+            boolean downsizeOnError) {
         this.sendFrameMeta = sendFrameMeta;
         this.bitRate = bitRate;
         this.maxFps = maxFps;
         this.codecOptions = codecOptions;
         this.encoderName = encoderName;
+        this.downsizeOnError = downsizeOnError;
     }
 
     @Override
@@ -96,6 +99,11 @@ public class ScreenEncoder implements Device.RotationListener {
                     codec.stop();
                 } catch (Exception e) {
                     Ln.e("Encoding error: " + e.getClass().getName() + ": " + e.getMessage());
+                    if (!downsizeOnError) {
+                        // Fail immediately
+                        throw e;
+                    }
+
                     int newMaxSize = chooseMaxSizeFallback(screenInfo.getVideoSize());
                     if (newMaxSize == 0) {
                         // Definitively fail

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -41,6 +41,8 @@ public class ScreenEncoder implements Device.RotationListener {
     private final boolean downsizeOnError;
     private long ptsOrigin;
 
+    private boolean firstFrameSent;
+
     public ScreenEncoder(boolean sendFrameMeta, int bitRate, int maxFps, List<CodecOption> codecOptions, String encoderName,
             boolean downsizeOnError) {
         this.sendFrameMeta = sendFrameMeta;
@@ -99,7 +101,7 @@ public class ScreenEncoder implements Device.RotationListener {
                     codec.stop();
                 } catch (Exception e) {
                     Ln.e("Encoding error: " + e.getClass().getName() + ": " + e.getMessage());
-                    if (!downsizeOnError) {
+                    if (!downsizeOnError || firstFrameSent) {
                         // Fail immediately
                         throw e;
                     }
@@ -157,6 +159,7 @@ public class ScreenEncoder implements Device.RotationListener {
                     }
 
                     IO.writeFully(fd, codecBuffer);
+                    firstFrameSent = true;
                 }
             } finally {
                 if (outputBufferId >= 0) {

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenInfo.java
@@ -80,15 +80,12 @@ public final class ScreenInfo {
         return new ScreenInfo(newContentRect, newUnlockedVideoSize, newDeviceRotation, lockedVideoOrientation);
     }
 
-    public static ScreenInfo computeScreenInfo(DisplayInfo displayInfo, Rect crop, int maxSize, int lockedVideoOrientation) {
-        int rotation = displayInfo.getRotation();
-
+    public static ScreenInfo computeScreenInfo(int rotation, Size deviceSize, Rect crop, int maxSize, int lockedVideoOrientation) {
         if (lockedVideoOrientation == Device.LOCK_VIDEO_ORIENTATION_INITIAL) {
             // The user requested to lock the video orientation to the current orientation
             lockedVideoOrientation = rotation;
         }
 
-        Size deviceSize = displayInfo.getSize();
         Rect contentRect = new Rect(0, 0, deviceSize.getWidth(), deviceSize.getHeight());
         if (crop != null) {
             if (rotation % 2 != 0) { // 180s preserve dimensions

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -70,7 +70,7 @@ public final class Server {
 
         try (DesktopConnection connection = DesktopConnection.open(device, tunnelForward, control)) {
             ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps(), codecOptions,
-                    options.getEncoderName());
+                    options.getEncoderName(), options.getDownsizeOnError());
 
             Thread controllerThread = null;
             Thread deviceMessageSenderThread = null;
@@ -236,6 +236,10 @@ public final class Server {
                 case "clipboard_autosync":
                     boolean clipboardAutosync = Boolean.parseBoolean(value);
                     options.setClipboardAutosync(clipboardAutosync);
+                    break;
+                case "downsize_on_error":
+                    boolean downsizeOnError = Boolean.parseBoolean(value);
+                    options.setDownsizeOnError(downsizeOnError);
                     break;
                 default:
                     Ln.w("Unknown server option: " + key);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -1,7 +1,6 @@
 package com.genymobile.scrcpy;
 
 import android.graphics.Rect;
-import android.media.MediaCodec;
 import android.media.MediaCodecInfo;
 import android.os.BatteryManager;
 import android.os.Build;
@@ -267,16 +266,6 @@ public final class Server {
     }
 
     private static void suggestFix(Throwable e) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if (e instanceof MediaCodec.CodecException) {
-                MediaCodec.CodecException mce = (MediaCodec.CodecException) e;
-                if (mce.getErrorCode() == 0xfffffc0e) {
-                    Ln.e("The hardware encoder is not able to encode at the given definition.");
-                    Ln.e("Try with a lower definition:");
-                    Ln.e("    scrcpy -m 1024");
-                }
-            }
-        }
         if (e instanceof InvalidDisplayIdException) {
             InvalidDisplayIdException idie = (InvalidDisplayIdException) e;
             int[] displayIds = idie.getAvailableDisplayIds();


### PR DESCRIPTION
Some devices are not able to encode at the device screen definition.
    
Instead of just failing, automatically try with a lower definition (fallback) on any MediaCodec error.

This is a recurrent issue for new users. The solution is explained in the [FAQ](https://github.com/Genymobile/scrcpy/blob/master/FAQ.md#exception) (and sometimes in the error message, depending on the error), but it will help a lot if scrcpy automatically retries with different "max size" values.

An option `--no-downsize-on-error` is also added to disable this behavior.

Here are binaries (replace in your v1.21 release):

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2947/3/scrcpy.exe) _sha256:bdf50503f7f0f2771758abd877344e10a7cd37d3b3539bef2d80c7323807a41e_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2947/3/scrcpy-server) _sha256:c2edcdb775776d5bca93fe04ca37159c7dc2cd36a6b7619e583c702e75eaa855_

<details><summary>v2 (obsolete)</summary>

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2947/2/scrcpy.exe) _sha256:9f43f1ef5452b0a826cce78740fd2b93582b36accd5b9295796322c1ee02c5f8_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2947/2/scrcpy-server) _sha256:86d9c13a88f9523150017c50061bf04b5ad234808139df31b337c2701e6b3791_

</details>

<details><summary>v1 (obsolete)</summary>

 - [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/2947/1/scrcpy.exe) _sha256:d5043a52eb572b445ffc4410d8327bb363258d0303dd645bc56423805296694d_
 - [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/2947/1/scrcpy-server) _sha256:86d9c13a88f9523150017c50061bf04b5ad234808139df31b337c2701e6b3791_

</details>

I don't have any device which actually fails, so tests and feedback are welcome.