### PR TITLE
[Draft] Add option to install the server as an APK

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -188,7 +188,7 @@ conf.set_quoted('SCRCPY_VERSION', meson.project_version())
 # the prefix used during configuration (meson --prefix=PREFIX)
 conf.set_quoted('PREFIX', get_option('prefix'))
 
-# build a "portable" version (with scrcpy-server accessible from the same
+# build a "portable" version (with scrcpy-server.apk accessible from the same
 # directory as the executable)
 conf.set('PORTABLE', get_option('portable'))
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -111,6 +111,10 @@ However, the option is only available when the HID keyboard is enabled (or a phy
 Also see \fB\-\-hid\-mouse\fR.
 
 .TP
+.B \-\-install
+Install the server (via "adb install") rather than pushing it to /data/local/tmp (via "adb push").
+
+.TP
 .B \-\-legacy\-paste
 Inject computer clipboard text as a sequence of key events on Ctrl+v (like MOD+Shift+v).
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -247,6 +247,10 @@ option if set, or by the file extension (.mp4 or .mkv).
 Force recording format (either mp4 or mkv).
 
 .TP
+.B \-\-reinstall
+Reinstall the server (via "adb install"), even if the correct version is already installed. Implies \fB\-\-install\fR.
+
+.TP
 .BI "\-\-render\-driver " name
 Request SDL to use the given render driver (this is just a hint).
 

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -330,6 +330,17 @@ sc_adb_install(struct sc_intr *intr, const char *serial, const char *local,
 }
 
 bool
+sc_adb_uninstall(struct sc_intr *intr, const char *serial, const char *pkg,
+                 unsigned flags) {
+    assert(serial);
+    const char *const argv[] =
+        SC_ADB_COMMAND("-s", serial, "uninstall", pkg);
+
+    sc_pid pid = sc_adb_execute(argv, flags);
+    return process_check_success_intr(intr, pid, "adb uninstall", flags);
+}
+
+bool
 sc_adb_tcpip(struct sc_intr *intr, const char *serial, uint16_t port,
              unsigned flags) {
     char port_string[5 + 1];

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -435,6 +435,7 @@ sc_adb_list_devices(struct sc_intr *intr, unsigned flags,
              "Please report an issue.");
         return false;
     }
+#undef BUFSIZE
 
     // It is parsed as a NUL-terminated string
     buf[r] = '\0';
@@ -757,4 +758,55 @@ sc_adb_get_installed_apk_path(struct sc_intr *intr, const char *serial,
     buf[r] = '\0';
 
     return sc_adb_parse_installed_apk_path(buf);
+}
+
+char *
+sc_adb_get_installed_apk_version(struct sc_intr *intr, const char *serial,
+                                 unsigned flags) {
+    assert(serial);
+    const char *const argv[] =
+        SC_ADB_COMMAND("-s", serial, "shell", "dumpsys", "package",
+                       SC_ANDROID_PACKAGE);
+
+    sc_pipe pout;
+    sc_pid pid = sc_adb_execute_p(argv, flags, &pout);
+    if (pid == SC_PROCESS_NONE) {
+        LOGD("Could not execute \"dumpsys package\"");
+        return NULL;
+    }
+
+    // "dumpsys package" output can be huge (e.g. 16k), but versionName is at
+    // the beginning, typically in the first 1024 bytes (64k should be enough
+    // for the whole output anyway)
+#define BUFSIZE 65536
+    char *buf = malloc(BUFSIZE);
+    if (!buf) {
+        return false;
+    }
+    ssize_t r = sc_pipe_read_all_intr(intr, pid, pout, buf, BUFSIZE - 1);
+    sc_pipe_close(pout);
+
+    bool ok = process_check_success_intr(intr, pid, "dumpsys package", flags);
+    if (!ok) {
+        free(buf);
+        return NULL;
+    }
+
+    if (r == -1) {
+        free(buf);
+        return NULL;
+    }
+
+    assert((size_t) r < BUFSIZE);
+#undef BUFSIZE
+    // if r == sizeof(buf), then the output is truncated, but we don't care,
+    // versionName is at the beginning in practice, and is unlikely to be
+    // truncated at 64k
+
+    // It is parsed as a NUL-terminated string
+    buf[r] = '\0';
+
+    char *version = sc_adb_parse_installed_apk_version(buf);
+    free(buf);
+    return version;
 }

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -713,3 +713,48 @@ sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags) {
 
     return sc_adb_parse_device_ip(buf);
 }
