### PR TITLE
Add build support for Windows on ARM64 (based on llvm-mingw)

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -145,13 +145,21 @@ else
     prebuilt_libusb_root = meson.get_cross_property('prebuilt_libusb_root')
     libusb_bin_dir = meson.current_source_dir() + '/prebuilt-deps/data/' + prebuilt_libusb
     libusb_include_dir = 'prebuilt-deps/data/' + prebuilt_libusb_root + '/include'
-
-    libusb = declare_dependency(
-        dependencies: [
-            cc.find_library('msys-usb-1.0', dirs: libusb_bin_dir),
+    if host_machine.cpu_family() == 'x86'
+      libusb = declare_dependency(
+	dependencies: [
+	  cc.find_library('msys-usb-1.0', dirs: libusb_bin_dir),
         ],
         include_directories: include_directories(libusb_include_dir)
-    )
+      )
+    elif host_machine.cpu_family() == 'aarch64'
+      libusb = declare_dependency(
+	dependencies: [
+	  cc.find_library('libusb-1.0', dirs: libusb_bin_dir),
+        ],
+        include_directories: include_directories(libusb_include_dir)
+      )
+    endif
 
     dependencies = [
         ffmpeg,

--- a/app/prebuilt-deps/prepare-ffmpeg-win-arm64.sh
+++ b/app/prebuilt-deps/prepare-ffmpeg-win-arm64.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DIR"
+. common
+mkdir -p "$PREBUILT_DATA_DIR"
+cd "$PREBUILT_DATA_DIR"
+
+DEP_DIR=ffmpeg-aarch64-4.3.1
+
+FILENAME=ffmpeg-4.3.1-windows-aarch64.7z
+SHA256SUM=8dd5ed9692f36c2f012a64903b8b2baec6581973d0d4dad872d1a476bcf5018b 
+
+if [[ -d "$DEP_DIR" ]]
+then
+    echo "$DEP_DIR" found
+    exit 0
+fi
+
+get_file "https://github.com/ZIXT233/FFmpeg-windows-aarch64-mingw/releases/download/n4.3.1/$FILENAME" \
+    "$FILENAME" "$SHA256SUM"
+
+mkdir "$DEP_DIR"
+cd "$DEP_DIR"
+
+ZIP_PREFIX=ffmpeg-4.3.1-windows-aarch64
+7z x "../$FILENAME" \
+    "$ZIP_PREFIX"/bin/avutil-56.dll \
+    "$ZIP_PREFIX"/bin/avcodec-58.dll \
+    "$ZIP_PREFIX"/bin/avformat-58.dll \
+    "$ZIP_PREFIX"/bin/swresample-3.dll \
+    "$ZIP_PREFIX"/bin/swscale-5.dll \
+    "$ZIP_PREFIX"/include
+
+mv "$ZIP_PREFIX"/* .
+rmdir "$ZIP_PREFIX"

--- a/app/prebuilt-deps/prepare-libusb-win-arm64.sh
+++ b/app/prebuilt-deps/prepare-libusb-win-arm64.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DIR"
+. common
+mkdir -p "$PREBUILT_DATA_DIR"
+cd "$PREBUILT_DATA_DIR"
+
+DEP_DIR=libusb-1.0.26
+
+FILENAME=libusb-windows-aarch64-mingw.7z
+SHA256SUM=4c83624edc89f95c3500fda3f982f038e7ce996979a8cca0e2e0133d3ef9ef64
+
+if [[ -d "$DEP_DIR" ]]
+then
+    echo "$DEP_DIR" found
+    exit 0
+fi
+
+get_file "https://github.com/ZIXT233/libusb-windows-aarch64-mingw/releases/download/v1.0.26/$FILENAME" "$FILENAME" "$SHA256SUM"
+
+mkdir "$DEP_DIR"
+cd "$DEP_DIR"
+
+# include/ is the same in all folders of the archive
+7z x "../$FILENAME" \
+    libusb-windows-aarch64-mingw/bin/libusb-1.0.dll \
+    libusb-windows-aarch64-mingw/include/
+
+mv libusb-windows-aarch64-mingw/bin MinGW-aarch64
+mv libusb-windows-aarch64-mingw/include .
+rm -rf libusb-windows-aarch64-mingw

--- a/app/prebuilt-deps/prepare-sdl-win-arm64.sh
+++ b/app/prebuilt-deps/prepare-sdl-win-arm64.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DIR"
+. common
+mkdir -p "$PREBUILT_DATA_DIR"
+cd "$PREBUILT_DATA_DIR"
+
+DEP_DIR=SDL2-2.0.22
+
+FILENAME=SDL-windows-aarch64-mingw.7z
+SHA256SUM=96a1bd6a0246419ab1e1ae510ba79dfbbfc94c2681f039426a632ffbd4d4b603
+
+if [[ -d "$DEP_DIR" ]]
+then
+    echo "$DEP_DIR" found
+    exit 0
+fi
+
+get_file "https://github.com/ZIXT233/SDL-windows-aarch64-mingw/releases/download/release-2.0.22/$FILENAME" "$FILENAME" "$SHA256SUM"
+
+mkdir "$DEP_DIR"
+cd "$DEP_DIR"
+
+7z x "../$FILENAME" \
+    SDL-windows-aarch64-mingw/bin/SDL2.dll \
+    SDL-windows-aarch64-mingw/include/ \
+    SDL-windows-aarch64-mingw/lib/
+
+mv SDL-windows-aarch64-mingw aarch64-w64-mingw32

--- a/cross_win_arm64.txt
+++ b/cross_win_arm64.txt
@@ -1,0 +1,25 @@
+# apt install mingw-w64 mingw-w64-tools
+
+[binaries]
+name = 'mingw'
+c = 'aarch64-w64-mingw32-gcc'
+cpp = 'aarch64-w64-mingw32-g++'
+ar = 'aarch64-w64-mingw32-ar'
+strip = 'aarch64-w64-mingw32-strip'
+pkgconfig = 'aarch64-w64-mingw32-pkg-config'
+windres = 'aarch64-w64-mingw32-windres'
+
+[host_machine]
+system = 'windows'
+cpu_family = 'aarch64'
+cpu = 'aarch64'
+endian = 'little'
+
+[properties]
+ffmpeg_avcodec = 'avcodec-58'
+ffmpeg_avformat = 'avformat-58'
+ffmpeg_avutil = 'avutil-56'
+prebuilt_ffmpeg = 'ffmpeg-aarch64-4.3.1'
+prebuilt_sdl2 = 'SDL2-2.0.22/aarch64-w64-mingw32'
+prebuilt_libusb_root = 'libusb-1.0.26'
+prebuilt_libusb = 'libusb-1.0.26/MinGW-aarch64'


### PR DESCRIPTION
  I tried to cross compile scrcpy for win on arm64 using llvm-mingw, which seems to be working properly and significantly improves video performance in win on arm64.

What I did:
- Prebuilt libusb,ffmpeg,SDL2 for win on arm64, which was placed in my responsitories. (Removed libusb build flags "-mwin32" and "--add-stdcall-alias" to support llvm)
- Added scripts to get prebuilt-deps.
- Added win on arm64 build option in release.mk,  which should be manually specified as llvm-mingw is a special toolchain. In addtion, I removed the linker option "-Wl,--allow-shlib-undefined" unsupported by llvm in build.ninja after meson completed. (There seems to be no way to prevent meson from passing this option so far, see:  https://github.com/mesonbuild/meson/issues/7506 )
- Modified app/build.ninja to select libusb dll depending on host_machine.cpu_family().

Known issue:
- Reported error "couldn't find image decorder" and "couldn't load icon" when starting. 
![36F3D3382058CE4FCE21E4AEB551C50B](https://user-images.githubusercontent.com/9472407/167326209-804dd824-401b-4424-97e7-308cbfef98dd.png)

I'm not sure where to put the prebuilt package to ensure its maintenance .
Let me know if there are any problems.

