### PR TITLE
Use DisplayManagerGlobal instance

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -3,12 +3,10 @@ package com.genymobile.scrcpy.wrappers;
 import com.genymobile.scrcpy.DisplayInfo;
 import com.genymobile.scrcpy.Size;
 
-import android.os.IInterface;
-
 public final class DisplayManager {
-    private final IInterface manager;
+    private final Object manager; // instance of hidden class android.hardware.display.DisplayManagerGlobal
 
-    public DisplayManager(IInterface manager) {
+    public DisplayManager(Object manager) {
         this.manager = manager;
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
@@ -50,6 +50,14 @@ public final class ServiceManager {
 
     public DisplayManager getDisplayManager() {
         if (displayManager == null) {
+            try {
+                Class<?> clazz = Class.forName("android.hardware.display.DisplayManagerGlobal");
+                Method getInstanceMethod = clazz.getDeclaredMethod("getInstance");
+                Object dmg = getInstanceMethod.invoke(null);
+                displayManager = new DisplayManager(dmg);
+            } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                throw new AssertionError(e);
+            }
             displayManager = new DisplayManager(getService("display", "android.hardware.display.IDisplayManager"));
         }
         return displayManager;


### PR DESCRIPTION
Use the client instance to communicate with the DisplayManager server.

Fixes #3446