+
+char *
+sc_adb_get_installed_apk_path(struct sc_intr *intr, const char *serial,
+                              unsigned flags) {
+    assert(serial);
+    const char *const argv[] =
+        SC_ADB_COMMAND("-s", serial, "shell", "pm", "list", "package", "-f",
+                       SC_ANDROID_PACKAGE);
+
+    sc_pipe pout;
+    sc_pid pid = sc_adb_execute_p(argv, flags, &pout);
+    if (pid == SC_PROCESS_NONE) {
+        LOGD("Could not execute \"pm list packages\"");
+        return NULL;
+    }
+
+    // "pm list packages -f <package>" output should contain only one line, so
+    // the output should be short
+    char buf[1024];
+    ssize_t r = sc_pipe_read_all_intr(intr, pid, pout, buf, sizeof(buf) - 1);
+    sc_pipe_close(pout);
+
+    bool ok = process_check_success_intr(intr, pid, "pm list packages", flags);
+    if (!ok) {
+        return NULL;
+    }
+
+    if (r == -1) {
+        return NULL;
+    }
+
+    assert((size_t) r < sizeof(buf));
+    if (r == sizeof(buf) - 1)  {
+        // The implementation assumes that the output of "pm list packages"
+        // fits in the buffer in a single pass
+        LOGW("Result of \"pm list package\" does not fit in 1Kb. "
+             "Please report an issue.");
+        return NULL;
+    }
+
+    // It is parsed as a NUL-terminated string
+    buf[r] = '\0';
+
+    return sc_adb_parse_installed_apk_path(buf);
+}

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -66,6 +66,10 @@ bool
 sc_adb_install(struct sc_intr *intr, const char *serial, const char *local,
                unsigned flags);
 
+bool
+sc_adb_uninstall(struct sc_intr *intr, const char *serial, const char *pkg,
+                 unsigned flags);
+
 /**
  * Execute `adb tcpip <port>`
  */

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -123,4 +123,11 @@ char *
 sc_adb_get_installed_apk_path(struct sc_intr *intr, const char *serial,
                               unsigned flags);
 
+/**
+ * Return the version of the installed APK for com.genymobile.scrcpy (if any)
+ */
+char *
+sc_adb_get_installed_apk_version(struct sc_intr *intr, const char *serial,
+                                 unsigned flags);
+
 #endif

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -15,6 +15,8 @@
 
 #define SC_ADB_SILENT (SC_ADB_NO_STDOUT | SC_ADB_NO_STDERR | SC_ADB_NO_LOGERR)
 
+#define SC_ANDROID_PACKAGE "com.genymobile.scrcpy"
+
 const char *
 sc_adb_get_executable(void);
 
