### PR TITLE
Consider emulators as TCP/IP devices

### DIFF
--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -473,9 +473,12 @@ sc_adb_accept_device(const struct sc_adb_device *device,
             }
             return !strcmp(selector->serial, device->serial);
         case SC_ADB_DEVICE_SELECT_USB:
-            return !sc_adb_is_serial_tcpip(device->serial);
+            return sc_adb_device_get_type(device->serial) ==
+                    SC_ADB_DEVICE_TYPE_USB;
         case SC_ADB_DEVICE_SELECT_TCPIP:
-            return sc_adb_is_serial_tcpip(device->serial);
+            // Both emulators and TCP/IP devices are selected via -e
+            return sc_adb_device_get_type(device->serial) !=
+                    SC_ADB_DEVICE_TYPE_USB;
         default:
             assert(!"Missing SC_ADB_DEVICE_SELECT_* handling");
             break;
@@ -509,8 +512,10 @@ sc_adb_devices_log(enum sc_log_level level, struct sc_adb_device *devices,
     for (size_t i = 0; i < count; ++i) {
         struct sc_adb_device *d = &devices[i];
         const char *selection = d->selected ? "-->" : "   ";
-        const char *type = sc_adb_is_serial_tcpip(d->serial) ? "(tcpip)"
-                                                             : "  (usb)";
+        bool is_usb =
+            sc_adb_device_get_type(d->serial) == SC_ADB_DEVICE_TYPE_USB;
+        const char *type = is_usb ? "  (usb)"
+                                  : "(tcpip)";
         LOG(level, "    %s %s  %-20s  %16s  %s",
              selection, type, d->serial, d->state, d->model ? d->model : "");
     }
@@ -706,9 +711,4 @@ sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags) {
     buf[r] = '\0';
 
     return sc_adb_parse_device_ip_from_output(buf);
-}
-
-bool
-sc_adb_is_serial_tcpip(const char *serial) {
-    return strchr(serial, ':');
 }

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -114,13 +114,4 @@ sc_adb_getprop(struct sc_intr *intr, const char *serial, const char *prop,
 char *
 sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags);
 
-/**
- * Indicate if the serial represents an IP address
- *
- * In practice, it just returns true if and only if it contains a ':', which is
- * sufficient to distinguish an ip:port from a real USB serial.
- */
-bool
-sc_adb_is_serial_tcpip(const char *serial);
-
 #endif

--- a/app/src/adb/adb_device.c
+++ b/app/src/adb/adb_device.c
@@ -25,3 +25,18 @@ sc_adb_devices_destroy(struct sc_vec_adb_devices *devices) {
     sc_vector_destroy(devices);
 }
 
+enum sc_adb_device_type
+sc_adb_device_get_type(const char *serial) {
+    // Starts with "emulator-"
+    if (!strncmp(serial, "emulator-", sizeof("emulator-") - 1)) {
+        return SC_ADB_DEVICE_TYPE_EMULATOR;
+    }
+
+    // If the serial contains a ':', then it is a TCP/IP device (it is
+    // sufficient to distinguish an ip:port from a real USB serial)
+    if (strchr(serial, ':')) {
+        return SC_ADB_DEVICE_TYPE_TCPIP;
+    }
+
+    return SC_ADB_DEVICE_TYPE_USB;
+}

--- a/app/src/adb/adb_device.h
+++ b/app/src/adb/adb_device.h
@@ -15,6 +15,12 @@ struct sc_adb_device {
     bool selected;
 };
 
+enum sc_adb_device_type {
+    SC_ADB_DEVICE_TYPE_USB,
+    SC_ADB_DEVICE_TYPE_TCPIP,
+    SC_ADB_DEVICE_TYPE_EMULATOR,
+};
+
 struct sc_vec_adb_devices SC_VECTOR(struct sc_adb_device);
 
 void
@@ -34,5 +40,11 @@ sc_adb_device_move(struct sc_adb_device *dst, struct sc_adb_device *src);
 
 void
 sc_adb_devices_destroy(struct sc_vec_adb_devices *devices);
+
+/**
+ * Deduce the device type from the serial
+ */
+enum sc_adb_device_type
+sc_adb_device_get_type(const char *serial);
 
 #endif

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -649,7 +649,8 @@ sc_server_configure_tcpip_known_address(struct sc_server *server,
 static bool
 sc_server_configure_tcpip_unknown_address(struct sc_server *server,
                                           const char *serial) {
-    bool is_already_tcpip = sc_adb_is_serial_tcpip(serial);
+    bool is_already_tcpip =
+        sc_adb_device_get_type(serial) == SC_ADB_DEVICE_TYPE_TCPIP;
     if (is_already_tcpip) {
         // Nothing to do
         LOGI("Device already connected via TCP/IP: %s", serial);


### PR DESCRIPTION
Emulators were wrongly considered as USB devices, so they were selected using -d instead of -e (which was inconsistent with the adb behavior).

Refs #3005
Refs #3137