### PR TITLE
Also retry if MediaCodec.configure() throws IllegalArgumentException

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -102,7 +102,7 @@ public class ScreenEncoder implements Device.RotationListener {
                     alive = encode(codec, fd);
                     // do not call stop() on exception, it would trigger an IllegalStateException
                     codec.stop();
-                } catch (IllegalStateException e) {
+                } catch (IllegalStateException | IllegalArgumentException e) {
                     Ln.e("Encoding error: " + e.getClass().getName() + ": " + e.getMessage());
                     if (!downsizeOnError || firstFrameSent) {
                         // Fail immediately


### PR DESCRIPTION
MediaCodec.configure() may throw an IllegalArgumentException if it does
not support the requested size. Also retry on this exception.

Fixes #2993
Refs #2947
Refs #2990