### PR TITLE
Different exit codes for failure to connect and disconnect

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -355,6 +355,12 @@ Set the initial window height.
 
 Default is 0 (automatic).
 
+.SH EXIT CODES
+.B scrcpy
+will exit with code 0 on normal program termination. If an initial
+connection cannot be established, the exit code 1 will be returned. If the
+device disconnects while a session is active, exit code 2 will be returned.
+
 .SH SHORTCUTS
 
 In the following list, MOD is the shortcut modifier. By default, it's (left)

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -70,13 +70,13 @@ main(int argc, char *argv[]) {
     }
 
 #ifdef HAVE_USB
-    bool ok = args.opts.otg ? scrcpy_otg(&args.opts)
+    int ret = args.opts.otg ? scrcpy_otg(&args.opts)
                             : scrcpy(&args.opts);
 #else
-    bool ok = scrcpy(&args.opts);
+    int ret = scrcpy(&args.opts);
 #endif
 
     avformat_network_deinit(); // ignore failure
 
-    return ok ? 0 : 1;
+    return ret;
 }

--- a/app/src/scrcpy.h
+++ b/app/src/scrcpy.h
@@ -6,7 +6,7 @@
 #include <stdbool.h>
 #include "options.h"
 
-bool
+int
 scrcpy(struct scrcpy_options *options);
 
 #endif

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -36,10 +36,10 @@ event_loop(struct scrcpy_otg *s) {
         switch (event.type) {
             case EVENT_USB_DEVICE_DISCONNECTED:
                 LOGW("Device disconnected");
-                return false;
+                return EVENT_USB_DEVICE_DISCONNECTED;
             case SDL_QUIT:
                 LOGD("User requested to quit");
-                return true;
+                return SDL_QUIT;
             default:
                 sc_screen_otg_handle_event(&s->screen_otg, &event);
                 break;
@@ -67,7 +67,7 @@ scrcpy_otg(struct scrcpy_options *options) {
         LOGW("Could not enable mouse focus clickthrough");
     }
 
-    bool ret = false;
+    int ret = 0;
 
     struct sc_hid_keyboard *keyboard = NULL;
     struct sc_hid_mouse *mouse = NULL;


### PR DESCRIPTION
Modify the return logic such that exit code 1 is used when the initial
connection fails, but if a session is established, and then the device
disconnects, exit code 2 is emitted.

Closes: Github:Genymobile/scrcpy#3083
Signed-off-by: martin f. krafft <madduck@madduck.net>