### PR TITLE
[WIP] Build dependencies from sources

### DIFF
--- a/app/deps/.gitignore
+++ b/app/deps/.gitignore
@@ -1,0 +1,2 @@
+/data
+/target-*

--- a/app/deps/src/build-ffmpeg.sh
+++ b/app/deps/src/build-ffmpeg.sh
@@ -29,6 +29,7 @@ cd "build-$HOST"
 
 params=(
     --prefix="$INSTALL_DIR"
+    --arch="$ARCH"
     --disable-autodetect
     --disable-programs
     --disable-everything
@@ -44,10 +45,19 @@ params=(
     --enable-muxer=mp4
     --enable-muxer=matroska
 )
-if [[ "$HOST_SYSTEM" == 'linux' ]]
-then
-    params+=(--enable-libv4l2)
-fi
+
+case "$HOST_SYSTEM" in
+    linux)
+        params+=(--enable-libv4l2)
+        ;;
+    windows)
+        params+=(--target-os=mingw32)
+        params+=(--cross-prefix="$HOST-")
+        ;;
+    *)
+        fail "Unsupported platform: $HOST"
+        ;;
+esac
 
 ../configure "${params[@]}"
 make -j $NJOBS

--- a/app/deps/src/build-ffmpeg.sh
+++ b/app/deps/src/build-ffmpeg.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+. init_deps
+
+VERSION=5.0.1
+FILENAME=ffmpeg-$VERSION.tar.xz
+
+URL=http://ffmpeg.org/releases/ffmpeg-$VERSION.tar.xz
+SHA256SUM=ef2efae259ce80a240de48ec85ecb062cecca26e4352ffb3fda562c21a93007b
+
+DEP_DIR="$DATA_DIR/ffmpeg-$VERSION-$SHA256SUM"
+
+if [[ ! -d "$DEP_DIR" ]]
+then
+    get_file "$URL" "$FILENAME" "$SHA256SUM"
+
+    mkdir "$DEP_DIR"
+    cd "$DEP_DIR"
+
+    tar xvf "../$FILENAME"
+else
+    echo "$DEP_DIR found"
+    cd "$DEP_DIR"
+fi
+
+cd "ffmpeg-$VERSION"
+rm -rf "build-$HOST"
+mkdir "build-$HOST"
+cd "build-$HOST"
+
+params=(
+    --prefix="$INSTALL_DIR"
+    --disable-autodetect
+    --disable-programs
+    --disable-everything
+    --disable-doc
+    --disable-swresample
+    --disable-swscale
+    --disable-avfilter
+    --disable-postproc
+    --disable-static
+    --enable-shared
+    --enable-decoder=h264
+    --enable-decoder=png
+    --enable-muxer=mp4
+    --enable-muxer=matroska
+)
+if [[ "$HOST_SYSTEM" == 'linux' ]]
+then
+    params+=(--enable-libv4l2)
+fi
+
+../configure "${params[@]}"
+make -j $NJOBS
+make install

--- a/app/deps/src/init_deps
+++ b/app/deps/src/init_deps
@@ -1,0 +1,44 @@
+set -e
+
+# The caller must set the following environment variable
+#  - $HOST (e.g. "x86_64-linux-gnu")
+#  - $HOST_SYSTEM ("linux", "windows", "apple"), for scripts convenience
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+[[ -z "$HOST" ]] && fail '$HOST not defined'
+[[ -z "$HOST_SYSTEM" ]] && fail '$HOST_SYSTEM not defined'
+
+DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DIR"
+
+DATA_DIR=$(realpath ../data)
+INSTALL_DIR=$(realpath ../target-"$HOST")
+NJOBS=$(grep -c ^processor /proc/cpuinfo)
+
+mkdir -p "$DATA_DIR"
+cd "$DATA_DIR"
+
+checksum() {
+    local file="$1"
+    local sum="$2"
+    echo "$file: verifying checksum..."
+    echo "$sum  $file" | sha256sum -c
+}
+
+get_file() {
+    local url="$1"
+    local file="$2"
+    local sum="$3"
+    if [[ -f "$file" ]]
+    then
+        echo "$file: found"
+    else
+        echo "$file: not found, downloading..."
+        wget "$url" -O "$file"
+    fi
+    checksum "$file" "$sum"
+}

