### PR TITLE
Add --print-fps to enable FPS counter on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ scrcpy --max-fps 15
 
 This is officially supported since Android 10, but may work on earlier versions.
 
+The actual capture framerate may be printed to the console:
+
+```
+scrcpy --print-fps
+```
+
+It may also be enabled or disabled at any time with <kbd>MOD</kbd>+<kbd>i</kbd>.
+
+
 #### Crop
 
 The device screen may be cropped to mirror only part of the screen.

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -212,6 +212,10 @@ This avoids issues when combining multiple keys to enter special characters,
 but breaks the expected behavior of alpha keys in games (typically WASD).
 
 .TP
+.B "\-\-print\-fps
+Start FPS counter, to print framerate logs to the console. It can be started or stopped at any time with MOD+i.
+
+.TP
 .BI "\-\-push\-target " path
 Set the target directory for pushing files to the device by drag & drop. It is passed as\-is to "adb push".
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -55,6 +55,7 @@
 #define OPT_NO_DOWNSIZE_ON_ERROR   1035
 #define OPT_OTG                    1036
 #define OPT_NO_CLEANUP             1037
+#define OPT_PRINT_FPS              1038
 
 struct sc_option {
     char shortopt;
@@ -335,6 +336,12 @@ static const struct sc_option options[] = {
                 "This avoids issues when combining multiple keys to enter a "
                 "special character, but breaks the expected behavior of alpha "
                 "keys in games (typically WASD).",
+    },
+    {
+        .longopt_id = OPT_PRINT_FPS,
+        .longopt = "print-fps",
+        .text = "Start FPS counter, to print framerate logs to the console. "
+                "It can be started or stopped at any time with MOD+i.",
     },
     {
         .longopt_id = OPT_PUSH_TARGET,
@@ -1546,6 +1553,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_CLEANUP:
                 opts->cleanup = false;
+                break;
+            case OPT_PRINT_FPS:
+                opts->start_fps_counter = true;
                 break;
             case OPT_OTG:
 #ifdef HAVE_USB

--- a/app/src/fps_counter.c
+++ b/app/src/fps_counter.c
@@ -117,6 +117,7 @@ sc_fps_counter_start(struct sc_fps_counter *counter) {
         counter->thread_started = true;
     }
 
+    LOGI("FPS counter started");
     return true;
 }
 
@@ -124,6 +125,7 @@ void
 sc_fps_counter_stop(struct sc_fps_counter *counter) {
     set_started(counter, false);
     sc_cond_signal(&counter->state_cond);
+    LOGI("FPS counter stopped");
 }
 
 bool

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -247,13 +247,9 @@ switch_fps_counter_state(struct sc_fps_counter *fps_counter) {
     // is no ToCToU issue
     if (sc_fps_counter_is_started(fps_counter)) {
         sc_fps_counter_stop(fps_counter);
-        LOGI("FPS counter stopped");
     } else {
-        if (sc_fps_counter_start(fps_counter)) {
-            LOGI("FPS counter started");
-        } else {
-            LOGE("FPS counter starting failed");
-        }
+        sc_fps_counter_start(fps_counter);
+        // Any error is already logged
     }
 }
 

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -63,4 +63,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .select_tcpip = false,
     .select_usb = false,
     .cleanup = true,
+    .start_fps_counter = false,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -138,6 +138,7 @@ struct scrcpy_options {
     bool select_usb;
     bool select_tcpip;
     bool cleanup;
+    bool start_fps_counter;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -588,6 +588,7 @@ aoa_hid_end:
             .rotation = options->rotation,
             .mipmaps = options->mipmaps,
             .fullscreen = options->fullscreen,
+            .start_fps_counter = options->start_fps_counter,
             .buffering_time = options->display_buffer,
         };
 

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -386,6 +386,7 @@ sc_screen_init(struct sc_screen *screen,
     screen->req.width = params->window_width;
     screen->req.height = params->window_height;
     screen->req.fullscreen = params->fullscreen;
+    screen->req.start_fps_counter = params->start_fps_counter;
 
     static const struct sc_video_buffer_callbacks cbs = {
         .on_new_frame = sc_video_buffer_on_new_frame,
@@ -560,6 +561,10 @@ sc_screen_show_initial_window(struct sc_screen *screen) {
 
     if (screen->req.fullscreen) {
         sc_screen_switch_fullscreen(screen);
+    }
+
+    if (screen->req.start_fps_counter) {
+        sc_fps_counter_start(&screen->fps_counter);
     }
 
     SDL_ShowWindow(screen->window);

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -35,6 +35,7 @@ struct sc_screen {
         uint16_t width;
         uint16_t height;
         bool fullscreen;
+        bool start_fps_counter;
     } req;
 
     SDL_Window *window;
@@ -93,6 +94,7 @@ struct sc_screen_params {
     bool mipmaps;
 
     bool fullscreen;
+    bool start_fps_counter;
 
     sc_tick buffering_time;
 };


### PR DESCRIPTION
The FPS counter could be enabled/disabled via MOD+i.
    
Add a command line option to enable it on start. This is consistent with other features like `--turn-screen-off` or `--fullscreen`).

Fixes #468