### PR TITLE
Use $ANDROID_SERIAL if no selector is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,9 @@ scrcpy --serial 0123456789abcdef
 scrcpy -s 0123456789abcdef  # short version
 ```
 
+The serial may also be provided via the environment variable `ANDROID_SERIAL`
+(also used by `adb`).
+
 If the device is connected over TCP/IP:
 
 ```bash

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -478,6 +478,10 @@ Push file to device (see \fB\-\-push\-target\fR)
 Path to adb.
 
 .TP
+.B ANDROID_SERIAL
+Device serial to use if no selector (-s, -d, -e or --tcpip=<addr>) is specified.
+
+.TP
 .B SCRCPY_ICON_PATH
 Path to the program icon.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -661,6 +661,11 @@ static const struct sc_envvar envvars[] = {
         .text = "Path to adb executable",
     },
     {
+        .name = "ANDROID_SERIAL",
+        .text = "Device serial to use if no selector (-s, -d, -e or "
+                "--tcpip=<addr>) is specified",
+    },
+    {
         .name = "SCRCPY_ICON_PATH",
         .text = "Path to the program icon",
     },

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -707,7 +707,15 @@ run_server(void *data) {
         } else if (params->select_tcpip) {
             selector.type = SC_ADB_DEVICE_SELECT_TCPIP;
         } else {
-            selector.type = SC_ADB_DEVICE_SELECT_ALL;
+            // No explicit selection, check $ANDROID_SERIAL
+            const char *env_serial = getenv("ANDROID_SERIAL");
+            if (env_serial) {
+                LOGI("Using ANDROID_SERIAL: %s", env_serial);
+                selector.type = SC_ADB_DEVICE_SELECT_SERIAL;
+                selector.serial = env_serial;
+            } else {
+                selector.type = SC_ADB_DEVICE_SELECT_ALL;
+            }
         }
         struct sc_adb_device device;
         ok = sc_adb_select_device(&server->intr, &selector, 0, &device);


### PR DESCRIPTION
Like adb, read the `ANDROID_SERIAL` environment variable to select a device by serial if no explicit selection (`-s`, `-d`, `-e` or `--tcpip=<addr>`) is provided via the command line.

Fixes #3111