### PR TITLE
Support wchar_t in argv in windows

### DIFF
--- a/app/src/main.c
+++ b/app/src/main.c
@@ -4,6 +4,10 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <libavformat/avformat.h>
+#ifdef _WIN32
+#include <windows.h>
+#include "util/str.h"
+#endif
 #ifdef HAVE_V4L2
 # include <libavdevice/avdevice.h>
 #endif
@@ -18,8 +22,8 @@
 #include "version.h"
 
 int
-main(int argc, char *argv[]) {
-#ifdef __WINDOWS__
+main_scrcpy(int argc, char *argv[]) {
+#ifdef _WIN32
     // disable buffering, we want logs immediately
     // even line buffering (setvbuf() with mode _IOLBF) is not sufficient
     setbuf(stdout, NULL);
@@ -79,4 +83,51 @@ main(int argc, char *argv[]) {
     avformat_network_deinit(); // ignore failure
 
     return ret;
+}
+
+int
+main(int argc, char *argv[]) {
+#ifndef _WIN32
+    return main_scrcpy(argc, argv);
+#else
+    int wargc;
+    wchar_t **wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    if (!wargv) {
+        LOG_OOM();
+        return SCRCPY_EXIT_FAILURE;
+    }
+
+    char **argv_utf8 = malloc((wargc + 1) * sizeof(*argv_utf8));
+    if (!argv) {
+        LOG_OOM();
+        LocalFree(wargv);
+        return SCRCPY_EXIT_FAILURE;
+    }
+
+    argv_utf8[wargc] = NULL;
+
+    for (int i = 0; i < wargc; ++i) {
+        argv_utf8[i] = sc_str_from_wchars(wargv[i]);
+        if (!argv_utf8[i]) {
+            LOG_OOM();
+            for (int j = 0; j < i; ++j) {
+                free(argv_utf8[j]);
+            }
+            LocalFree(wargv);
+            free(argv_utf8);
+            return SCRCPY_EXIT_FAILURE;
+        }
+    }
+
+    LocalFree(wargv);
+
+    int ret = main_scrcpy(wargc, argv_utf8);
+
+    for (int i = 0; i < wargc; ++i) {
+        free(argv_utf8[i]);
+    }
+    free(argv_utf8);
+
+    return ret;
+#endif
 }


### PR DESCRIPTION
This MR will fix #2932.

There are various approaches that can be used to address this issue, such as the usage of `wmain` with link flag `-municode`. Only the applied method, however, was successful.

Signed-off-by: Yu-Chen Lin <npes87184@gmail.com>