### PR TITLE
Add --no-cleanup option

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -147,6 +147,12 @@ It may only work over USB, and is currently only supported on Linux.
 Also see \fB\-\-hid\-keyboard\fR.
 
 .TP
+.B \-\-no\-cleanup
+By default, scrcpy removes the server binary from the device and restores the device state (show touches, stay awake and power mode) on exit.
+
+This option disables this cleanup.
+
+.TP
 .B \-\-no\-clipboard\-autosync
 By default, scrcpy automatically synchronizes the computer clipboard to the device clipboard before injecting Ctrl+v, and the device clipboard to the computer clipboard whenever it changes.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -54,6 +54,7 @@
 #define OPT_RAW_KEY_EVENTS         1034
 #define OPT_NO_DOWNSIZE_ON_ERROR   1035
 #define OPT_OTG                    1036
+#define OPT_NO_CLEANUP             1037
 
 struct sc_option {
     char shortopt;
@@ -249,6 +250,14 @@ static const struct sc_option options[] = {
                 "other dimension is computed so that the device aspect-ratio "
                 "is preserved.\n"
                 "Default is 0 (unlimited).",
+    },
+    {
+        .longopt_id = OPT_NO_CLEANUP,
+        .longopt = "no-cleanup",
+        .text = "By default, scrcpy removes the server binary from the device "
+                "and restores the device state (show touches, stay awake and "
+                "power mode) on exit.\n"
+                "This option disables this cleanup."
     },
     {
         .longopt_id = OPT_NO_CLIPBOARD_AUTOSYNC,
@@ -1534,6 +1543,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_DOWNSIZE_ON_ERROR:
                 opts->downsize_on_error = false;
+                break;
+            case OPT_NO_CLEANUP:
+                opts->cleanup = false;
                 break;
             case OPT_OTG:
 #ifdef HAVE_USB

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -62,4 +62,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .tcpip_dst = NULL,
     .select_tcpip = false,
     .select_usb = false,
+    .cleanup = true,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -137,6 +137,7 @@ struct scrcpy_options {
     const char *tcpip_dst;
     bool select_usb;
     bool select_tcpip;
+    bool cleanup;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -320,6 +320,7 @@ scrcpy(struct scrcpy_options *options) {
         .downsize_on_error = options->downsize_on_error,
         .tcpip = options->tcpip,
         .tcpip_dst = options->tcpip_dst,
+        .cleanup = options->cleanup,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -244,6 +244,10 @@ execute_server(struct sc_server *server,
         // By default, downsize_on_error is true
         ADD_PARAM("downsize_on_error=false");
     }
+    if (!params->cleanup) {
+        // By default, cleanup is true
+        ADD_PARAM("cleanup=false");
+    }
 
 #undef ADD_PARAM
 

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -46,6 +46,7 @@ struct sc_server_params {
     const char *tcpip_dst;
     bool select_usb;
     bool select_tcpip;
+    bool cleanup;
 };
 
 struct sc_server {

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -21,6 +21,7 @@ public class Options {
     private boolean powerOffScreenOnClose;
     private boolean clipboardAutosync = true;
     private boolean downsizeOnError = true;
+    private boolean cleanup = true;
 
     // Options not used by the scrcpy client, but useful to use scrcpy-server directly
     private boolean sendDeviceMeta = true; // send device name and size
@@ -153,6 +154,14 @@ public class Options {
 
     public void setDownsizeOnError(boolean downsizeOnError) {
         this.downsizeOnError = downsizeOnError;
+    }
+
+    public boolean getCleanup() {
+        return cleanup;
+    }
+
+    public void setCleanup(boolean cleanup) {
+        this.cleanup = cleanup;
     }
 
     public boolean getSendDeviceMeta() {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -51,11 +51,13 @@ public final class Server {
             }
         }
 
-        try {
-            CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, restoreNormalPowerMode,
-                    options.getPowerOffScreenOnClose());
-        } catch (IOException e) {
-            Ln.e("Could not configure cleanup", e);
+        if (options.getCleanup()) {
+            try {
+                CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, restoreNormalPowerMode,
+                        options.getPowerOffScreenOnClose());
+            } catch (IOException e) {
+                Ln.e("Could not configure cleanup", e);
+            }
         }
     }
 
@@ -242,6 +244,10 @@ public final class Server {
                 case "downsize_on_error":
                     boolean downsizeOnError = Boolean.parseBoolean(value);
                     options.setDownsizeOnError(downsizeOnError);
+                    break;
+                case "cleanup":
+                    boolean cleanup = Boolean.parseBoolean(value);
+                    options.setCleanup(cleanup);
                     break;
                 case "send_device_meta":
                     boolean sendDeviceMeta = Boolean.parseBoolean(value);


### PR DESCRIPTION
It might be useful not to cleanup on exit (to leave the screen turned off for example).

Fixes #1764