--- a/app/deps/src/init_deps
+++ b/app/deps/src/init_deps
@@ -10,7 +10,19 @@ fail() {
 }
 
 [[ -z "$HOST" ]] && fail '$HOST not defined'
-[[ -z "$HOST_SYSTEM" ]] && fail '$HOST_SYSTEM not defined'
+
+if [[ "$HOST" == *linux* ]]
+then
+    HOST_SYSTEM='linux'
+elif [[ "$HOST" == *mingw* ]]
+then
+    HOST_SYSTEM='windows'
+else
+    fail "Host system could not be deduced from '$HOST'"
+fi
+
+ARCH="${HOST%%-*}"
+[[ -z "$ARCH" ]] && fail "Arch could not be deduced from '$HOST'"
 
 DIR=$(dirname ${BASH_SOURCE[0]})
 cd "$DIR"


### PR DESCRIPTION
For Windows releases, scrcpy use prebuilt dependencies downloaded from "official" sources.
However, the vendors don't always provide builds for all the architectures, and we can't apply patches when necessary (to fix a bug until the next release for example). Also see #1753.

For Linux, we use the dependencies from the package manager.
But it might be interesting to build the dependencies to provide a "portable" version (either a static build or an archive with all .so included and RPATH set).

This MR aims to provide scripts (one for each dependency: ffmpeg, sdl, libusb, adb(?)), intended to be called from the release script (from Linux to build for Linux and Windows (macOS is more complicated from Linux)).

For now, only the script to build ffmpeg for linux is provided:

```bash
export HOST=x86_64-linux-gnu
export HOST_SYSTEM=linux  # for convenience, could be deduced from $HOST later
cd app/deps/src
./ffmpeg.sh
```

This downloads the FFmpeg sources, then build locally for the target platform, and install them into `app/deps/target-x86_64-linux-gnu`. The structure looks like this (only the relevant parts of the tree are shown here):

```
app/deps
├── data
│   ├── ffmpeg-5.0.1-ef2efae259ce80a240de48ec85ecb062cecca26e4352ffb3fda562c21a93007b
│   └── ffmpeg-5.0.1.tar.xz
├── src
│   ├── ffmpeg.sh
│   └── init_deps
└── target-x86_64-linux-gnu
    ├── include
    │   ├── libavcodec
    │   ├── libavdevice
    │   ├── libavformat
    │   └── libavutil
    ├── lib
    │   ├── libavcodec.so -> libavcodec.so.59.18.100
    │   ├── libavcodec.so.59 -> libavcodec.so.59.18.100
    │   ├── libavcodec.so.59.18.100
    │   ├── libavdevice.so -> libavdevice.so.59.4.100
    │   ├── libavdevice.so.59 -> libavdevice.so.59.4.100
    │   ├── libavdevice.so.59.4.100
    │   ├── libavformat.so -> libavformat.so.59.16.100
    │   ├── libavformat.so.59 -> libavformat.so.59.16.100
    │   ├── libavformat.so.59.16.100
    │   ├── libavutil.so -> libavutil.so.57.17.100
    │   ├── libavutil.so.57 -> libavutil.so.57.17.100
    │   ├── libavutil.so.57.17.100
    │   └── pkgconfig
    │       ├── libavcodec.pc
    │       ├── libavdevice.pc
    │       ├── libavformat.pc
    │       └── libavutil.pc
    └── …
```

The correct target directory should then be used by meson to build (not done yet).

The scripts (for now ffmpeg only) must be adapted to cross-compile with mingw when the host system is Windows (not done yet).