### PR TITLE
Remove deprecated meson.source_root()

### DIFF
--- a/server/meson.build
+++ b/server/meson.build
@@ -13,8 +13,8 @@ if prebuilt_server == ''
                   install_dir: 'share/scrcpy')
 else
     if not prebuilt_server.startswith('/')
-        # relative path needs some trick
-        prebuilt_server = meson.source_root() + '/' + prebuilt_server
+        # prebuilt server path is relative to the root scrcpy directory
+        prebuilt_server = '../' + prebuilt_server
     endif
     custom_target('scrcpy-server-prebuilt',
                   input: prebuilt_server,


### PR DESCRIPTION
This method is deprecated since Meson 0.56.0:
<https://mesonbuild.com/Release-notes-for-0-56-0.html#mesonbuild_root-and-mesonsource_root-are-deprecated>

We could replace it with meson.project_source_root(), but this would
make Meson 0.56 or above mandatory. Since the path in always computed
from the server/ directory, just add '..' to reference the root project
directory.

Refs c456e3826470753bdaefcffc93e9ae1bf25b12f7

cc @npes87184 as the author of c456e3826470753bdaefcffc93e9ae1bf25b12f7.