### PR TITLE
Forward audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Its features include:
  - [physical keyboard simulation (HID)](#physical-keyboard-simulation-hid)
  - [physical mouse simulation (HID)](#physical-mouse-simulation-hid)
  - [OTG mode](#otg)
+ - Audio forwarding
  - and more…
 
 ## Requirements
@@ -106,7 +107,7 @@ process][BUILD_simple]).
 For Windows, a prebuilt archive with all the dependencies (including `adb`) is
 available:
 
- - [`scrcpy-win64-v1.25.zip`][direct-win64]  
+ - [`scrcpy-win64-v1.25.zip`][direct-win64]
    <sub>SHA-256: `db65125e9c65acd00359efb7cea9c05f63cc7ccd5833000cd243cc92f5053028`</sub>
 
 [direct-win64]: https://github.com/Genymobile/scrcpy/releases/download/v1.25/scrcpy-win64-v1.25.zip
@@ -1052,11 +1053,18 @@ scrcpy --push-target=/sdcard/Movies/
 
 ### Audio forwarding
 
-Audio is not forwarded by _scrcpy_. Use [sndcpy].
+Audio forwarding is supported on Android 11 or newer. On older devices, Scrcpy doesn't have the permission to record system audio.
+
+Most sound will be redirected to Scrcpy client (which means they will stop playing on device), except rington, alarm and notification sound will continue to play on device.
+
+To disable audio forwarding:
+
+```bash
+scrcpy --no-forward-audio
+```
 
 Also see [issue #14].
 
-[sndcpy]: https://github.com/rom1v/sndcpy
 [issue #14]: https://github.com/Genymobile/scrcpy/issues/14
 
 
@@ -1110,10 +1118,10 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
  | Drag & drop APK file                        | Install APK from computer
  | Drag & drop non-APK file                    | [Push file to device](#push-file-to-device)
 
-_¹Double-click on black borders to remove them._  
-_²Right-click turns the screen on if it was off, presses BACK otherwise._  
-_³4th and 5th mouse buttons, if your mouse has them._  
-_⁴For react-native apps in development, `MENU` triggers development menu._  
+_¹Double-click on black borders to remove them._
+_²Right-click turns the screen on if it was off, presses BACK otherwise._
+_³4th and 5th mouse buttons, if your mouse has them._
+_⁴For react-native apps in development, `MENU` triggers development menu._
 _⁵Only on Android >= 7._
 
 Shortcuts with repeated keys are executed by releasing and pressing the key a

--- a/app/meson.build
+++ b/app/meson.build
@@ -4,6 +4,7 @@ src = [
     'src/adb/adb_device.c',
     'src/adb/adb_parser.c',
     'src/adb/adb_tunnel.c',
+    'src/audio_player.c',
     'src/cli.c',
     'src/clock.c',
     'src/compat.c',

--- a/app/src/audio_player.c
+++ b/app/src/audio_player.c
@@ -6,56 +6,56 @@
 #include "util/log.h"
 
 static void callback(void *userdata, unsigned char *buf, int len) {
-  struct sc_audio_player *audio_player =
-      SDL_static_cast(struct sc_audio_player *, userdata);
+    struct sc_audio_player *audio_player =
+        SDL_static_cast(struct sc_audio_player *, userdata);
 
-  int head = 0;
-  for (;;) {
-    size_t r = net_recv(audio_player->audio_socket, buf + head, len - head);
-    head += (int)r;
-    if (head == len) {
-      return;
+    int head = 0;
+    for (; head < len;) {
+        ssize_t r =
+            net_recv(audio_player->audio_socket, buf + head, len - head);
+        if (r <= 0) {
+            SDL_PauseAudioDevice(audio_player->dev, 1);
+            return;
+        }
+        head += (int)r;
     }
-  }
 }
 
 bool sc_audio_player_init(struct sc_audio_player *audio_player,
                           sc_socket audio_socket) {
-  SDL_AudioSpec want, have;
-  SDL_zero(want);
+    SDL_AudioSpec want, have;
+    SDL_zero(want);
 
-  want.freq = 48000;
-  want.format = AUDIO_S16LSB;
-  want.channels = 2;
-  want.samples = 4096;
-  want.callback = callback;
-  want.userdata = audio_player;
+    want.freq = 48000;
+    want.format = AUDIO_S16LSB;
+    want.channels = 2;
+    want.samples = 4096;
+    want.callback = callback;
+    want.userdata = audio_player;
 
-  if (SDL_Init(SDL_INIT_AUDIO)) {
-    LOGE("SDL_Init(SDL_INIT_AUDIO) failed: %s", SDL_GetError());
-    return false;
-  }
+    if (SDL_Init(SDL_INIT_AUDIO)) {
+        LOGE("SDL_Init(SDL_INIT_AUDIO) failed: %s", SDL_GetError());
+        return false;
+    }
 
-  SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
-  if (dev <= 0) {
-    LOGE("SDL_OpenAudioDevice failed: %s", SDL_GetError());
-    return false;
-  }
+    SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    if (dev <= 0) {
+        LOGE("SDL_OpenAudioDevice failed: %s", SDL_GetError());
+        return false;
+    }
 
-  audio_player->audio_socket = audio_socket;
-  audio_player->dev = dev;
-  return true;
+    audio_player->audio_socket = audio_socket;
+    audio_player->dev = dev;
+    return true;
 }
 
 void sc_audio_player_start(struct sc_audio_player *audio_player) {
-  assert(audio_player->audio_socket);
-  assert(audio_player->dev);
+    assert(audio_player->audio_socket);
+    assert(audio_player->dev);
 
-  SDL_PauseAudioDevice(audio_player->dev, 0);
+    SDL_PauseAudioDevice(audio_player->dev, 0);
 }
 
 void sc_audio_player_destory(struct sc_audio_player *audio_player) {
-  SDL_CloseAudioDevice(audio_player->dev);
+    SDL_CloseAudioDevice(audio_player->dev);
 }
-
-void start() {}

--- a/app/src/audio_player.c
+++ b/app/src/audio_player.c
@@ -1,0 +1,61 @@
+#include "audio_player.h"
+
+#include <SDL2/SDL.h>
+#include <assert.h>
+
+#include "util/log.h"
+
+static void callback(void *userdata, unsigned char *buf, int len) {
+  struct sc_audio_player *audio_player =
+      SDL_static_cast(struct sc_audio_player *, userdata);
+
+  int head = 0;
+  for (;;) {
+    size_t r = net_recv(audio_player->audio_socket, buf + head, len - head);
+    head += (int)r;
+    if (head == len) {
+      return;
+    }
+  }
+}
+
+bool sc_audio_player_init(struct sc_audio_player *audio_player,
+                          sc_socket audio_socket) {
+  SDL_AudioSpec want, have;
+  SDL_zero(want);
+
+  want.freq = 48000;
+  want.format = AUDIO_S16LSB;
+  want.channels = 2;
+  want.samples = 4096;
+  want.callback = callback;
+  want.userdata = audio_player;
+
+  if (SDL_Init(SDL_INIT_AUDIO)) {
+    LOGE("SDL_Init(SDL_INIT_AUDIO) failed: %s", SDL_GetError());
+    return false;
+  }
+
+  SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+  if (dev <= 0) {
+    LOGE("SDL_OpenAudioDevice failed: %s", SDL_GetError());
+    return false;
+  }
+
+  audio_player->audio_socket = audio_socket;
+  audio_player->dev = dev;
+  return true;
+}
+
+void sc_audio_player_start(struct sc_audio_player *audio_player) {
+  assert(audio_player->audio_socket);
+  assert(audio_player->dev);
+
+  SDL_PauseAudioDevice(audio_player->dev, 0);
+}
+
+void sc_audio_player_destory(struct sc_audio_player *audio_player) {
+  SDL_CloseAudioDevice(audio_player->dev);
+}
+
+void start() {}

--- a/app/src/audio_player.c
+++ b/app/src/audio_player.c
@@ -14,6 +14,9 @@ static void callback(void *userdata, unsigned char *buf, int len) {
         ssize_t r =
             net_recv(audio_player->audio_socket, buf + head, len - head);
         if (r <= 0) {
+            // Stop player immediately on EOF.
+            // Otherwise SDL will play what's in `buf` repeatly
+            // until `sc_audio_player_destory` is called.
             SDL_PauseAudioDevice(audio_player->dev, 1);
             return;
         }

--- a/app/src/audio_player.h
+++ b/app/src/audio_player.h
@@ -1,0 +1,25 @@
+#ifndef SC_AUDIO_PLAYER_H
+#define SC_AUDIO_PLAYER_H
+
+#include "common.h"
+
+#include <SDL2/SDL_audio.h>
+#include <stdbool.h>
+
+#include "util/net.h"
+#include "util/thread.h"
+
+struct sc_audio_player {
+  sc_socket audio_socket;
+  SDL_AudioDeviceID dev;
+  sc_thread thread;
+};
+
+bool sc_audio_player_init(struct sc_audio_player *audio_player,
+                          sc_socket audio_socket);
+
+void sc_audio_player_start(struct sc_audio_player *audio_player);
+
+void sc_audio_player_destory(struct sc_audio_player *audio_player);
+
+#endif

--- a/app/src/audio_player.h
+++ b/app/src/audio_player.h
@@ -12,7 +12,6 @@
 struct sc_audio_player {
     sc_socket audio_socket;
     SDL_AudioDeviceID dev;
-    sc_thread thread;
 };
 
 bool sc_audio_player_init(struct sc_audio_player *audio_player,

--- a/app/src/audio_player.h
+++ b/app/src/audio_player.h
@@ -10,9 +10,9 @@
 #include "util/thread.h"
 
 struct sc_audio_player {
-  sc_socket audio_socket;
-  SDL_AudioDeviceID dev;
-  sc_thread thread;
+    sc_socket audio_socket;
+    SDL_AudioDeviceID dev;
+    sc_thread thread;
 };
 
 bool sc_audio_player_init(struct sc_audio_player *audio_player,

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -57,6 +57,7 @@
 #define OPT_NO_CLEANUP             1037
 #define OPT_PRINT_FPS              1038
 #define OPT_NO_POWER_ON            1039
+#define OPT_NO_FORWARD_AUDIO       1040
 
 struct sc_option {
     char shortopt;
@@ -307,6 +308,11 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_NO_POWER_ON,
         .longopt = "no-power-on",
         .text = "Do not power on the device on start.",
+    },
+    {
+        .longopt_id = OPT_NO_FORWARD_AUDIO,
+        .longopt = "no-forward-audio",
+        .text = "Disable audio forwarding",
     },
     {
         .longopt_id = OPT_OTG,
@@ -1606,6 +1612,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_POWER_ON:
                 opts->power_on = false;
+                break;
+            case OPT_NO_FORWARD_AUDIO:
+                opts->forward_audio = false;
                 break;
             case OPT_PRINT_FPS:
                 opts->start_fps_counter = true;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -65,4 +65,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .cleanup = true,
     .start_fps_counter = false,
     .power_on = true,
+    .forward_audio = true,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -140,6 +140,7 @@ struct scrcpy_options {
     bool cleanup;
     bool start_fps_counter;
     bool power_on;
+    bool forward_audio;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -13,6 +13,7 @@
 # include <windows.h>
 #endif
 
+#include "audio_player.h"
 #include "controller.h"
 #include "decoder.h"
 #include "demuxer.h"
@@ -48,6 +49,7 @@ struct scrcpy {
 #endif
     struct sc_controller controller;
     struct sc_file_pusher file_pusher;
+    struct sc_audio_player audio_player;
 #ifdef HAVE_USB
     struct sc_usb usb;
     struct sc_aoa aoa;
@@ -303,6 +305,7 @@ scrcpy(struct scrcpy_options *options) {
 #endif
     bool controller_initialized = false;
     bool controller_started = false;
+    bool audio_player_initialized = false;
     bool screen_initialized = false;
 
     struct sc_acksync *acksync = NULL;
@@ -337,6 +340,7 @@ scrcpy(struct scrcpy_options *options) {
         .tcpip_dst = options->tcpip_dst,
         .cleanup = options->cleanup,
         .power_on = options->power_on,
+        .forward_audio = options->forward_audio,
     };
 
     static const struct sc_server_callbacks cbs = {
@@ -572,6 +576,13 @@ aoa_hid_end:
         controller_started = true;
         controller = &s->controller;
 
+        if (!sc_audio_player_init(&s->audio_player, s->server.audio_socket)) {
+            goto end;
+        }
+        audio_player_initialized = true;
+
+        sc_audio_player_start(&s->audio_player);
+
         if (options->turn_screen_off) {
             struct sc_control_msg msg;
             msg.type = SC_CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE;
@@ -717,6 +728,10 @@ end:
     }
     if (controller_initialized) {
         sc_controller_destroy(&s->controller);
+    }
+
+    if (audio_player_initialized) {
+        sc_audio_player_destory(&s->audio_player);
     }
 
     if (recorder_initialized) {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -576,12 +576,14 @@ aoa_hid_end:
         controller_started = true;
         controller = &s->controller;
 
-        if (!sc_audio_player_init(&s->audio_player, s->server.audio_socket)) {
-            goto end;
-        }
-        audio_player_initialized = true;
+        if (s->server.audio_socket) {
+            if (!sc_audio_player_init(&s->audio_player, s->server.audio_socket)) {
+                goto end;
+            }
+            audio_player_initialized = true;
 
-        sc_audio_player_start(&s->audio_player);
+            sc_audio_player_start(&s->audio_player);
+        }
 
         if (options->turn_screen_off) {
             struct sc_control_msg msg;

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -49,6 +49,7 @@ struct sc_server_params {
     bool select_tcpip;
     bool cleanup;
     bool power_on;
+    bool forward_audio;
 };
 
 struct sc_server {
@@ -69,6 +70,7 @@ struct sc_server {
 
     sc_socket video_socket;
     sc_socket control_socket;
+    sc_socket audio_socket;
 
     const struct sc_server_callbacks *cbs;
     void *cbs_userdata;

--- a/server/src/main/java/com/genymobile/scrcpy/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/AudioEncoder.java
@@ -150,6 +150,7 @@ public class AudioEncoder {
                     } finally {
                         Ln.i("Audio capture stop");
                         recorder.stop();
+                        recorder.release();
                     }
                 }
             });

--- a/server/src/main/java/com/genymobile/scrcpy/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/AudioEncoder.java
@@ -1,0 +1,165 @@
+package com.genymobile.scrcpy;
+
+import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+
+import com.genymobile.scrcpy.wrappers.ServiceManager;
+
+import android.app.Application;
+import android.content.AttributionSource;
+import android.content.ComponentName;
+import android.content.ContextWrapper;
+import android.content.Intent;
+import android.media.AudioFormat;
+import android.media.AudioRecord;
+import android.media.MediaRecorder;
+import android.os.Build;
+
+public class AudioEncoder {
+
+    public static class FakePackageNameContext extends ContextWrapper {
+        public FakePackageNameContext() {
+            super(null);
+        }
+
+        @Override
+        public String getOpPackageName() {
+            // Android 11
+            return ServiceManager.PACKAGE_NAME;
+        }
+
+        @Override
+        public AttributionSource getAttributionSource() {
+            try {
+                // Android 12+
+                return (AttributionSource) AttributionSource.class.getConstructor(int.class, String.class, String.class)
+                        .newInstance(2000, ServiceManager.PACKAGE_NAME, null);
+            } catch (Throwable e) {
+                Ln.e("Can't create fake AttributionSource", e);
+                return null;
+            }
+        }
+    }
+
+    private static final int SAMPLE_RATE = 48000;
+    private static final int CHANNELS = 2;
+
+    private DesktopConnection connection;
+
+    public AudioEncoder(DesktopConnection connection) {
+        this.connection = connection;
+    }
+
+    private static AudioFormat createAudioFormat() {
+        AudioFormat.Builder builder = new AudioFormat.Builder();
+        builder.setEncoding(AudioFormat.ENCODING_PCM_16BIT);
+        builder.setSampleRate(SAMPLE_RATE);
+        builder.setChannelMask(AudioFormat.CHANNEL_IN_STEREO);
+        return builder.build();
+    }
+
+    private static AudioRecord createAudioRecord()
+            throws ClassNotFoundException, NoSuchMethodException, SecurityException, IllegalAccessException,
+            IllegalArgumentException, InstantiationException, InvocationTargetException, NoSuchFieldException {
+        AudioRecord.Builder builder = new AudioRecord.Builder();
+        try {
+            // Android 12+
+            builder.setContext(new FakePackageNameContext());
+        } catch (NoSuchMethodError e) {
+            // Android 11
+            Class<?> activityThreadClass = Class.forName("android.app.ActivityThread");
+            Constructor<?> activityThreadConstructor = activityThreadClass.getDeclaredConstructor();
+            activityThreadConstructor.setAccessible(true);
+            Object activityThread = activityThreadConstructor.newInstance();
+
+            Field sCurrentActivityThreadField = activityThreadClass.getDeclaredField("sCurrentActivityThread");
+            sCurrentActivityThreadField.setAccessible(true);
+            sCurrentActivityThreadField.set(null, activityThread);
+
+            Application app = Application.class.newInstance();
+            Field baseField = ContextWrapper.class.getDeclaredField("mBase");
+            baseField.setAccessible(true);
+            baseField.set(app, new FakePackageNameContext());
+
+            Field mInitialApplicationField = activityThreadClass.getDeclaredField("mInitialApplication");
+            mInitialApplicationField.setAccessible(true);
+            mInitialApplicationField.set(activityThread, app);
+        }
+        builder.setAudioSource(MediaRecorder.AudioSource.REMOTE_SUBMIX);
+        builder.setAudioFormat(createAudioFormat());
+        builder.setBufferSizeInBytes(1024 * 1024);
+        return builder.build();
+    }
+
+    public Thread startRecording() {
+        try {
+            // Android 11 requires Apps to be at foreground to record audio.
+            // Normally, each App has its own user ID,
+            // so Android checks whether the requesting App
+            // has the user ID that's at the foreground.
+            // But Scrcpy server is NOT an App.
+            // It's only a jar package started from Android shell.
+            // So it has the same user ID (2000) with Android shell (`com.android.shell`).
+            // If there is an activitiy from Android shell running at foreground,
+            // the App Ops permission system will believe Scrcpy is also at foreground.
+            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
+                Intent intent = new Intent(Intent.ACTION_MAIN);
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                intent.addCategory(Intent.CATEGORY_LAUNCHER);
+                intent.setComponent(
+                        new ComponentName(ServiceManager.PACKAGE_NAME, "com.android.shell.HeapDumpActivity"));
+                ServiceManager.getActivityManager().startActivityAsUserWithFeature(intent);
+                // Wait for activity to start
+                // TODO find better method
+                Thread.sleep(1000);
+            }
+
+            final AudioRecord recorder = createAudioRecord();
+            Ln.i("AudioRecord created");
+
+            DesktopConnection connection = this.connection;
+            Thread recorderThread = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        // Both `new AudioRecord()` and `AudioRecord#startRecoding()`
+                        // have the forefround check.
+                        recorder.startRecording();
+                        Ln.i("AudioRecord started");
+
+                        // Close the dialog opened above to bypass Android 11 foreground check
+                        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
+                            ServiceManager.getActivityManager().forceStopPackage(ServiceManager.PACKAGE_NAME);
+                        }
+
+                        int BUFFER_MS = 15; // do not buffer more than BUFFER_MS milliseconds
+                        byte[] buf = new byte[SAMPLE_RATE * CHANNELS * BUFFER_MS / 1000];
+                        while (true) {
+                            int r = recorder.read(buf, 0, buf.length);
+                            if (r > 0) {
+                                connection.sendAudioData(buf, 0, r);
+                            }
+                            if (r < 0) {
+                                Ln.e("Audio capture error: " + r);
+                            }
+                        }
+                    } catch (IOException e) {
+                        // ignore
+                    } finally {
+                        Ln.i("Audio capture stop");
+                        recorder.stop();
+                    }
+                }
+            });
+            recorderThread.start();
+
+            return recorderThread;
+        } catch (Throwable e) {
+            Ln.e("Can't create AudioRecord", e);
+            return null;
+        }
+    }
+
+}

--- a/server/src/main/java/com/genymobile/scrcpy/DesktopConnection.java
+++ b/server/src/main/java/com/genymobile/scrcpy/DesktopConnection.java
@@ -111,7 +111,7 @@ public final class DesktopConnection implements Closeable {
             }
             if (forwardAudio) {
                 try {
-                    audioSocket = connect(SOCKET_NAME);
+                    audioSocket = connect(socketName);
                 } catch (IOException | RuntimeException e) {
                     videoSocket.close();
                     if (controlSocket != null) {

--- a/server/src/main/java/com/genymobile/scrcpy/DesktopConnection.java
+++ b/server/src/main/java/com/genymobile/scrcpy/DesktopConnection.java
@@ -24,10 +24,14 @@ public final class DesktopConnection implements Closeable {
     private final InputStream controlInputStream;
     private final OutputStream controlOutputStream;
 
+    private final LocalSocket audioSocket;
+    private final OutputStream audioOutputStream;
+
     private final ControlMessageReader reader = new ControlMessageReader();
     private final DeviceMessageWriter writer = new DeviceMessageWriter();
 
-    private DesktopConnection(LocalSocket videoSocket, LocalSocket controlSocket) throws IOException {
+    private DesktopConnection(LocalSocket videoSocket, LocalSocket controlSocket, LocalSocket audioSocket)
+            throws IOException {
         this.videoSocket = videoSocket;
         this.controlSocket = controlSocket;
         if (controlSocket != null) {
@@ -36,6 +40,12 @@ public final class DesktopConnection implements Closeable {
         } else {
             controlInputStream = null;
             controlOutputStream = null;
+        }
+        this.audioSocket = audioSocket;
+        if (audioSocket != null) {
+            this.audioOutputStream = audioSocket.getOutputStream();
+        } else {
+            this.audioOutputStream = null;
         }
         videoFd = videoSocket.getFileDescriptor();
     }
@@ -55,11 +65,13 @@ public final class DesktopConnection implements Closeable {
         return SOCKET_NAME_PREFIX + String.format("_%08x", uid);
     }
 
-    public static DesktopConnection open(int uid, boolean tunnelForward, boolean control, boolean sendDummyByte) throws IOException {
+    public static DesktopConnection open(int uid, boolean tunnelForward, boolean control, boolean sendDummyByte,
+            boolean forwardAudio) throws IOException {
         String socketName = getSocketName(uid);
 
         LocalSocket videoSocket;
         LocalSocket controlSocket = null;
+        LocalSocket audioSocket = null;
         if (tunnelForward) {
             try (LocalServerSocket localServerSocket = new LocalServerSocket(socketName)) {
                 videoSocket = localServerSocket.accept();
@@ -75,6 +87,17 @@ public final class DesktopConnection implements Closeable {
                         throw e;
                     }
                 }
+                if (forwardAudio) {
+                    try {
+                        audioSocket = localServerSocket.accept();
+                    } catch (IOException | RuntimeException e) {
+                        videoSocket.close();
+                        if (controlSocket != null) {
+                            controlSocket.close();
+                        }
+                        throw e;
+                    }
+                }
             }
         } else {
             videoSocket = connect(socketName);
@@ -86,9 +109,20 @@ public final class DesktopConnection implements Closeable {
                     throw e;
                 }
             }
+            if (forwardAudio) {
+                try {
+                    audioSocket = connect(SOCKET_NAME);
+                } catch (IOException | RuntimeException e) {
+                    videoSocket.close();
+                    if (controlSocket != null) {
+                        controlSocket.close();
+                    }
+                    throw e;
+                }
+            }
         }
 
-        return new DesktopConnection(videoSocket, controlSocket);
+        return new DesktopConnection(videoSocket, controlSocket, audioSocket);
     }
 
     public void close() throws IOException {
@@ -99,6 +133,11 @@ public final class DesktopConnection implements Closeable {
             controlSocket.shutdownInput();
             controlSocket.shutdownOutput();
             controlSocket.close();
+        }
+        if (audioSocket != null) {
+            audioSocket.shutdownInput();
+            audioSocket.shutdownOutput();
+            audioSocket.close();
         }
     }
 
@@ -132,5 +171,9 @@ public final class DesktopConnection implements Closeable {
 
     public void sendDeviceMessage(DeviceMessage msg) throws IOException {
         writer.writeTo(msg, controlOutputStream);
+    }
+
+    public void sendAudioData(byte[] buffer, int offset, int length) throws IOException {
+        audioOutputStream.write(buffer, offset, length);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -24,6 +24,7 @@ public class Options {
     private boolean downsizeOnError = true;
     private boolean cleanup = true;
     private boolean powerOn = true;
+    private boolean forwardAudio = true;
 
     // Options not used by the scrcpy client, but useful to use scrcpy-server directly
     private boolean sendDeviceMeta = true; // send device name and size
@@ -180,6 +181,14 @@ public class Options {
 
     public void setPowerOn(boolean powerOn) {
         this.powerOn = powerOn;
+    }
+
+    public boolean getForwardAudio() {
+        return forwardAudio;
+    }
+
+    public void setForwardAudio(boolean forwardAudio) {
+        this.forwardAudio = forwardAudio;
     }
 
     public boolean getSendDeviceMeta() {

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -64,7 +64,6 @@ public class ScreenEncoder implements Device.RotationListener {
     }
 
     public void streamScreen(Device device, FileDescriptor fd) throws IOException {
-        Workarounds.prepareMainLooper();
         if (Build.BRAND.equalsIgnoreCase("meizu")) {
             // <https://github.com/Genymobile/scrcpy/issues/240>
             // <https://github.com/Genymobile/scrcpy/issues/2656>

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -31,11 +31,9 @@ public final class Server {
             }
 
             if (options.getStayAwake()) {
-                int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB
-                        | BatteryManager.BATTERY_PLUGGED_WIRELESS;
+                int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB | BatteryManager.BATTERY_PLUGGED_WIRELESS;
                 try {
-                    String oldValue = Settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in",
-                            String.valueOf(stayOn));
+                    String oldValue = Settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
                     try {
                         restoreStayOn = Integer.parseInt(oldValue);
                         if (restoreStayOn == stayOn) {
@@ -53,8 +51,7 @@ public final class Server {
 
         if (options.getCleanup()) {
             try {
-                CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp,
-                        restoreNormalPowerMode,
+                CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, restoreNormalPowerMode,
                         options.getPowerOffScreenOnClose());
             } catch (IOException e) {
                 Ln.e("Could not configure cleanup", e);
@@ -75,20 +72,18 @@ public final class Server {
         boolean sendDummyByte = options.getSendDummyByte();
         boolean forwardAudio = options.getForwardAudio();
 
-        try (DesktopConnection connection = DesktopConnection.open(uid, tunnelForward, control, sendDummyByte,
-                forwardAudio)) {
+        try (DesktopConnection connection = DesktopConnection.open(uid, tunnelForward, control, sendDummyByte, forwardAudio)) {
             if (options.getSendDeviceMeta()) {
                 Size videoSize = device.getScreenInfo().getVideoSize();
                 connection.sendDeviceMeta(Device.getDeviceName(), videoSize.getWidth(), videoSize.getHeight());
             }
-            ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(),
-                    options.getMaxFps(), codecOptions, options.getEncoderName(), options.getDownsizeOnError());
+            ScreenEncoder screenEncoder = new ScreenEncoder(options.getSendFrameMeta(), options.getBitRate(), options.getMaxFps(), codecOptions,
+                    options.getEncoderName(), options.getDownsizeOnError());
 
             Thread controllerThread = null;
             Thread deviceMessageSenderThread = null;
             if (control) {
-                final Controller controller = new Controller(device, connection, options.getClipboardAutosync(),
-                        options.getPowerOn());
+                final Controller controller = new Controller(device, connection, options.getClipboardAutosync(), options.getPowerOn());
 
                 // asynchronous
                 controllerThread = startController(controller);
@@ -113,7 +108,6 @@ public final class Server {
                 // this is expected on close
                 Ln.d("Screen streaming stopped");
             } finally {
-                Ln.i("Stopping");
                 initThread.interrupt();
                 if (controllerThread != null) {
                     controllerThread.interrupt();
@@ -168,8 +162,7 @@ public final class Server {
         String clientVersion = args[0];
         if (!clientVersion.equals(BuildConfig.VERSION_NAME)) {
             throw new IllegalArgumentException(
-                    "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "("
-                            + clientVersion + ")");
+                    "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "(" + clientVersion + ")");
         }
 
         Options options = new Options();

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
@@ -2,7 +2,9 @@ package com.genymobile.scrcpy.wrappers;
 
 import com.genymobile.scrcpy.Ln;
 
+import android.content.Intent;
 import android.os.Binder;
+import android.os.Bundle;
 import android.os.IBinder;
 import android.os.IInterface;
 
@@ -16,6 +18,8 @@ public class ActivityManager {
     private Method getContentProviderExternalMethod;
     private boolean getContentProviderExternalMethodNewVersion = true;
     private Method removeContentProviderExternalMethod;
+    private Method startActivityAsUserWithFeatureMethod;
+    private Method forceStopPackageMethod;
 
     public ActivityManager(IInterface manager) {
         this.manager = manager;
@@ -83,5 +87,66 @@ public class ActivityManager {
 
     public ContentProvider createSettingsProvider() {
         return getContentProviderExternal("settings", new Binder());
+    }
+
+    private Method getStartActivityAsUserWithFeatureMethod()
+            throws NoSuchMethodException, SecurityException, ClassNotFoundException {
+        if (startActivityAsUserWithFeatureMethod == null) {
+            startActivityAsUserWithFeatureMethod = manager.getClass().getMethod("startActivityAsUserWithFeature",
+                    Class.forName("android.app.IApplicationThread"),
+                    String.class,
+                    String.class,
+                    Intent.class,
+                    String.class,
+                    IBinder.class,
+                    String.class,
+                    int.class,
+                    int.class,
+                    Class.forName("android.app.ProfilerInfo"),
+                    Bundle.class,
+                    int.class);
+        }
+        return startActivityAsUserWithFeatureMethod;
+    }
+
+    public int startActivityAsUserWithFeature(Intent intent) {
+        try {
+            Method startActivityAsUserWithFeatureMethod = getStartActivityAsUserWithFeatureMethod();
+            return (int) startActivityAsUserWithFeatureMethod.invoke(
+                    /* this */ manager,
+                    /* caller */ null,
+                    /* callingPackage */ ServiceManager.PACKAGE_NAME,
+                    /* callingFeatureId */ null,
+                    /* intent */ intent,
+                    /* resolvedType */ null,
+                    /* resultTo */ null,
+                    /* resultWho */ null,
+                    /* requestCode */ 0,
+                    /* startFlags */ 0,
+                    /* profilerInfo */ null,
+                    /* bOptions */ null,
+                    /* userId */ /* UserHandle.USER_CURRENT */ -2);
+        } catch (Throwable e) {
+            Ln.e("Could not invoke method", e);
+            return 0;
+        }
+    }
+
+    private Method getForceStopPackageMethod()
+            throws NoSuchMethodException, SecurityException, ClassNotFoundException {
+        if (forceStopPackageMethod == null) {
+            forceStopPackageMethod = manager.getClass().getMethod("forceStopPackage",
+                    String.class, int.class);
+        }
+        return forceStopPackageMethod;
+    }
+
+    public void forceStopPackage(String packageName) {
+        try {
+            Method forceStopPackageMethod = getForceStopPackageMethod();
+            forceStopPackageMethod.invoke(manager, packageName, /* userId */ /* UserHandle.USER_CURRENT */ -2);
+        } catch (Throwable e) {
+            Ln.e("Could not invoke method", e);
+        }
     }
 }


### PR DESCRIPTION
Related to #14

Android version support:

* Android 10 or older: Not supported. `com.android.shell` package doesn't have `RECORD_AUDIO` permission declared.
* Android 11: Using the "Share heap dump" hack to bypass Android foreground check. The dialog is closed after AudioRecord started. Plus the `FakePackageNameContext` hack to "fix" Android permission check.
* Android 12 or newer: Using another variant of `FakePackageNameContext` hack to "fix" Android permission check. No "Share heap dump" hack required.

New option:

`--no-forward-audio` on client side, `forward_audio` on server side. Forwarding is enabled by default.

Socket order:

video -> [control] -> [audio]

Control and audio sockets may be absent if `--no-control` or `--no-forward-audio` is specified, but the order is maintained.

Audio compression:

No compression used, so the audio stream can be easily played at client side. The bandwidth is 48000Hz x 16bits x 2 channels = 1536000 bits =192000 bytes = 192KB = 187.5KiB per second, so I don't think it needs compression (at least on wired connection).

Latency:

The latency is around 30ms, tested in a rhythm game. And in one hour of continue using, the latency is seemingly increasing. Maybe it still requires packet header and time-stamping.