### PR TITLE
Add HID support for macOS

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -199,7 +199,7 @@ Install the packages with [Homebrew]:
 
 ```bash
 # runtime dependencies
-brew install sdl2 ffmpeg
+brew install sdl2 ffmpeg libusb
 
 # client build dependencies
 brew install pkg-config meson

--- a/app/meson.build
+++ b/app/meson.build
@@ -74,7 +74,7 @@ if v4l2_support
     src += [ 'src/v4l2_sink.c' ]
 endif
 
-usb_support = get_option('usb') and host_machine.system() == 'linux'
+usb_support = get_option('usb') and host_machine.system() != 'windows'
 if usb_support
     src += [
         'src/usb/aoa_hid.c',

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -100,7 +100,7 @@ Simulate a physical keyboard by using HID over AOAv2.
 
 This provides a better experience for IME users, and allows to generate non-ASCII characters, contrary to the default injection method.
 
-It may only work over USB, and is currently only supported on Linux.
+It may only work over USB.
 
 The keyboard layout must be configured (once and for all) on the device, via Settings -> System -> Languages and input -> Physical keyboard. This settings page can be started directly:
 
@@ -142,7 +142,7 @@ In this mode, the computer mouse is captured to control the device directly (rel
 
 LAlt, LSuper or RSuper toggle the capture mode, to give control of the mouse back to the computer.
 
-It may only work over USB, and is currently only supported on Linux.
+It may only work over USB.
 
 Also see \fB\-\-hid\-keyboard\fR.
 
@@ -190,7 +190,7 @@ LAlt, LSuper or RSuper toggle the mouse capture mode, to give control of the mou
 
 If any of \fB\-\-hid\-keyboard\fR or \fB\-\-hid\-mouse\fR is set, only enable keyboard or mouse respectively, otherwise enable both.
 
-It may only work over USB, and is currently only supported on Linux.
+It may only work over USB.
 
 See \fB\-\-hid\-keyboard\fR and \fB\-\-hid\-mouse\fR.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -186,8 +186,7 @@ static const struct sc_option options[] = {
                 "It provides a better experience for IME users, and allows to "
                 "generate non-ASCII characters, contrary to the default "
                 "injection method.\n"
-                "It may only work over USB, and is currently only supported "
-                "on Linux.\n"
+                "It may only work over USB.\n"
                 "The keyboard layout must be configured (once and for all) on "
                 "the device, via Settings -> System -> Languages and input -> "
                 "Physical keyboard. This settings page can be started "
@@ -239,8 +238,7 @@ static const struct sc_option options[] = {
                 "device directly (relative mouse mode).\n"
                 "LAlt, LSuper or RSuper toggle the capture mode, to give "
                 "control of the mouse back to the computer.\n"
-                "It may only work over USB, and is currently only supported "
-                "on Linux.\n"
+                "It may only work over USB.\n"
                 "Also see --hid-keyboard.",
     },
     {
@@ -311,8 +309,7 @@ static const struct sc_option options[] = {
                 "control of the mouse back to the computer.\n"
                 "If any of --hid-keyboard or --hid-mouse is set, only enable "
                 "keyboard or mouse respectively, otherwise enable both.\n"
-                "It may only work over USB, and is currently only supported "
-                "on Linux.\n"
+                "It may only work over USB.\n"
                 "See --hid-keyboard and --hid-mouse.",
     },
     {

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -5,7 +5,8 @@
 #include "util/log.h"
 
 static void
-sc_screen_otg_set_mouse_capture(bool capture) {
+sc_screen_otg_set_mouse_capture(struct sc_screen_otg *screen, bool capture) {
+    (void) screen;
     if (SDL_SetRelativeMouseMode(capture)) {
         LOGE("Could not set relative mouse mode to %s: %s",
              capture ? "true" : "false", SDL_GetError());
@@ -13,13 +14,16 @@ sc_screen_otg_set_mouse_capture(bool capture) {
 }
 
 static inline bool
-sc_screen_otg_get_mouse_capture(void) {
+sc_screen_otg_get_mouse_capture(struct sc_screen_otg *screen) {
+    (void) screen;
     return SDL_GetRelativeMouseMode();
 }
 
 static inline void
-sc_screen_otg_toggle_mouse_capture(void) {
-    sc_screen_otg_set_mouse_capture(!sc_screen_otg_get_mouse_capture());
+sc_screen_otg_toggle_mouse_capture(struct sc_screen_otg *screen) {
+    (void) screen;
+    bool new_value = !sc_screen_otg_get_mouse_capture(screen);
+    sc_screen_otg_set_mouse_capture(screen, new_value);
 }
 
 static void
@@ -86,7 +90,7 @@ sc_screen_otg_init(struct sc_screen_otg *screen,
 
     if (screen->mouse) {
         // Capture mouse on start
-        sc_screen_otg_set_mouse_capture(true);
+        sc_screen_otg_set_mouse_capture(screen, true);
     }
 
     return true;
@@ -198,7 +202,7 @@ sc_screen_otg_handle_event(struct sc_screen_otg *screen, SDL_Event *event) {
                     break;
                 case SDL_WINDOWEVENT_FOCUS_LOST:
                     if (screen->mouse) {
-                        sc_screen_otg_set_mouse_capture(false);
+                        sc_screen_otg_set_mouse_capture(screen, false);
                     }
                     break;
             }
@@ -232,7 +236,7 @@ sc_screen_otg_handle_event(struct sc_screen_otg *screen, SDL_Event *event) {
                     if (key == cap) {
                         // A mouse capture key has been pressed then released:
                         // toggle the capture mouse mode
-                        sc_screen_otg_toggle_mouse_capture();
+                        sc_screen_otg_toggle_mouse_capture(screen);
                     }
                     // Mouse capture keys are never forwarded to the device
                     return;
@@ -244,26 +248,26 @@ sc_screen_otg_handle_event(struct sc_screen_otg *screen, SDL_Event *event) {
             }
             break;
         case SDL_MOUSEMOTION:
-            if (screen->mouse && sc_screen_otg_get_mouse_capture()) {
+            if (screen->mouse && sc_screen_otg_get_mouse_capture(screen)) {
                 sc_screen_otg_process_mouse_motion(screen, &event->motion);
             }
             break;
         case SDL_MOUSEBUTTONDOWN:
-            if (screen->mouse && sc_screen_otg_get_mouse_capture()) {
+            if (screen->mouse && sc_screen_otg_get_mouse_capture(screen)) {
                 sc_screen_otg_process_mouse_button(screen, &event->button);
             }
             break;
         case SDL_MOUSEBUTTONUP:
             if (screen->mouse) {
-                if (sc_screen_otg_get_mouse_capture()) {
+                if (sc_screen_otg_get_mouse_capture(screen)) {
                     sc_screen_otg_process_mouse_button(screen, &event->button);
                 } else {
-                    sc_screen_otg_set_mouse_capture(true);
+                    sc_screen_otg_set_mouse_capture(screen, true);
                 }
             }
             break;
         case SDL_MOUSEWHEEL:
-            if (screen->mouse && sc_screen_otg_get_mouse_capture()) {
+            if (screen->mouse && sc_screen_otg_get_mouse_capture(screen)) {
                 sc_screen_otg_process_mouse_wheel(screen, &event->wheel);
             }
             break;

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -6,7 +6,26 @@
 
 static void
 sc_screen_otg_set_mouse_capture(struct sc_screen_otg *screen, bool capture) {
+#ifdef __APPLE__
+    // Workaround for SDL bug on macOS:
+    // <https://github.com/libsdl-org/SDL/issues/5340>
+    if (capture) {
+        int mouse_x, mouse_y;
+        SDL_GetGlobalMouseState(&mouse_x, &mouse_y);
+
+        int x, y, w, h;
+        SDL_GetWindowPosition(screen->window, &x, &y);
+        SDL_GetWindowSize(screen->window, &w, &h);
+
+        bool outside_window = mouse_x < x || mouse_x >= x + w
+                           || mouse_y < y || mouse_y >= y + h;
+        if (outside_window) {
+            SDL_WarpMouseInWindow(screen->window, w / 2, h / 2);
+        }
+    }
+#else
     (void) screen;
+#endif
     if (SDL_SetRelativeMouseMode(capture)) {
         LOGE("Could not set relative mouse mode to %s: %s",
              capture ? "true" : "false", SDL_GetError());


### PR DESCRIPTION
Build with libusb on macOS to enable HID/OTG features.

Due to a bug in SDL (https://github.com/libsdl-org/SDL/issues/5340) related to relative mouse mode, implement a workaround to capture the mouse correctly (and avoid double mouse cursors).

Fixes #2774

Tests welcome.

---

FYI, Windows support (for OTG only) will be provided by #3011.