### PR TITLE
Improve device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ scrcpy -b2M -m800  # short version
 
 #### Multi-devices
 
-If several devices are listed in `adb devices`, you must specify the _serial_:
+If several devices are listed in `adb devices`, you can specify the _serial_:
 
 ```bash
 scrcpy --serial 0123456789abcdef
@@ -434,6 +434,19 @@ If the device is connected over TCP/IP:
 ```bash
 scrcpy --serial 192.168.0.1:5555
 scrcpy -s 192.168.0.1:5555  # short version
+```
+
+If only one device is connected via either USB or TCP/IP, it is possible to
+select it automatically:
+
+```bash
+# Select the only device connected via USB
+scrcpy -d             # like adb -d
+scrcpy --select-usb   # long version
+
+# Select the only device connected via TCP/IP
+scrcpy -e             # like adb -e
+scrcpy --select-tcpip # long version
 ```
 
 You can start several instances of _scrcpy_ for several devices.

--- a/app/meson.build
+++ b/app/meson.build
@@ -1,6 +1,7 @@
 src = [
     'src/main.c',
     'src/adb/adb.c',
+    'src/adb/adb_device.c',
     'src/adb/adb_parser.c',
     'src/adb/adb_tunnel.c',
     'src/cli.c',
@@ -221,6 +222,7 @@ if get_option('buildtype') == 'debug'
     tests = [
         ['test_adb_parser', [
             'tests/test_adb_parser.c',
+            'src/adb/adb_device.c',
             'src/adb/adb_parser.c',
             'src/util/str.c',
             'src/util/strbuf.c',

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -44,6 +44,12 @@ The values are expressed in the device natural orientation (typically, portrait 
 value is computed on the cropped size.
 
 .TP
+.B \-d, \-\-select\-usb
+Use USB device (if there is exactly one, like adb -d).
+
+Also see \fB\-e\fR (\fB\-\-select\-tcpip\fR).
+
+.TP
 .BI "\-\-disable-screensaver"
 Disable screensaver while scrcpy is running.
 
@@ -61,6 +67,12 @@ Default is 0.
 Add a buffering delay (in milliseconds) before displaying. This increases latency to compensate for jitter.
 
 Default is 0 (no buffering).
+
+.TP
+.B \-e, \-\-select\-tcpip
+Use TCP/IP device (if there is exactly one, like adb -e).
+
+Also see \fB\-d\fR (\fB\-\-select\-usb\fR).
 
 .TP
 .BI "\-\-encoder " name

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -482,3 +482,8 @@ sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags) {
 
     return sc_adb_parse_device_ip_from_output(buf);
 }
+
+bool
+sc_adb_is_serial_tcpip(const char *serial) {
+    return strchr(serial, ':');
+}

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -195,6 +195,14 @@ sc_adb_execute(const char *const argv[], unsigned flags) {
 }
 
 bool
+sc_adb_start_server(struct sc_intr *intr, unsigned flags) {
+    const char *const argv[] = SC_ADB_COMMAND("start-server");
+
+    sc_pid pid = sc_adb_execute(argv, flags);
+    return process_check_success_intr(intr, pid, "adb start-server", flags);
+}
+
+bool
 sc_adb_forward(struct sc_intr *intr, const char *serial, uint16_t local_port,
                const char *device_socket_name, unsigned flags) {
     char local[4 + 5 + 1]; // tcp:PORT

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -421,6 +421,24 @@ sc_adb_accept_device(const struct sc_adb_device *device, const char *serial) {
         return true;
     }
 
+    char *device_serial_colon = strchr(device->serial, ':');
+    if (device_serial_colon) {
+        // The device serial is an IP:port...
+        char *serial_colon = strchr(serial, ':');
+        if (!serial_colon) {
+            // But the requested serial has no ':', so only consider the IP part
+            // of the device serial. This allows to use "192.168.1.1" to match
+            // any "192.168.1.1:port".
+            size_t serial_len = strlen(serial);
+            size_t device_ip_len = device_serial_colon - device->serial;
+            if (serial_len != device_ip_len) {
+                // They are not equal, they don't even have the same length
+                return false;
+            }
+            return !strncmp(serial, device->serial, device_ip_len);
+        }
+    }
+
     return !strcmp(serial, device->serial);
 }
 

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -588,38 +588,6 @@ sc_adb_getprop(struct sc_intr *intr, const char *serial, const char *prop,
 }
 
 char *
-sc_adb_get_serialno(struct sc_intr *intr, unsigned flags) {
-    const char *const argv[] = SC_ADB_COMMAND("get-serialno");
-
-    sc_pipe pout;
-    sc_pid pid = sc_adb_execute_p(argv, flags, &pout);
-    if (pid == SC_PROCESS_NONE) {
-        LOGE("Could not execute \"adb get-serialno\"");
-        return NULL;
-    }
-
-    char buf[128];
-    ssize_t r = sc_pipe_read_all_intr(intr, pid, pout, buf, sizeof(buf) - 1);
-    sc_pipe_close(pout);
-
-    bool ok = process_check_success_intr(intr, pid, "adb get-serialno", flags);
-    if (!ok) {
-        return NULL;
-    }
-
-    if (r == -1) {
-        return NULL;
-    }
-
-    assert((size_t) r < sizeof(buf));
-    buf[r] = '\0';
-    size_t len = strcspn(buf, " \r\n");
-    buf[len] = '\0';
-
-    return strdup(buf);
-}
-
-char *
 sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags) {
     assert(serial);
     const char *const argv[] =

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -451,6 +451,10 @@ sc_adb_accept_device(const struct sc_adb_device *device,
                 }
             }
             return !strcmp(selector->serial, device->serial);
+        case SC_ADB_DEVICE_SELECT_USB:
+            return !sc_adb_is_serial_tcpip(device->serial);
+        case SC_ADB_DEVICE_SELECT_TCPIP:
+            return sc_adb_is_serial_tcpip(device->serial);
         default:
             assert(!"Missing SC_ADB_DEVICE_SELECT_* handling");
             break;
@@ -542,6 +546,12 @@ sc_adb_select_device(struct sc_intr *intr,
                 assert(selector->serial);
                 LOGE("Could not find ADB device %s:", selector->serial);
                 break;
+            case SC_ADB_DEVICE_SELECT_USB:
+                LOGE("Could not find any ADB device over USB:");
+                break;
+            case SC_ADB_DEVICE_SELECT_TCPIP:
+                LOGE("Could not find any ADB device over TCP/IP:");
+                break;
             default:
                 assert(!"Unexpected selector type");
                 break;
@@ -562,12 +572,21 @@ sc_adb_select_device(struct sc_intr *intr,
                 LOGE("Multiple (%" SC_PRIsizet ") ADB devices with serial %s:",
                      sel_count, selector->serial);
                 break;
+            case SC_ADB_DEVICE_SELECT_USB:
+                LOGE("Multiple (%" SC_PRIsizet ") ADB devices over USB:",
+                     sel_count);
+                break;
+            case SC_ADB_DEVICE_SELECT_TCPIP:
+                LOGE("Multiple (%" SC_PRIsizet ") ADB devices over TCP/IP:",
+                     sel_count);
+                break;
             default:
                 assert(!"Unexpected selector type");
                 break;
         }
         sc_adb_devices_log(SC_LOG_LEVEL_ERROR, devices, count);
-        LOGE("Select a device via -s (--serial)");
+        LOGE("Select a device via -s (--serial), -d (--select-usb) or -e "
+             "(--select-tcpip)");
         sc_adb_devices_destroy_all(devices, count);
         return false;
     }

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -374,6 +374,166 @@ sc_adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags) {
     return process_check_success_intr(intr, pid, "adb disconnect", flags);
 }
 
+static ssize_t
+sc_adb_list_devices(struct sc_intr *intr, unsigned flags,
+                    struct sc_adb_device *devices, size_t len) {
+    const char *const argv[] = SC_ADB_COMMAND("devices", "-l");
+
+    sc_pipe pout;
+    sc_pid pid = sc_adb_execute_p(argv, flags, &pout);
+    if (pid == SC_PROCESS_NONE) {
+        LOGE("Could not execute \"adb devices -l\"");
+        return -1;
+    }
+
+    char buf[4096];
+    ssize_t r = sc_pipe_read_all_intr(intr, pid, pout, buf, sizeof(buf) - 1);
+    sc_pipe_close(pout);
+
+    bool ok = process_check_success_intr(intr, pid, "adb devices -l", flags);
+    if (!ok) {
+        return -1;
+    }
+
+    if (r == -1) {
+        return -1;
+    }
+
+    assert((size_t) r < sizeof(buf));
+    if (r == sizeof(buf) - 1)  {
+        // The implementation assumes that the output of "adb devices -l" fits
+        // in the buffer in a single pass
+        LOGW("Result of \"adb devices -l\" does not fit in 4Kb. "
+             "Please report an issue.\n");
+        return -1;
+    }
+
+    // It is parsed as a NUL-terminated string
+    buf[r] = '\0';
+
+    // List all devices to the output list directly
+    return sc_adb_parse_devices(buf, devices, len);
+}
+
+static bool
+sc_adb_accept_device(const struct sc_adb_device *device, const char *serial) {
+    if (!serial) {
+        return true;
+    }
+
+    return !strcmp(serial, device->serial);
+}
+
+static size_t
+sc_adb_devices_select(struct sc_adb_device *devices, size_t len,
+                      const char *serial, size_t *idx_out) {
+    size_t count = 0;
+    for (size_t i = 0; i < len; ++i) {
+        struct sc_adb_device *device = &devices[i];
+        device->selected = sc_adb_accept_device(device, serial);
+        if (device->selected) {
+            if (idx_out && !count) {
+                *idx_out = i;
+            }
+            ++count;
+        }
+    }
+
+    return count;
+}
+
+static void
+sc_adb_devices_log(enum sc_log_level level, struct sc_adb_device *devices,
+                   size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        struct sc_adb_device *d = &devices[i];
+        const char *selection = d->selected ? "-->" : "   ";
+        const char *type = sc_adb_is_serial_tcpip(d->serial) ? "(tcpip)"
+                                                             : "  (usb)";
+        LOG(level, "    %s %s  %-20s  %16s  %s",
+             selection, type, d->serial, d->state, d->model ? d->model : "");
+    }
+}
+
+static bool
+sc_adb_device_check_state(struct sc_adb_device *device,
+                          struct sc_adb_device *devices, size_t count) {
+    const char *state = device->state;
+
+    if (!strcmp("device", state)) {
+        return true;
+    }
+
+    if (!strcmp("unauthorized", state)) {
+        LOGE("Device is unauthorized:");
+        sc_adb_devices_log(SC_LOG_LEVEL_ERROR, devices, count);
+        LOGE("A popup should open on the device to request authorization.");
+        LOGE("Check the FAQ: "
+             "<https://github.com/Genymobile/scrcpy/blob/master/FAQ.md>");
+    }
+
+    return false;
+}
+
+bool
+sc_adb_select_device(struct sc_intr *intr, const char *serial, unsigned flags,
+                     struct sc_adb_device *out_device) {
+    struct sc_adb_device devices[16];
+    ssize_t count =
+        sc_adb_list_devices(intr, flags, devices, ARRAY_LEN(devices));
+    if (count == -1) {
+        LOGE("Could not list ADB devices");
+        return false;
+    }
+
+    if (count == 0) {
+        LOGE("Could not find any ADB device");
+        return false;
+    }
+
+    size_t sel_idx; // index of the single matching device if sel_count == 1
+    size_t sel_count = sc_adb_devices_select(devices, count, serial, &sel_idx);
+
+    if (sel_count == 0) {
+        // if count > 0 && sel_count == 0, then necessarily a serial is provided
+        assert(serial);
+        LOGE("Could not find ADB device %s", serial);
+        sc_adb_devices_log(SC_LOG_LEVEL_ERROR, devices, count);
+        sc_adb_devices_destroy_all(devices, count);
+        return false;
+    }
+
+    if (sel_count > 1) {
+        if (serial) {
+            LOGE("Multiple (%" SC_PRIsizet ") ADB devices with serial %s:",
+                 sel_count, serial);
+        } else {
+            LOGE("Multiple (%" SC_PRIsizet ") ADB devices:", sel_count);
+        }
+        sc_adb_devices_log(SC_LOG_LEVEL_ERROR, devices, count);
+        LOGE("Select a device via -s (--serial)");
+        sc_adb_devices_destroy_all(devices, count);
+        return false;
+    }
+
+    assert(sel_count == 1); // sel_idx is valid only if sel_count == 1
+    struct sc_adb_device *device = &devices[sel_idx];
+
+    bool ok = sc_adb_device_check_state(device, devices, count);
+    if (!ok) {
+        sc_adb_devices_destroy_all(devices, count);
+        return false;
+    }
+
+    LOGD("ADB device found:");
+    sc_adb_devices_log(SC_LOG_LEVEL_DEBUG, devices, count);
+
+    // Move devics into out_device (do not destroy device)
+    sc_adb_device_move(out_device, device);
+    sc_adb_devices_destroy_all(devices, count);
+    return true;
+}
+
 char *
 sc_adb_getprop(struct sc_intr *intr, const char *serial, const char *prop,
                unsigned flags) {

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -424,39 +424,49 @@ sc_adb_list_devices(struct sc_intr *intr, unsigned flags,
 }
 
 static bool
-sc_adb_accept_device(const struct sc_adb_device *device, const char *serial) {
-    if (!serial) {
-        return true;
-    }
-
-    char *device_serial_colon = strchr(device->serial, ':');
-    if (device_serial_colon) {
-        // The device serial is an IP:port...
-        char *serial_colon = strchr(serial, ':');
-        if (!serial_colon) {
-            // But the requested serial has no ':', so only consider the IP part
-            // of the device serial. This allows to use "192.168.1.1" to match
-            // any "192.168.1.1:port".
-            size_t serial_len = strlen(serial);
-            size_t device_ip_len = device_serial_colon - device->serial;
-            if (serial_len != device_ip_len) {
-                // They are not equal, they don't even have the same length
-                return false;
+sc_adb_accept_device(const struct sc_adb_device *device,
+                     const struct sc_adb_device_selector *selector) {
+    switch (selector->type) {
+        case SC_ADB_DEVICE_SELECT_ALL:
+            return true;
+        case SC_ADB_DEVICE_SELECT_SERIAL:
+            assert(selector->serial);
+            char *device_serial_colon = strchr(device->serial, ':');
+            if (device_serial_colon) {
+                // The device serial is an IP:port...
+                char *serial_colon = strchr(selector->serial, ':');
+                if (!serial_colon) {
+                    // But the requested serial has no ':', so only consider
+                    // the IP part of the device serial. This allows to use
+                    // "192.168.1.1" to match any "192.168.1.1:port".
+                    size_t serial_len = strlen(selector->serial);
+                    size_t device_ip_len = device_serial_colon - device->serial;
+                    if (serial_len != device_ip_len) {
+                        // They are not equal, they don't even have the same
+                        // length
+                        return false;
+                    }
+                    return !strncmp(selector->serial, device->serial,
+                                    device_ip_len);
+                }
             }
-            return !strncmp(serial, device->serial, device_ip_len);
-        }
+            return !strcmp(selector->serial, device->serial);
+        default:
+            assert(!"Missing SC_ADB_DEVICE_SELECT_* handling");
+            break;
     }
 
-    return !strcmp(serial, device->serial);
+    return false;
 }
 
 static size_t
 sc_adb_devices_select(struct sc_adb_device *devices, size_t len,
-                      const char *serial, size_t *idx_out) {
+                      const struct sc_adb_device_selector *selector,
+                      size_t *idx_out) {
     size_t count = 0;
     for (size_t i = 0; i < len; ++i) {
         struct sc_adb_device *device = &devices[i];
-        device->selected = sc_adb_accept_device(device, serial);
+        device->selected = sc_adb_accept_device(device, selector);
         if (device->selected) {
             if (idx_out && !count) {
                 *idx_out = i;
@@ -502,8 +512,9 @@ sc_adb_device_check_state(struct sc_adb_device *device,
 }
 
 bool
-sc_adb_select_device(struct sc_intr *intr, const char *serial, unsigned flags,
-                     struct sc_adb_device *out_device) {
+sc_adb_select_device(struct sc_intr *intr,
+                     const struct sc_adb_device_selector *selector,
+                     unsigned flags, struct sc_adb_device *out_device) {
     struct sc_adb_device devices[16];
     ssize_t count =
         sc_adb_list_devices(intr, flags, devices, ARRAY_LEN(devices));
@@ -518,23 +529,42 @@ sc_adb_select_device(struct sc_intr *intr, const char *serial, unsigned flags,
     }
 
     size_t sel_idx; // index of the single matching device if sel_count == 1
-    size_t sel_count = sc_adb_devices_select(devices, count, serial, &sel_idx);
+    size_t sel_count =
+        sc_adb_devices_select(devices, count, selector, &sel_idx);
 
     if (sel_count == 0) {
-        // if count > 0 && sel_count == 0, then necessarily a serial is provided
-        assert(serial);
-        LOGE("Could not find ADB device %s", serial);
+        // if count > 0 && sel_count == 0, then necessarily a selection is
+        // requested
+        assert(selector->type != SC_ADB_DEVICE_SELECT_ALL);
+
+        switch (selector->type) {
+            case SC_ADB_DEVICE_SELECT_SERIAL:
+                assert(selector->serial);
+                LOGE("Could not find ADB device %s:", selector->serial);
+                break;
+            default:
+                assert(!"Unexpected selector type");
+                break;
+        }
+
         sc_adb_devices_log(SC_LOG_LEVEL_ERROR, devices, count);
         sc_adb_devices_destroy_all(devices, count);
         return false;
     }
 
     if (sel_count > 1) {
-        if (serial) {
-            LOGE("Multiple (%" SC_PRIsizet ") ADB devices with serial %s:",
-                 sel_count, serial);
-        } else {
-            LOGE("Multiple (%" SC_PRIsizet ") ADB devices:", sel_count);
+        switch (selector->type) {
+            case SC_ADB_DEVICE_SELECT_ALL:
+                LOGE("Multiple (%" SC_PRIsizet ") ADB devices:", sel_count);
+                break;
+            case SC_ADB_DEVICE_SELECT_SERIAL:
+                assert(selector->serial);
+                LOGE("Multiple (%" SC_PRIsizet ") ADB devices with serial %s:",
+                     sel_count, selector->serial);
+                break;
+            default:
+                assert(!"Unexpected selector type");
+                break;
         }
         sc_adb_devices_log(SC_LOG_LEVEL_ERROR, devices, count);
         LOGE("Select a device via -s (--serial)");

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -18,6 +18,16 @@
 const char *
 sc_adb_get_executable(void);
 
+enum sc_adb_device_selector_type {
+    SC_ADB_DEVICE_SELECT_ALL,
+    SC_ADB_DEVICE_SELECT_SERIAL,
+};
+
+struct sc_adb_device_selector {
+    enum sc_adb_device_selector_type type;
+    const char *serial;
+};
+
 sc_pid
 sc_adb_execute(const char *const argv[], unsigned flags);
 
@@ -79,8 +89,9 @@ sc_adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags);
  * Return true if a single matching device is found, and write it to out_device.
  */
 bool
-sc_adb_select_device(struct sc_intr *intr, const char *serial, unsigned flags,
-                     struct sc_adb_device *out_device);
+sc_adb_select_device(struct sc_intr *intr,
+                     const struct sc_adb_device_selector *selector,
+                     unsigned flags, struct sc_adb_device *out_device);
 
 /**
  * Execute `adb getprop <prop>`

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -22,6 +22,9 @@ sc_pid
 sc_adb_execute(const char *const argv[], unsigned flags);
 
 bool
+sc_adb_start_server(struct sc_intr *intr, unsigned flags);
+
+bool
 sc_adb_forward(struct sc_intr *intr, const char *serial, uint16_t local_port,
                const char *device_socket_name, unsigned flags);
 

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -93,4 +93,13 @@ sc_adb_get_serialno(struct sc_intr *intr, unsigned flags);
 char *
 sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags);
 
+/**
+ * Indicate if the serial represents an IP address
+ *
+ * In practice, it just returns true if and only if it contains a ':', which is
+ * sufficient to distinguish an ip:port from a real USB serial.
+ */
+bool
+sc_adb_is_serial_tcpip(const char *serial);
+
 #endif

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -21,6 +21,8 @@ sc_adb_get_executable(void);
 enum sc_adb_device_selector_type {
     SC_ADB_DEVICE_SELECT_ALL,
     SC_ADB_DEVICE_SELECT_SERIAL,
+    SC_ADB_DEVICE_SELECT_USB,
+    SC_ADB_DEVICE_SELECT_TCPIP,
 };
 
 struct sc_adb_device_selector {

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 #include <inttypes.h>
 
+#include "adb_device.h"
 #include "util/intr.h"
 
 #define SC_ADB_NO_STDOUT (1 << 0)
@@ -68,6 +69,15 @@ sc_adb_connect(struct sc_intr *intr, const char *ip_port, unsigned flags);
  */
 bool
 sc_adb_disconnect(struct sc_intr *intr, const char *ip_port, unsigned flags);
+
+/**
+ * Execute `adb devices` and parse the result to select a device
+ *
+ * Return true if a single matching device is found, and write it to out_device.
+ */
+bool
+sc_adb_select_device(struct sc_intr *intr, const char *serial, unsigned flags,
+                     struct sc_adb_device *out_device);
 
 /**
  * Execute `adb getprop <prop>`

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -87,14 +87,6 @@ sc_adb_getprop(struct sc_intr *intr, const char *serial, const char *prop,
                unsigned flags);
 
 /**
- * Execute `adb get-serialno`
- *
- * Return the result, to be freed by the caller, or NULL on error.
- */
-char *
-sc_adb_get_serialno(struct sc_intr *intr, unsigned flags);
-
-/**
  * Attempt to retrieve the device IP
  *
  * Return the IP as a string of the form "xxx.xxx.xxx.xxx", to be freed by the

--- a/app/src/adb/adb_device.c
+++ b/app/src/adb/adb_device.c
@@ -1,0 +1,26 @@
+#include "adb_device.h"
+
+#include <stdlib.h>
+
+void
+sc_adb_device_destroy(struct sc_adb_device *device) {
+    free(device->serial);
+    free(device->state);
+    free(device->model);
+}
+
+void
+sc_adb_device_move(struct sc_adb_device *dst, struct sc_adb_device *src) {
+    *dst = *src;
+    src->serial = NULL;
+    src->state = NULL;
+    src->model = NULL;
+}
+
+void
+sc_adb_devices_destroy_all(struct sc_adb_device *devices, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        sc_adb_device_destroy(&devices[i]);
+    }
+}
+

--- a/app/src/adb/adb_device.h
+++ b/app/src/adb/adb_device.h
@@ -10,6 +10,7 @@ struct sc_adb_device {
     char *serial;
     char *state;
     char *model;
+    bool selected;
 };
 
 void

--- a/app/src/adb/adb_device.h
+++ b/app/src/adb/adb_device.h
@@ -1,0 +1,33 @@
+#ifndef SC_ADB_DEVICE_H
+#define SC_ADB_DEVICE_H
+
+#include "common.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+
+struct sc_adb_device {
+    char *serial;
+    char *state;
+    char *model;
+};
+
+void
+sc_adb_device_destroy(struct sc_adb_device *device);
+
+/**
+ * Move src to dst
+ *
+ * After this call, the content of src is undefined, except that
+ * sc_adb_device_destroy() can be called.
+ *
+ * This is useful to take a device from a list that will be destroyed, without
+ * making unnecessary copies.
+ */
+void
+sc_adb_device_move(struct sc_adb_device *dst, struct sc_adb_device *src);
+
+void
+sc_adb_devices_destroy_all(struct sc_adb_device *devices, size_t count);
+
+#endif

--- a/app/src/adb/adb_parser.c
+++ b/app/src/adb/adb_parser.c
@@ -104,6 +104,8 @@ sc_adb_parse_device(char *line, struct sc_adb_device *device) {
         device->model = NULL;
     }
 
+    device->selected = false;
+
     return true;
 }
 

--- a/app/src/adb/adb_parser.h
+++ b/app/src/adb/adb_parser.h
@@ -5,6 +5,19 @@
 
 #include <stddef.h>
 
+#include "adb_device.h"
+
+/**
+ * Parse the available devices from the output of `adb devices`
+ *
+ * The parameter must be a NUL-terminated string.
+ *
+ * Warning: this function modifies the buffer for optimization purposes.
+ */
+ssize_t
+sc_adb_parse_devices(char *str, struct sc_adb_device *devices,
+                     size_t devices_len);
+
 /**
  * Parse the ip from the output of `adb shell ip route`
  *

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -119,6 +119,12 @@ static const struct sc_option options[] = {
                 "Any --max-size value is cmoputed on the cropped size.",
     },
     {
+        .shortopt = 'd',
+        .longopt = "select-usb",
+        .text = "Use USB device (if there is exactly one, like adb -d).\n"
+                "Also see -e (--select-tcpip).",
+    },
+    {
         .longopt_id = OPT_DISABLE_SCREENSAVER,
         .longopt = "disable-screensaver",
         .text = "Disable screensaver while scrcpy is running.",
@@ -140,6 +146,12 @@ static const struct sc_option options[] = {
         .text = "Add a buffering delay (in milliseconds) before displaying. "
                 "This increases latency to compensate for jitter.\n"
                 "Default is 0 (no buffering).",
+    },
+    {
+        .shortopt = 'e',
+        .longopt = "select-tcpip",
+        .text = "Use TCP/IP device (if there is exactly one, like adb -e).\n"
+                "Also see -d (--select-usb).",
     },
     {
         .longopt_id = OPT_ENCODER_NAME,
@@ -1320,6 +1332,12 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                     return false;
                 }
                 break;
+            case 'd':
+                opts->select_usb = true;
+                break;
+            case 'e':
+                opts->select_tcpip = true;
+                break;
             case 'f':
                 opts->fullscreen = true;
                 break;
@@ -1559,8 +1577,16 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     // If a TCP/IP address is provided, then tcpip must be enabled
     assert(opts->tcpip || !opts->tcpip_dst);
 
-    if (opts->serial && opts->tcpip_dst) {
-        LOGE("Incompatible options: -s/--serial and --tcpip with an argument");
+    unsigned selectors = !!opts->serial
+                       + !!opts->tcpip_dst
+                       + opts->select_tcpip
+                       + opts->select_usb;
+    if (selectors > 1) {
+        LOGE("At most one device selector option may be passed, among:\n"
+             "  --serial (-s)\n"
+             "  --select-usb (-d)\n"
+             "  --select-tcpip (-e)\n"
+             "  --tcpip=<addr> (with an argument)");
         return false;
     }
 

--- a/app/src/compat.h
+++ b/app/src/compat.h
@@ -8,8 +8,10 @@
 
 #ifndef __WIN32
 # define PRIu64_ PRIu64
+# define SC_PRIsizet "zu"
 #else
 # define PRIu64_ "I64u"  // Windows...
+# define SC_PRIsizet "Iu"
 #endif
 
 // In ffmpeg/doc/APIchanges:

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -60,4 +60,6 @@ const struct scrcpy_options scrcpy_options_default = {
     .downsize_on_error = true,
     .tcpip = false,
     .tcpip_dst = NULL,
+    .select_tcpip = false,
+    .select_usb = false,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -135,6 +135,8 @@ struct scrcpy_options {
     bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
+    bool select_usb;
+    bool select_tcpip;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -442,7 +442,7 @@ scrcpy(struct scrcpy_options *options) {
 
             if (count > 1) {
                 LOGE("Multiple (%d) devices with serial %s", (int) count, serial);
-                sc_usb_device_destroy_all(usb_devices, count);
+                sc_usb_devices_destroy_all(usb_devices, count);
                 sc_usb_destroy(&s->usb);
                 sc_acksync_destroy(&s->acksync);
                 goto aoa_hid_end;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -430,32 +430,19 @@ scrcpy(struct scrcpy_options *options) {
             }
 
             assert(serial);
-            struct sc_usb_device usb_devices[16];
-            ssize_t count = sc_usb_find_devices(&s->usb, serial, usb_devices,
-                                                ARRAY_LEN(usb_devices));
-            if (count <= 0) {
-                LOGE("Could not find USB device %s", serial);
+            struct sc_usb_device usb_device;
+            ok = sc_usb_select_device(&s->usb, serial, &usb_device);
+            if (!ok) {
                 sc_usb_destroy(&s->usb);
-                sc_acksync_destroy(&s->acksync);
                 goto aoa_hid_end;
             }
-
-            if (count > 1) {
-                LOGE("Multiple (%d) devices with serial %s", (int) count, serial);
-                sc_usb_devices_destroy_all(usb_devices, count);
-                sc_usb_destroy(&s->usb);
-                sc_acksync_destroy(&s->acksync);
-                goto aoa_hid_end;
-            }
-
-            struct sc_usb_device *usb_device = &usb_devices[0];
 
             LOGI("USB device: %s (%04" PRIx16 ":%04" PRIx16 ") %s %s",
-                 usb_device->serial, usb_device->vid, usb_device->pid,
-                 usb_device->manufacturer, usb_device->product);
+                 usb_device.serial, usb_device.vid, usb_device.pid,
+                 usb_device.manufacturer, usb_device.product);
 
-            ok = sc_usb_connect(&s->usb, usb_device->device, NULL, NULL);
-            sc_usb_device_destroy(usb_device);
+            ok = sc_usb_connect(&s->usb, usb_device.device, NULL, NULL);
+            sc_usb_device_destroy(&usb_device);
             if (!ok) {
                 LOGE("Failed to connect to USB device %s", serial);
                 sc_usb_destroy(&s->usb);

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -297,6 +297,8 @@ scrcpy(struct scrcpy_options *options) {
 
     struct sc_server_params params = {
         .req_serial = options->serial,
+        .select_usb = options->select_usb,
+        .select_tcpip = options->select_tcpip,
         .log_level = options->log_level,
         .crop = options->crop,
         .port_range = options->port_range,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -687,9 +687,15 @@ run_server(void *data) {
     bool need_initial_serial = !params->tcpip_dst;
 
     if (need_initial_serial) {
+        struct sc_adb_device_selector selector;
+        if (params->req_serial) {
+            selector.type = SC_ADB_DEVICE_SELECT_SERIAL;
+            selector.serial = params->req_serial;
+        } else {
+            selector.type = SC_ADB_DEVICE_SELECT_ALL;
+        }
         struct sc_adb_device device;
-        ok = sc_adb_select_device(&server->intr, params->req_serial, 0,
-                                  &device);
+        ok = sc_adb_select_device(&server->intr, &selector, 0, &device);
         if (!ok) {
             goto error_connection_failed;
         }

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -659,10 +659,7 @@ sc_server_configure_tcpip_known_address(struct sc_server *server,
 static bool
 sc_server_configure_tcpip_unknown_address(struct sc_server *server,
                                           const char *serial) {
-    // The serial is either the real serial when connected via USB, or
-    // the IP:PORT when connected over TCP/IP. Only the latter contains
-    // a colon.
-    bool is_already_tcpip = strchr(serial, ':');
+    bool is_already_tcpip = sc_adb_is_serial_tcpip(serial);
     if (is_already_tcpip) {
         // Nothing to do
         LOGI("Device already connected via TCP/IP: %s", serial);

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -687,10 +687,19 @@ run_server(void *data) {
     bool need_initial_serial = !params->tcpip_dst;
 
     if (need_initial_serial) {
+        // At most one of the 3 following parameters may be set
+        assert(!!params->req_serial
+               + params->select_usb
+               + params->select_tcpip <= 1);
+
         struct sc_adb_device_selector selector;
         if (params->req_serial) {
             selector.type = SC_ADB_DEVICE_SELECT_SERIAL;
             selector.serial = params->req_serial;
+        } else if (params->select_usb) {
+            selector.type = SC_ADB_DEVICE_SELECT_USB;
+        } else if (params->select_tcpip) {
+            selector.type = SC_ADB_DEVICE_SELECT_TCPIP;
         } else {
             selector.type = SC_ADB_DEVICE_SELECT_ALL;
         }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -44,6 +44,8 @@ struct sc_server_params {
     bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
+    bool select_usb;
+    bool select_tcpip;
 };
 
 struct sc_server {

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -115,7 +115,7 @@ scrcpy_otg(struct scrcpy_options *options) {
         if (!serial) {
             LOGE("Specify the device via -s or --serial");
         }
-        sc_usb_device_destroy_all(usb_devices, count);
+        sc_usb_devices_destroy_all(usb_devices, count);
         goto end;
     }
     usb_device_initialized = true;

--- a/app/src/usb/usb.c
+++ b/app/src/usb/usb.c
@@ -183,6 +183,7 @@ sc_usb_select_device(struct sc_usb *usb, const char *serial,
         } else {
             LOGE("Multiple (%" SC_PRIsizet ") USB devices:", sel_count);
         }
+        sc_usb_devices_log(SC_LOG_LEVEL_ERROR, usb_devices, count);
         LOGE("Select a device via -s (--serial)");
         sc_usb_devices_destroy_all(usb_devices, count);
         return false;

--- a/app/src/usb/usb.c
+++ b/app/src/usb/usb.c
@@ -79,7 +79,7 @@ sc_usb_device_destroy(struct sc_usb_device *usb_device) {
 }
 
 void
-sc_usb_device_destroy_all(struct sc_usb_device *usb_devices, size_t count) {
+sc_usb_devices_destroy_all(struct sc_usb_device *usb_devices, size_t count) {
     for (size_t i = 0; i < count; ++i) {
         sc_usb_device_destroy(&usb_devices[i]);
     }

--- a/app/src/usb/usb.c
+++ b/app/src/usb/usb.c
@@ -72,10 +72,21 @@ accept_device(libusb_device *device, const char *serial,
 
 void
 sc_usb_device_destroy(struct sc_usb_device *usb_device) {
-    libusb_unref_device(usb_device->device);
+    if (usb_device->device) {
+        libusb_unref_device(usb_device->device);
+    }
     free(usb_device->serial);
     free(usb_device->manufacturer);
     free(usb_device->product);
+}
+
+void
+sc_usb_device_move(struct sc_usb_device *dst, struct sc_usb_device *src) {
+    *dst = *src;
+    src->device = NULL;
+    src->serial = NULL;
+    src->manufacturer = NULL;
+    src->product = NULL;
 }
 
 void

--- a/app/src/usb/usb.h
+++ b/app/src/usb/usb.h
@@ -61,9 +61,9 @@ sc_usb_init(struct sc_usb *usb);
 void
 sc_usb_destroy(struct sc_usb *usb);
 
-ssize_t
-sc_usb_find_devices(struct sc_usb *usb, const char *serial,
-                    struct sc_usb_device *devices, size_t len);
+bool
+sc_usb_select_device(struct sc_usb *usb, const char *serial,
+                     struct sc_usb_device *out_device);
 
 bool
 sc_usb_connect(struct sc_usb *usb, libusb_device *device,

--- a/app/src/usb/usb.h
+++ b/app/src/usb/usb.h
@@ -41,7 +41,7 @@ void
 sc_usb_device_destroy(struct sc_usb_device *usb_device);
 
 void
-sc_usb_device_destroy_all(struct sc_usb_device *usb_devices, size_t count);
+sc_usb_devices_destroy_all(struct sc_usb_device *usb_devices, size_t count);
 
 bool
 sc_usb_init(struct sc_usb *usb);

--- a/app/src/usb/usb.h
+++ b/app/src/usb/usb.h
@@ -35,6 +35,7 @@ struct sc_usb_device {
     char *product;
     uint16_t vid;
     uint16_t pid;
+    bool selected;
 };
 
 void

--- a/app/src/usb/usb.h
+++ b/app/src/usb/usb.h
@@ -40,6 +40,18 @@ struct sc_usb_device {
 void
 sc_usb_device_destroy(struct sc_usb_device *usb_device);
 
+/**
+ * Move src to dst
+ *
+ * After this call, the content of src is undefined, except that
+ * sc_usb_device_destroy() can be called.
+ *
+ * This is useful to take a device from a list that will be destroyed, without
+ * making unnecessary copies.
+ */
+void
+sc_usb_device_move(struct sc_usb_device *dst, struct sc_usb_device *src);
+
 void
 sc_usb_devices_destroy_all(struct sc_usb_device *usb_devices, size_t count);
 

--- a/app/src/util/log.c
+++ b/app/src/util/log.c
@@ -55,6 +55,16 @@ sc_get_log_level(void) {
     return log_level_sdl_to_sc(sdl_log);
 }
 
+void
+sc_log(enum sc_log_level level, const char *fmt, ...) {
+    SDL_LogPriority sdl_level = log_level_sc_to_sdl(level);
+
+    va_list ap;
+    va_start(ap, fmt);
+    SDL_LogMessageV(SDL_LOG_CATEGORY_APPLICATION, sdl_level, fmt, ap);
+    va_end(ap);
+}
+
 #ifdef _WIN32
 bool
 sc_log_windows_error(const char *prefix, int error) {

--- a/app/src/util/log.h
+++ b/app/src/util/log.h
@@ -25,6 +25,10 @@ sc_set_log_level(enum sc_log_level level);
 enum sc_log_level
 sc_get_log_level(void);
 
+void
+sc_log(enum sc_log_level level, const char *fmt, ...);
+#define LOG(LEVEL, ...) sc_log((LEVEL), __VA_ARGS__)
+
 #ifdef _WIN32
 // Log system error (typically returned by GetLastError() or similar)
 bool

--- a/app/src/util/process.h
+++ b/app/src/util/process.h
@@ -12,8 +12,6 @@
 # include <winsock2.h>
 # include <windows.h>
 # define SC_PRIexitcode "lu"
-// <https://stackoverflow.com/a/44383330/1987178>
-# define SC_PRIsizet "Iu"
 # define SC_PROCESS_NONE NULL
 # define SC_EXIT_CODE_NONE -1UL // max value as unsigned long
   typedef HANDLE sc_pid;
@@ -23,7 +21,6 @@
 #else
 
 # include <sys/types.h>
-# define SC_PRIsizet "zu"
 # define SC_PRIexitcode "d"
 # define SC_PROCESS_NONE -1
 # define SC_EXIT_CODE_NONE -1

--- a/app/tests/test_adb_parser.c
+++ b/app/tests/test_adb_parser.c
@@ -2,7 +2,157 @@
 
 #include <assert.h>
 
+#include "adb/adb_device.h"
 #include "adb/adb_parser.h"
+
+static void test_adb_devices() {
+    char output[] =
+        "List of devices attached\n"
+        "0123456789abcdef	device usb:2-1 product:MyProduct model:MyModel "
+            "device:MyDevice transport_id:1\n"
+        "192.168.1.1:5555	device product:MyWifiProduct model:MyWifiModel "
+            "device:MyWifiDevice trandport_id:2\n";
+
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 2);
+
+    struct sc_adb_device *device = &devices[0];
+    assert(!strcmp("0123456789abcdef", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyModel", device->model));
+
+    device = &devices[1];
+    assert(!strcmp("192.168.1.1:5555", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyWifiModel", device->model));
+
+    sc_adb_devices_destroy_all(devices, count);
+}
+
+static void test_adb_devices_cr() {
+    char output[] =
+        "List of devices attached\r\n"
+        "0123456789abcdef	device usb:2-1 product:MyProduct model:MyModel "
+            "device:MyDevice transport_id:1\r\n"
+        "192.168.1.1:5555	device product:MyWifiProduct model:MyWifiModel "
+            "device:MyWifiDevice trandport_id:2\r\n";
+
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 2);
+
+    struct sc_adb_device *device = &devices[0];
+    assert(!strcmp("0123456789abcdef", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyModel", device->model));
+
+    device = &devices[1];
+    assert(!strcmp("192.168.1.1:5555", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyWifiModel", device->model));
+
+    sc_adb_devices_destroy_all(devices, count);
+}
+
+static void test_adb_devices_daemon_start() {
+    char output[] =
+        "* daemon not running; starting now at tcp:5037\n"
+        "* daemon started successfully\n"
+        "List of devices attached\n"
+        "0123456789abcdef	device usb:2-1 product:MyProduct model:MyModel "
+            "device:MyDevice transport_id:1\n";
+
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 1);
+
+    struct sc_adb_device *device = &devices[0];
+    assert(!strcmp("0123456789abcdef", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyModel", device->model));
+
+    sc_adb_device_destroy(device);
+}
+
+static void test_adb_devices_daemon_start_mixed() {
+    char output[] =
+        "List of devices attached\n"
+        "adb server version (41) doesn't match this client (39); killing...\n"
+        "* daemon started successfully *\n"
+        "0123456789abcdef	unauthorized usb:1-1\n"
+        "87654321	device usb:2-1 product:MyProduct model:MyModel "
+            "device:MyDevice\n";
+
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 2);
+
+    struct sc_adb_device *device = &devices[0];
+    assert(!strcmp("0123456789abcdef", device->serial));
+    assert(!strcmp("unauthorized", device->state));
+    fprintf(stderr, "==== [%s]\n", device->model);
+    assert(!device->model);
+
+    device = &devices[1];
+    assert(!strcmp("87654321", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyModel", device->model));
+
+    sc_adb_devices_destroy_all(devices, count);
+}
+
+static void test_adb_devices_without_eol() {
+    char output[] =
+        "List of devices attached\n"
+        "0123456789abcdef	device usb:2-1 product:MyProduct model:MyModel "
+            "device:MyDevice transport_id:1";
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 1);
+
+    struct sc_adb_device *device = &devices[0];
+    assert(!strcmp("0123456789abcdef", device->serial));
+    assert(!strcmp("device", device->state));
+    assert(!strcmp("MyModel", device->model));
+
+    sc_adb_device_destroy(device);
+}
+
+static void test_adb_devices_without_header() {
+    char output[] =
+        "0123456789abcdef	device usb:2-1 product:MyProduct model:MyModel "
+            "device:MyDevice transport_id:1\n";
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == -1);
+}
+
+static void test_adb_devices_corrupted() {
+    char output[] =
+        "List of devices attached\n"
+        "corrupted_garbage\n";
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 0);
+}
+
+static void test_adb_devices_spaces() {
+    char output[] =
+        "List of devices attached\n"
+        "0123456789abcdef       unauthorized usb:1-4 transport_id:3\n";
+
+    struct sc_adb_device devices[16];
+    ssize_t count = sc_adb_parse_devices(output, devices, ARRAY_LEN(devices));
+    assert(count == 1);
+
+    struct sc_adb_device *device = &devices[0];
+    assert(!strcmp("0123456789abcdef", device->serial));
+    assert(!strcmp("unauthorized", device->state));
+    assert(!device->model);
+
+    sc_adb_device_destroy(device);
+}
 
 static void test_get_ip_single_line() {
     char ip_route[] = "192.168.1.0/24 dev wlan0  proto kernel  scope link  src "
@@ -85,6 +235,15 @@ static void test_get_ip_truncated() {
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
+
+    test_adb_devices();
+    test_adb_devices_cr();
+    test_adb_devices_daemon_start();
+    test_adb_devices_daemon_start_mixed();
+    test_adb_devices_without_eol();
+    test_adb_devices_without_header();
+    test_adb_devices_corrupted();
+    test_adb_devices_spaces();
 
     test_get_ip_single_line();
     test_get_ip_single_line_without_eol();


### PR DESCRIPTION
Currently, if several devices are connected, `scrcpy` fails with:

```console
$ scrcpy
scrcpy 1.22 <https://github.com/Genymobile/scrcpy>
error: more than one device/emulator
ERROR: "adb get-serialno" returned with value 1
ERROR: Could not get device serial
ERROR: Server connection failed
```

This is not very user-friendly: the user must call `adb devices` manually to get the serial, then call `scrcpy -s xxxxxxxxxx` explicitly.

This PR brings features to improve device selection.

If several devices are connected, scrcpy prints the list of devices:

```console
$ scrcpy
…
ERROR: Multiple (3) ADB devices:
ERROR:     -->   (usb)  fedcba09                        device  GM1913
ERROR:     -->   (usb)  01234567890abcdef         unauthorized  
ERROR:     --> (tcpip)  192.168.1.1:5555                device  Nexus_5
ERROR: Select a device via -s (--serial), -d (--select-usb) or -e (--select-tcpip)
ERROR: Server connection failed
```

So it is possible to immediately call scrcpy again with `-s`.

In addition, two new options allow to select a USB or TCP/IP device when there is only one connected:
 - `-d` (or `--select-usb`) uses a USB device (like `adb -d`)
 - `-e` (or `--select-tcpip`) uses a TCP/IP device (like `adb -e`)

For example, to run `scrcpy` with the single TCP/IP device:

```console
$ scrcpy -e
…
DEBUG: ADB device found:
DEBUG:           (usb)  fedcba09                        device  GM1913
DEBUG:           (usb)  05f5e60a0ae518e5          unauthorized  
DEBUG:     --> (tcpip)  192.168.1.1:5555                device  Nexus_5
```

To run `scrcpy` with a single USB device:

```console
$ scrcpy -d
…
ERROR: Multiple (2) ADB devices over USB:
ERROR:     -->   (usb)  fedcba09                        device  GM1913
ERROR:     -->   (usb)  01234567890abcdef         unauthorized  
ERROR:         (tcpip)  192.168.1.1:5555                device  Nexus_5
ERROR: Select a device via -s (--serial), -d (--select-usb) or -e (--select-tcpip)
ERROR: Server connection failed
```

Since there are several devices connected over USB in this example, it fails, with a detailed error message.

Notice that the list of devices is printed at `DEBUG` level if it works (so it is not printed in release mode unless `-Vdebug` is passed), whereas it is printed at `ERROR` level if it fails.
(Maybe we should print it at `INFO` level when everything works, so that it is always printed?)

The first commits implement the same behavior for listing USB devices for HID/OTG mode (introduced in [v1.22](https://github.com/Genymobile/scrcpy/releases/tag/v1.22):

```console
$ scrcpy --otg
…
ERROR: Multiple (2) USB devices:
ERROR:     --> fedcba09           (xxxx:xxxx)  OnePlus SM8150-MTP
ERROR:     --> 01234567890abcdef  (xxxx:xxxx)  LGE Nexus 5
ERROR: Select a device via -s (--serial)
```

---

Do not conflate `--select-tcpip` with the `--tcpip` option introduced in [v1.21](https://github.com/Genymobile/scrcpy/releases/tag/v1.21).
 - `--tcpip` (without argument):
   1. connects to the selected device (which could be selected via `-s`, even `-U` or `-T`)
   2. enables TCP/IP mode (execute `adb tcpip 5555`)
   3. retrieves the device IP (by parsing `adb shell ip route`)
   4. connects to the device (`adb connect IP:5555`)
   5. starts mirroring
 - `--select-tcpip` just selects a device already connected (i.e. listed in `adb devices`) via TCP/IP

_In hindsight, maybe `--tcpip` should have been called `--connect-tcpip` or similar to avoid confusion, but it's too late._