### PR TITLE
Add option to prevent power on on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,16 @@ To turn the device screen off when closing scrcpy:
 scrcpy --power-off-on-close
 ```
 
+#### Power on on start
+
+By default, on start, the device is powered on.
+
+To prevent this behavior:
+
+```bash
+scrcpy --no-power-on
+```
+
 
 #### Show touches
 

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -29,6 +29,7 @@ _scrcpy() {
         -N --no-display
         --no-key-repeat
         --no-mipmaps
+        --no-power-on
         --otg
         -p --port=
         --power-off-on-close

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -35,6 +35,7 @@ arguments=(
     {-N,--no-display}'[Do not display device \(during screen recording or when V4L2 sink is enabled\)]'
     '--no-key-repeat[Do not forward repeated key events when a key is held down]'
     '--no-mipmaps[Disable the generation of mipmaps]'
+    '--no-power-on[Do not power on the device on start]'
     '--otg[Run in OTG mode \(simulating physical keyboard and mouse\)]'
     {-p,--port=}'[\[port\[\:port\]\] Set the TCP port \(range\) used by the client to listen]'
     '--power-off-on-close[Turn the device screen off when closing scrcpy]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -181,6 +181,10 @@ Do not forward repeated key events when a key is held down.
 If the renderer is OpenGL 3.0+ or OpenGL ES 2.0+, then mipmaps are automatically generated to improve downscaling quality. This option disables the generation of mipmaps.
 
 .TP
+.B \-\-no\-power\-on
+Do not power on the device on start.
+
+.TP
 .B \-\-otg
 Run in OTG mode: simulate physical keyboard and mouse, as if the computer keyboard and mouse were plugged directly to the device via an OTG cable.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -56,6 +56,7 @@
 #define OPT_OTG                    1036
 #define OPT_NO_CLEANUP             1037
 #define OPT_PRINT_FPS              1038
+#define OPT_NO_POWER_ON            1039
 
 struct sc_option {
     char shortopt;
@@ -301,6 +302,11 @@ static const struct sc_option options[] = {
         .text = "If the renderer is OpenGL 3.0+ or OpenGL ES 2.0+, then "
                 "mipmaps are automatically generated to improve downscaling "
                 "quality. This option disables the generation of mipmaps.",
+    },
+    {
+        .longopt_id = OPT_NO_POWER_ON,
+        .longopt = "no-power-on",
+        .text = "Do not power on the device on start.",
     },
     {
         .longopt_id = OPT_OTG,
@@ -1597,6 +1603,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_CLEANUP:
                 opts->cleanup = false;
+                break;
+            case OPT_NO_POWER_ON:
+                opts->power_on = false;
                 break;
             case OPT_PRINT_FPS:
                 opts->start_fps_counter = true;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -64,4 +64,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .select_usb = false,
     .cleanup = true,
     .start_fps_counter = false,
+    .power_on = true,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -139,6 +139,7 @@ struct scrcpy_options {
     bool select_tcpip;
     bool cleanup;
     bool start_fps_counter;
+    bool power_on;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -324,6 +324,7 @@ scrcpy(struct scrcpy_options *options) {
         .tcpip = options->tcpip,
         .tcpip_dst = options->tcpip_dst,
         .cleanup = options->cleanup,
+        .power_on = options->power_on,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -248,6 +248,10 @@ execute_server(struct sc_server *server,
         // By default, cleanup is true
         ADD_PARAM("cleanup=false");
     }
+    if (!params->power_on) {
+        // By default, power_on is true
+        ADD_PARAM("power_on=false");
+    }
 
 #undef ADD_PARAM
 

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -47,6 +47,7 @@ struct sc_server_params {
     bool select_usb;
     bool select_tcpip;
     bool cleanup;
+    bool power_on;
 };
 
 struct sc_server {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -22,6 +22,7 @@ public class Controller {
     private final DesktopConnection connection;
     private final DeviceMessageSender sender;
     private final boolean clipboardAutosync;
+    private final boolean powerOn;
 
     private final KeyCharacterMap charMap = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
 
@@ -32,10 +33,11 @@ public class Controller {
 
     private boolean keepPowerModeOff;
 
-    public Controller(Device device, DesktopConnection connection, boolean clipboardAutosync) {
+    public Controller(Device device, DesktopConnection connection, boolean clipboardAutosync, boolean powerOn) {
         this.device = device;
         this.connection = connection;
         this.clipboardAutosync = clipboardAutosync;
+        this.powerOn = powerOn;
         initPointers();
         sender = new DeviceMessageSender(connection);
     }
@@ -56,7 +58,7 @@ public class Controller {
 
     public void control() throws IOException {
         // on start, power on the device
-        if (!Device.isScreenOn()) {
+        if (powerOn && !Device.isScreenOn()) {
             device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, Device.INJECT_MODE_ASYNC);
 
             // dirty hack

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -22,6 +22,7 @@ public class Options {
     private boolean clipboardAutosync = true;
     private boolean downsizeOnError = true;
     private boolean cleanup = true;
+    private boolean powerOn = true;
 
     // Options not used by the scrcpy client, but useful to use scrcpy-server directly
     private boolean sendDeviceMeta = true; // send device name and size
@@ -162,6 +163,14 @@ public class Options {
 
     public void setCleanup(boolean cleanup) {
         this.cleanup = cleanup;
+    }
+
+    public boolean getPowerOn() {
+        return powerOn;
+    }
+
+    public void setPowerOn(boolean powerOn) {
+        this.powerOn = powerOn;
     }
 
     public boolean getSendDeviceMeta() {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -82,7 +82,7 @@ public final class Server {
             Thread controllerThread = null;
             Thread deviceMessageSenderThread = null;
             if (control) {
-                final Controller controller = new Controller(device, connection, options.getClipboardAutosync());
+                final Controller controller = new Controller(device, connection, options.getClipboardAutosync(), options.getPowerOn());
 
                 // asynchronous
                 controllerThread = startController(controller);
@@ -247,6 +247,10 @@ public final class Server {
                 case "cleanup":
                     boolean cleanup = Boolean.parseBoolean(value);
                     options.setCleanup(cleanup);
+                    break;
+                case "power_on":
+                    boolean powerOn = Boolean.parseBoolean(value);
+                    options.setPowerOn(powerOn);
                     break;
                 case "send_device_meta":
                     boolean sendDeviceMeta = Boolean.parseBoolean(value);


### PR DESCRIPTION
By default, on start, the device is powered on. To prevent this behavior, add a new option `--no-power-on`.

Fixes #3148

---

Are you ok with the option name (`--no-power-on`)?
There is already an option `--power-off-on-close`, so we could use `--no-power-on-on-start`, but I think I prefer `--no-power-on`).