### PR TITLE
Adapt event injection to Android 13

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
@@ -14,13 +14,13 @@ public final class InputManager {
     public static final int INJECT_INPUT_EVENT_MODE_WAIT_FOR_RESULT = 1;
     public static final int INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH = 2;
 
-    private final IInterface manager;
+    private final android.hardware.input.InputManager manager;
     private Method injectInputEventMethod;
     private boolean alternativeInjectInputEventMethod;
 
     private static Method setDisplayIdMethod;
 
-    public InputManager(IInterface manager) {
+    public InputManager(android.hardware.input.InputManager manager) {
         this.manager = manager;
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
@@ -16,7 +16,6 @@ public final class InputManager {
 
     private final android.hardware.input.InputManager manager;
     private Method injectInputEventMethod;
-    private boolean alternativeInjectInputEventMethod;
 
     private static Method setDisplayIdMethod;
 
@@ -26,12 +25,7 @@ public final class InputManager {
 
     private Method getInjectInputEventMethod() throws NoSuchMethodException {
         if (injectInputEventMethod == null) {
-            try {
-                injectInputEventMethod = manager.getClass().getMethod("injectInputEvent", InputEvent.class, int.class);
-            } catch (NoSuchMethodException e) {
-                injectInputEventMethod = manager.getClass().getMethod("injectInputEvent", InputEvent.class, int.class, int.class);
-                alternativeInjectInputEventMethod = true;
-            }
+            injectInputEventMethod = manager.getClass().getMethod("injectInputEvent", InputEvent.class, int.class);
         }
         return injectInputEventMethod;
     }
@@ -39,10 +33,6 @@ public final class InputManager {
     public boolean injectInputEvent(InputEvent inputEvent, int mode) {
         try {
             Method method = getInjectInputEventMethod();
-            if (alternativeInjectInputEventMethod) {
-                // See <https://github.com/Genymobile/scrcpy/issues/2250>
-                return (boolean) method.invoke(manager, inputEvent, mode, 0);
-            }
             return (boolean) method.invoke(manager, inputEvent, mode);
         } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
             Ln.e("Could not invoke method", e);

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.os.IBinder;
 import android.os.IInterface;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 @SuppressLint("PrivateApi,DiscouragedPrivateApi")
@@ -56,7 +57,13 @@ public final class ServiceManager {
 
     public InputManager getInputManager() {
         if (inputManager == null) {
-            inputManager = new InputManager(getService("input", "android.hardware.input.IInputManager"));
+            try {
+                Method getInstanceMethod = android.hardware.input.InputManager.class.getDeclaredMethod("getInstance");
+                android.hardware.input.InputManager im = (android.hardware.input.InputManager) getInstanceMethod.invoke(null);
+                inputManager = new InputManager(im);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                throw new AssertionError(e);
+            }
         }
         return inputManager;
     }


### PR DESCRIPTION
Using the "input" service results in a permission error in Android 13.

Use the `InputManager` instance (retrieved by `InputManager.getInstance()`) instead.

Fixes #3186