### PR TITLE
Apply requested window size in OTG mode

### DIFF
--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -162,6 +162,8 @@ scrcpy_otg(struct scrcpy_options *options) {
         .always_on_top = options->always_on_top,
         .window_x = options->window_x,
         .window_y = options->window_y,
+        .window_width = options->window_width,
+        .window_height = options->window_height,
         .window_borderless = options->window_borderless,
     };
 

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -55,6 +55,10 @@ scrcpy_otg(struct scrcpy_options *options) {
 
     const char *serial = options->serial;
 
+    if (!SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "1")) {
+        LOGW("Could not enable linear filtering");
+    }
+
     // Minimal SDL initialization
     if (SDL_Init(SDL_INIT_EVENTS)) {
         LOGE("Could not initialize SDL: %s", SDL_GetError());

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -69,8 +69,8 @@ sc_screen_otg_init(struct sc_screen_otg *screen,
           ? params->window_x : (int) SDL_WINDOWPOS_UNDEFINED;
     int y = params->window_y != SC_WINDOW_POSITION_UNDEFINED
           ? params->window_y : (int) SDL_WINDOWPOS_UNDEFINED;
-    int width = 256;
-    int height = 256;
+    int width = params->window_width ? params->window_width : 256;
+    int height = params->window_height ? params->window_height : 256;
 
     uint32_t window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
     if (params->always_on_top) {
@@ -96,6 +96,11 @@ sc_screen_otg_init(struct sc_screen_otg *screen,
 
     if (icon) {
         SDL_SetWindowIcon(screen->window, icon);
+
+        if (!SDL_RenderSetLogicalSize(screen->renderer, icon->w, icon->h)) {
+            LOGW("Could not set renderer logical size: %s", SDL_GetError());
+            // don't fail
+        }
 
         screen->texture = SDL_CreateTextureFromSurface(screen->renderer, icon);
         scrcpy_icon_destroy(icon);

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -72,7 +72,8 @@ sc_screen_otg_init(struct sc_screen_otg *screen,
     int width = params->window_width ? params->window_width : 256;
     int height = params->window_height ? params->window_height : 256;
 
-    uint32_t window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
+    uint32_t window_flags = SDL_WINDOW_ALLOW_HIGHDPI
+                          | SDL_WINDOW_RESIZABLE;
     if (params->always_on_top) {
         window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
     }

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -72,7 +72,7 @@ sc_screen_otg_init(struct sc_screen_otg *screen,
     int width = 256;
     int height = 256;
 
-    uint32_t window_flags = 0;
+    uint32_t window_flags = SDL_WINDOW_ALLOW_HIGHDPI;
     if (params->always_on_top) {
         window_flags |= SDL_WINDOW_ALWAYS_ON_TOP;
     }

--- a/app/src/usb/screen_otg.h
+++ b/app/src/usb/screen_otg.h
@@ -29,6 +29,8 @@ struct sc_screen_otg_params {
     bool always_on_top;
     int16_t window_x; // accepts SC_WINDOW_POSITION_UNDEFINED
     int16_t window_y; // accepts SC_WINDOW_POSITION_UNDEFINED
+    uint16_t window_width;
+    uint16_t window_height;
     bool window_borderless;
 };
 


### PR DESCRIPTION
Apply the values provided by `--window-width` and `--window-height` also in OTG mode (if `--otg` is passed).

Fixes #3099