@@ -113,5 +115,12 @@ sc_adb_getprop(struct sc_intr *intr, const char *serial, const char *prop,
  */
 char *
 sc_adb_get_device_ip(struct sc_intr *intr, const char *serial, unsigned flags);
+
+/**
+ * Return the path of the installed APK for com.genymobile.scrcpy (if any)
+ */
+char *
+sc_adb_get_installed_apk_path(struct sc_intr *intr, const char *serial,
+                              unsigned flags);
 
 #endif

--- a/app/src/adb/adb_parser.c
+++ b/app/src/adb/adb_parser.c
@@ -253,3 +253,34 @@ sc_adb_parse_installed_apk_path(char *str) {
 
     return strdup(s);
 }
+
+char *
+sc_adb_parse_installed_apk_version(const char *str) {
+    // str is the (beginning of the) output of `dumpsys package`
+    // We want to extract the version string from a line starting with 4 spaces
+    // then `versionName=` then the version string.
+
+#define VERSION_NAME_PREFIX "\n    versionName="
+    char *s = strstr(str, VERSION_NAME_PREFIX);
+    if (!s) {
+        // Not found
+        return NULL;
+    }
+
+    s+= sizeof(VERSION_NAME_PREFIX) - 1;
+
+    size_t len = strspn(s, "0123456789.");
+    if (!len) {
+        LOGW("Unexpected version name with no value");
+        return NULL;
+    }
+
+    char *version = malloc(len + 1);
+    if (!version) {
+        return NULL;
+    }
+
+    memcpy(version, s, len);
+    version[len] = '\0';
+    return version;
+}

--- a/app/src/adb/adb_parser.c
+++ b/app/src/adb/adb_parser.c
@@ -225,3 +225,31 @@ sc_adb_parse_device_ip(char *str) {
 
     return NULL;
 }
+
+char *
+sc_adb_parse_installed_apk_path(char *str) {
+    // str is expected to look like:
+    // "package:/data/app/.../base.apk=com.genymobile.scrcpy"
+    //          ^^^^^^^^^^^^^^^^^^^^^^
+    // We want to extract the path (which may contain '=', even in practice)
+
+    if (strncmp(str, "package:", 8)) {
+        // Does not start with "package:"
+        return NULL;
+    }
+
+    char *s = str + 8;
+    size_t len = strcspn(s, " \r\n");
+    s[len] = '\0';
+
+    char *p = strrchr(s, '=');
+    if (!p) {
+        // No '=' found
+        return NULL;
+    }
+
+    // Truncate at the last '='
+    *p = '\0';
+
+    return strdup(s);
+}

--- a/app/src/adb/adb_parser.h
+++ b/app/src/adb/adb_parser.h
@@ -38,4 +38,13 @@ sc_adb_parse_device_ip(char *str);
 char *
 sc_adb_parse_installed_apk_path(char *str);
 
+/**
+ * Parse the package version from the output of
+ * `adb shell dumpsys package <package>`
+ *
+ * The parameter must be a NUL-terminated string.
+ */
+char *
+sc_adb_parse_installed_apk_version(const char *str);
+
 #endif

--- a/app/src/adb/adb_parser.h
+++ b/app/src/adb/adb_parser.h
@@ -27,4 +27,15 @@ sc_adb_parse_devices(char *str, struct sc_vec_adb_devices *out_vec);
 char *
 sc_adb_parse_device_ip(char *str);
 
+/**
+ * Parse the package path from the output of
+ * `adb shell pm list packages -f <package>`
+ *
+ * The parameter must be a NUL-terminated string.
+ *
+ * Warning: this function modifies the buffer for optimization purposes.
+ */
+char *
+sc_adb_parse_installed_apk_path(char *str);
+
 #endif

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -58,6 +58,7 @@
 #define OPT_PRINT_FPS              1038
 #define OPT_NO_POWER_ON            1039
 #define OPT_INSTALL                1040
+#define OPT_REINSTALL              1041
 
 struct sc_option {
     char shortopt;
@@ -384,6 +385,13 @@ static const struct sc_option options[] = {
         .longopt = "record-format",
         .argdesc = "format",
         .text = "Force recording format (either mp4 or mkv).",
+    },
+    {
+        .longopt_id = OPT_REINSTALL,
+        .longopt = "reinstall",
+        .text = "Reinstall the server (via 'adb install'), even if the correct "
+                "version is already installed.\n"
+                "Implies --install.",
     },
     {
         .longopt_id = OPT_RENDER_DRIVER,
@@ -1619,6 +1627,10 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_INSTALL:
                 opts->install = true;
+                break;
+            case OPT_REINSTALL:
+                opts->install = true;
+                opts->reinstall = true;
                 break;
             case OPT_OTG:
 #ifdef HAVE_USB

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -57,6 +57,7 @@
 #define OPT_NO_CLEANUP             1037
 #define OPT_PRINT_FPS              1038
 #define OPT_NO_POWER_ON            1039
+#define OPT_INSTALL                1040
 
 struct sc_option {
     char shortopt;
@@ -206,6 +207,12 @@ static const struct sc_option options[] = {
         .shortopt = 'h',
         .longopt = "help",
         .text = "Print this help.",
+    },
+    {
+        .longopt_id = OPT_INSTALL,
+        .longopt = "install",
+        .text = "Install the server (via 'adb install') rather than pushing "
+                "it to /data/local/tmp (via 'adb push').",
     },
     {
         .longopt_id = OPT_LEGACY_PASTE,
@@ -1609,6 +1616,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_PRINT_FPS:
                 opts->start_fps_counter = true;
+                break;
+            case OPT_INSTALL:
+                opts->install = true;
                 break;
             case OPT_OTG:
 #ifdef HAVE_USB

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -65,4 +65,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .cleanup = true,
     .start_fps_counter = false,
     .power_on = true,
+    .install = false,
 };

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -66,4 +66,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .start_fps_counter = false,
     .power_on = true,
     .install = false,
+    .reinstall = false,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -140,6 +140,7 @@ struct scrcpy_options {
     bool cleanup;
     bool start_fps_counter;
     bool power_on;
+    bool install;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -141,6 +141,7 @@ struct scrcpy_options {
     bool start_fps_counter;
     bool power_on;
     bool install;
+    bool reinstall;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -325,6 +325,7 @@ scrcpy(struct scrcpy_options *options) {
         .tcpip_dst = options->tcpip_dst,
         .cleanup = options->cleanup,
         .power_on = options->power_on,
+        .install = options->install,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -326,6 +326,7 @@ scrcpy(struct scrcpy_options *options) {
         .cleanup = options->cleanup,
         .power_on = options->power_on,
         .install = options->install,
+        .reinstall = options->reinstall,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -105,7 +105,10 @@ error:
 }
 
 static bool
-push_server(struct sc_intr *intr, const char *serial, bool install) {
+push_server(struct sc_intr *intr, const char *serial, bool install,
+            bool reinstall) {
+    assert(install || !reinstall); // reinstall implies install
+
     char *server_path = get_server_path();
     if (!server_path) {
         return false;
@@ -121,7 +124,7 @@ push_server(struct sc_intr *intr, const char *serial, bool install) {
         char *version = sc_adb_get_installed_apk_version(intr, serial, 0);
         bool same_version = version && !strcmp(version, SCRCPY_VERSION);
         free(version);
-        if (same_version) {
+        if (!reinstall && same_version) {
             LOGI("Server " SCRCPY_VERSION " already installed");
             ok = true;
         } else {
@@ -818,7 +821,7 @@ run_server(void *data) {
     assert(serial);
     LOGD("Device serial: %s", serial);
 
-    ok = push_server(&server->intr, serial, params->install);
+    ok = push_server(&server->intr, serial, params->install, params->reinstall);
     if (!ok) {
         LOGE("Failed to push server");
         goto error_connection_failed;

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -316,6 +316,10 @@ execute_server(struct sc_server *server,
         // By default, power_on is true
         ADD_PARAM("power_on=false");
     }
+    if (params->install) {
+        // By default, installed is false
+        ADD_PARAM("installed=true");
+    }
 
 #undef ADD_PARAM
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -14,10 +14,10 @@
 #include "util/process_intr.h"
 #include "util/str.h"
 
-#define SC_SERVER_FILENAME "scrcpy-server"
+#define SC_SERVER_FILENAME "scrcpy-server.apk"
 
 #define SC_SERVER_PATH_DEFAULT PREFIX "/share/scrcpy/" SC_SERVER_FILENAME
-#define SC_DEVICE_SERVER_PATH "/data/local/tmp/scrcpy-server.jar"
+#define SC_DEVICE_SERVER_PATH "/data/local/tmp/scrcpy-server.apk"
 
 static char *
 get_server_path(void) {

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -48,6 +48,7 @@ struct sc_server_params {
     bool select_tcpip;
     bool cleanup;
     bool power_on;
+    bool install;
 };
 
 struct sc_server {

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -49,6 +49,7 @@ struct sc_server_params {
     bool cleanup;
     bool power_on;
     bool install;
+    bool reinstall;
 };
 
 struct sc_server {

--- a/app/tests/test_adb_parser.c
+++ b/app/tests/test_adb_parser.c
@@ -263,6 +263,32 @@ static void test_apk_path_invalid(void) {
     assert(!path);
 }
 
+static void test_apk_version(void) {
+    char str[] =
+        "Key Set Manager:\n"
+        "  [com.genymobile.scrcpy]\n"
+        "      Signing KeySets: 128\n"
+        "\n"
+        "Packages:\n"
+        "  Package [com.genymobile.scrcpy] (89abcdef):\n"
+        "    userId=12345\n"
+        "    pkg=Package{012345 com.genymobile.scrcpy}\n"
+        "    codePath=/data/app/~~abcdef==/com.genymobile.scrcpy-012345==\n"
+        "    resourcePath=/data/app/~~abcdef==/com.genymobile.scrcpy-013245==\n"
+        "    primaryCpuAbi=null\n"
+        "    secondaryCpuAbi=null\n"
+        "    versionCode=12400 minSdk=21 targetSdk=31\n"
+        "    versionName=1.24\n"
+        "    splits=[base]\n"
+        "    apkSigningVersion=2\n"
+        "    applicationInfo=ApplicationInfo{012345 com.genymobile.scrcpy}\n";
+
+    const char *expected = "1.24";
+    char *version = sc_adb_parse_installed_apk_version(str);
+    assert(!strcmp(version, expected));
+    free(version);
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -287,6 +313,7 @@ int main(int argc, char *argv[]) {
 
     test_apk_path();
     test_apk_path_invalid();
+    test_apk_version();
 
     return 0;
 }

--- a/app/tests/test_adb_parser.c
+++ b/app/tests/test_adb_parser.c
@@ -241,6 +241,28 @@ static void test_get_ip_truncated(void) {
     assert(!ip);
 }
 
+static void test_apk_path(void) {
+    char str[] = "package:/data/app/~~71mguyc6p-kNjQdNaNkToA==/com.genymobile."
+                 "scrcpy-l6fiqqUSU7Ok7QLg-rIyJA==/base.apk=com.genymobile."
+                 "scrcpy\n";
+
+    const char *expected = "/data/app/~~71mguyc6p-kNjQdNaNkToA==/com.genymobile"
+                           ".scrcpy-l6fiqqUSU7Ok7QLg-rIyJA==/base.apk";
+    char *path = sc_adb_parse_installed_apk_path(str);
+    assert(!strcmp(path, expected));
+    free(path);
+}
+
+static void test_apk_path_invalid(void) {
+    // Does not start with "package:"
+    char str[] = "garbage:/data/app/~~71mguyc6p-kNjQdNaNkToA==/com.genymobile."
+                 "scrcpy-l6fiqqUSU7Ok7QLg-rIyJA==/base.apk=com.genymobile."
+                 "scrcpy\n";
+
+    char *path = sc_adb_parse_installed_apk_path(str);
+    assert(!path);
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -262,6 +284,9 @@ int main(int argc, char *argv[]) {
     test_get_ip_no_wlan();
     test_get_ip_no_wlan_without_eol();
     test_get_ip_truncated();
+
+    test_apk_path();
+    test_apk_path_invalid();
 
     return 0;
 }

--- a/run
+++ b/run
@@ -21,5 +21,5 @@ then
 fi
 
 SCRCPY_ICON_PATH="app/data/icon.png" \
-SCRCPY_SERVER_PATH="$BUILDDIR/server/scrcpy-server" \
+SCRCPY_SERVER_PATH="$BUILDDIR/server/scrcpy-server.apk" \
 "$BUILDDIR/app/scrcpy" "$@"

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -6,3 +6,4 @@
 /build
 /captures
 .externalNativeBuild
+/keystore.properties

--- a/server/HOWTO_keystore.txt
+++ b/server/HOWTO_keystore.txt
@@ -1,0 +1,12 @@
+For an APK to be installable, it must be signed: <https://developer.android.com/training/articles/keystore>
+
+For that purpose, create a keystore by executing this command:
+
+    keytool -genkey -v -keystore ~/.android/scrcpy.keystore -keyalg RSA -keysize 2048 -validity 10000 -alias scrcpy -dname cn=scrcpy
+
+(Adapt ~/.android/scrcpy.keystore if you want to generate it to another location.)
+
+Then create server/keystore.properties and edit its properties:
+
+    cp keystore.properties.sample keystore.properties
+    vim keystore.properties  # fill the properties

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -10,10 +10,26 @@ android {
         versionName "1.24"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+    signingConfigs {
+        release {
+            // to be defined in server/keystore.properties (see server/HOWTO_keystore.txt)
+            def keystorePropsFile = rootProject.file("server/keystore.properties")
+            if (keystorePropsFile.exists()) {
+                def props = new Properties()
+                props.load(new FileInputStream(keystorePropsFile))
+
+                storeFile rootProject.file(props['storeFile'])
+                storePassword props['storePassword']
+                keyAlias props['keyAlias']
+                keyPassword props['keyPassword']
+            }
+        }
+    }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
         }
     }
 }

--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -21,7 +21,7 @@ BUILD_TOOLS_DIR="$ANDROID_HOME/build-tools/$BUILD_TOOLS"
 BUILD_DIR="$(realpath ${BUILD_DIR:-build_manual})"
 CLASSES_DIR="$BUILD_DIR/classes"
 SERVER_DIR=$(dirname "$0")
-SERVER_BINARY=scrcpy-server
+SERVER_BINARY=scrcpy-server.apk
 ANDROID_JAR="$ANDROID_HOME/platforms/android-$PLATFORM/android.jar"
 
 echo "Platform: android-$PLATFORM"

--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -14,13 +14,41 @@ set -e
 SCRCPY_DEBUG=false
 SCRCPY_VERSION_NAME=1.24
 
+SERVER_DIR="$(realpath $(dirname "$0"))"
+KEYSTORE_PROPERTIES_FILE="$SERVER_DIR/keystore.properties"
+
+if [[ ! -f "$KEYSTORE_PROPERTIES_FILE" ]]
+then
+    echo "The file '$KEYSTORE_PROPERTIES_FILE' does not exist." >&2
+    echo "Please read '$SERVER_DIR/HOWTO_keystore.txt'." >&2
+    exit 1
+fi
+
+declare -A props
+while IFS='=' read -r key value
+do
+    props["$key"]="$value"
+done < "$KEYSTORE_PROPERTIES_FILE"
+
+KEYSTORE_FILE=${props['storeFile']}
+KEYSTORE_PASSWORD=${props['storePassword']}
+KEYSTORE_KEY_ALIAS=${props['keyAlias']}
+KEYSTORE_KEY_PASSWORD=${props['keyPassword']}
+
+if [[ ! -f "$KEYSTORE_FILE" ]]
+then
+    echo "Keystore '$KEYSTORE_FILE' (read from '$KEYSTORE_PROPERTIES_FILE')" \
+         "does not exist." >&2
+    echo "Please read '$SERVER_DIR/HOWTO_keystore.txt'." >&2
+    exit 2
+fi
+
 PLATFORM=${ANDROID_PLATFORM:-33}
 BUILD_TOOLS=${ANDROID_BUILD_TOOLS:-33.0.0}
 BUILD_TOOLS_DIR="$ANDROID_HOME/build-tools/$BUILD_TOOLS"
 
 BUILD_DIR="$(realpath ${BUILD_DIR:-build_manual})"
 CLASSES_DIR="$BUILD_DIR/classes"
-SERVER_DIR=$(dirname "$0")
 SERVER_BINARY=scrcpy-server.apk
 ANDROID_JAR="$ANDROID_HOME/platforms/android-$PLATFORM/android.jar"
 
@@ -64,11 +92,7 @@ then
         android/content/*.class \
         com/genymobile/scrcpy/*.class \
         com/genymobile/scrcpy/wrappers/*.class
-
-    echo "Archiving..."
     cd "$BUILD_DIR"
-    jar cvf "$SERVER_BINARY" classes.dex
-    rm -rf classes.dex classes
 else
     # use d8
     "$BUILD_TOOLS_DIR/d8" --classpath "$ANDROID_JAR" \
@@ -79,8 +103,24 @@ else
         com/genymobile/scrcpy/wrappers/*.class
 
     cd "$BUILD_DIR"
-    mv classes.zip "$SERVER_BINARY"
-    rm -rf classes
+    unzip -o classes.zip classes.dex  # we need the inner classes.dex
 fi
+
+echo "Packaging..."
+# note: if a res directory exists, add: -S "$SERVER_DIR/src/main/res"
+"$BUILD_TOOLS_DIR/aapt" package -f \
+    -M "$SERVER_DIR/src/main/AndroidManifest.xml" \
+    -I "$ANDROID_JAR" \
+    -F "$SERVER_BINARY.unaligned"
+"$BUILD_TOOLS_DIR/aapt" add "$SERVER_BINARY.unaligned" classes.dex
+"$BUILD_TOOLS_DIR/zipalign" -p 4 "$SERVER_BINARY.unaligned" "$SERVER_BINARY"
+rm "$SERVER_BINARY.unaligned"
+
+"$BUILD_TOOLS_DIR/apksigner" sign \
+    --ks "$KEYSTORE_FILE" \
+    --ks-pass "pass:$KEYSTORE_PASSWORD" \
+    --ks-key-alias "$KEYSTORE_KEY_ALIAS" \
+    --key-pass "pass:$KEYSTORE_KEY_PASSWORD" \
+    "$SERVER_BINARY"
 
 echo "Server generated in $BUILD_DIR/$SERVER_BINARY"

--- a/server/keystore.properties.sample
+++ b/server/keystore.properties.sample
@@ -1,0 +1,4 @@
+storeFile=/path/to/your/keystore
+storePassword=PASSWORD
+keyAlias=scrcpy
+keyPassword=PASSWORD

--- a/server/meson.build
+++ b/server/meson.build
@@ -6,7 +6,7 @@ if prebuilt_server == ''
                   # gradle is responsible for tracking source changes
                   build_by_default: true,
                   build_always_stale: true,
-                  output: 'scrcpy-server',
+                  output: 'scrcpy-server.apk',
                   command: [find_program('./scripts/build-wrapper.sh'), meson.current_source_dir(), '@OUTPUT@', get_option('buildtype')],
                   console: true,
                   install: true,
@@ -18,7 +18,7 @@ else
     endif
     custom_target('scrcpy-server-prebuilt',
                   input: prebuilt_server,
-                  output: 'scrcpy-server',
+                  output: 'scrcpy-server.apk',
                   command: ['cp', '@INPUT@', '@OUTPUT@'],
                   install: true,
                   install_dir: 'share/scrcpy')

--- a/server/scripts/build-wrapper.sh
+++ b/server/scripts/build-wrapper.sh
@@ -25,5 +25,5 @@ then
     cp "$PROJECT_ROOT/build/outputs/apk/debug/server-debug.apk" "$OUTPUT"
 else
     "$GRADLE" -p "$PROJECT_ROOT" assembleRelease
-    cp "$PROJECT_ROOT/build/outputs/apk/release/server-release-unsigned.apk" "$OUTPUT"
+    cp "$PROJECT_ROOT/build/outputs/apk/release/server-release.apk" "$OUTPUT"
 fi

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -14,7 +14,7 @@ import java.io.IOException;
  */
 public final class CleanUp {
 
-    public static final String SERVER_PATH = "/data/local/tmp/scrcpy-server.jar";
+    public static final String SERVER_PATH = "/data/local/tmp/scrcpy-server.apk";
 
     // A simple struct to be passed from the main process to the cleanup process
     public static class Config implements Parcelable {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -7,6 +7,7 @@ import com.genymobile.scrcpy.wrappers.SurfaceControl;
 import com.genymobile.scrcpy.wrappers.WindowManager;
 
 import android.content.IOnPrimaryClipChangedListener;
+import android.content.pm.ApplicationInfo;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
@@ -20,6 +21,8 @@ import android.view.KeyEvent;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class Device {
+
+    private static final String SCRCPY_PACKAGE_NAME = "com.genymobile.scrcpy";
 
     public static final int POWER_MODE_OFF = SurfaceControl.POWER_MODE_OFF;
     public static final int POWER_MODE_NORMAL = SurfaceControl.POWER_MODE_NORMAL;
@@ -311,5 +314,13 @@ public final class Device {
         if (accelerometerRotation) {
             wm.thawRotation();
         }
+    }
+
+    public static String getInstalledApkPath() {
+        ApplicationInfo info = ServiceManager.getPackageManager().getApplicationInfo(SCRCPY_PACKAGE_NAME);
+        if (info == null) {
+            return null;
+        }
+        return info.sourceDir;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -23,6 +23,7 @@ public class Options {
     private boolean downsizeOnError = true;
     private boolean cleanup = true;
     private boolean powerOn = true;
+    private boolean installed = false;
 
     // Options not used by the scrcpy client, but useful to use scrcpy-server directly
     private boolean sendDeviceMeta = true; // send device name and size
@@ -195,5 +196,13 @@ public class Options {
 
     public void setSendDummyByte(boolean sendDummyByte) {
         this.sendDummyByte = sendDummyByte;
+    }
+
+    public boolean getInstalled() {
+        return installed;
+    }
+
+    public void setInstalled(boolean installed) {
+        this.installed = installed;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -51,8 +51,8 @@ public final class Server {
 
         if (options.getCleanup()) {
             try {
-                CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, restoreNormalPowerMode,
-                        options.getPowerOffScreenOnClose());
+                CleanUp.configure(options.getInstalled(), options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp,
+                        restoreNormalPowerMode, options.getPowerOffScreenOnClose());
             } catch (IOException e) {
                 Ln.e("Could not configure cleanup", e);
             }
@@ -250,6 +250,10 @@ public final class Server {
                 case "power_on":
                     boolean powerOn = Boolean.parseBoolean(value);
                     options.setPowerOn(powerOn);
+                    break;
+                case "installed":
+                    boolean installed = Boolean.parseBoolean(value);
+                    options.setInstalled(installed);
                     break;
                 case "send_device_meta":
                     boolean sendDeviceMeta = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/PackageManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/PackageManager.java
@@ -1,0 +1,36 @@
+package com.genymobile.scrcpy.wrappers;
+
+import com.genymobile.scrcpy.Ln;
+
+import android.content.pm.ApplicationInfo;
+import android.os.IInterface;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class PackageManager {
+
+    private IInterface manager;
+    private Method getApplicationInfoMethod;
+
+    public PackageManager(IInterface manager) {
+        this.manager = manager;
+    }
+
+    private Method getGetApplicationInfoMethod() throws NoSuchMethodException {
+        if (getApplicationInfoMethod == null) {
+            getApplicationInfoMethod = manager.getClass().getDeclaredMethod("getApplicationInfo", String.class, int.class, int.class);
+        }
+        return getApplicationInfoMethod;
+    }
+
+    public ApplicationInfo getApplicationInfo(String packageName) {
+        try {
+            Method method = getGetApplicationInfoMethod();
+            return (ApplicationInfo) method.invoke(manager, packageName, 0, ServiceManager.USER_ID);
+        } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+            Ln.e("Cannot get application info", e);
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
@@ -29,6 +29,7 @@ public final class ServiceManager {
     private static StatusBarManager statusBarManager;
     private static ClipboardManager clipboardManager;
     private static ActivityManager activityManager;
+    private static PackageManager packageManager;
 
     private ServiceManager() {
         /* not instantiable */
@@ -121,5 +122,21 @@ public final class ServiceManager {
         }
 
         return activityManager;
+    }
+
+    public static PackageManager getPackageManager() {
+        if (packageManager == null) {
+            try {
+                //IInterface manager = getService("package", "android.content.pm.IPackageManager");
+                Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+                Method getPackageManager = activityThreadClass.getDeclaredMethod("getPackageManager");
+                IInterface manager = (IInterface) getPackageManager.invoke(null);
+                return new PackageManager(manager);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+
+        return packageManager;
     }
 }


### PR DESCRIPTION
To get shell permissions, the server must execute a [java main()](https://blog.rom1v.com/2018/03/introducing-scrcpy/#run-a-java-main-on-android) executable from `adb shell`.

The jar/apk containing the executable can be either pushed to any location (`/data/local/tmp`), or installed on the device.

Since the [beginning of the project](https://blog.rom1v.com/2018/03/introducing-scrcpy/#quick-installation), scrcpy just pushed the server to `/data/local/tmp`, because it's faster and simpler.

However, scrcpy might benefit from a companion Android app for supporting new features:
 - provide an IME (to inject non-ASCII text);
 - forward audio (a proper integration of what [sndcpy](https://github.com/rom1v/sndcpy) does);
 - optionally mirror camera instead of the screen (which requires a user authorization from an app)…

Instead of building a separate Android app to manage (install/reinstall), this PR makes possible to install the server directly as an APK (and execute the server from there):

```
scrcpy --install
scrcpy --reinstall
```

This paves the way to easily integrate Android component and start activities or services embedded in the server.

As a consequence, the server is now named `scrcpy-server.apk` (which is a drawback IMO, since people will want to install it manually instead of letting the client manage it) and is apk-signed so that it can be installed.

Refs https://github.com/Genymobile/scrcpy/issues/1722
Refs https://github.com/Genymobile/scrcpy/issues/1880#issuecomment-725655830