### PR TITLE
Fix chrome when --forward-all-clicks is enabled

### DIFF
--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -117,8 +117,9 @@ sc_control_msg_serialize(const struct sc_control_msg *msg, unsigned char *buf) {
             uint16_t pressure =
                 sc_float_to_u16fp(msg->inject_touch_event.pressure);
             sc_write16be(&buf[22], pressure);
-            sc_write32be(&buf[24], msg->inject_touch_event.buttons);
-            return 28;
+            sc_write32be(&buf[24], msg->inject_touch_event.action_button);
+            sc_write32be(&buf[28], msg->inject_touch_event.buttons);
+            return 32;
         case SC_CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT:
             write_position(&buf[1], &msg->inject_scroll_event.position);
             int16_t hscroll =
@@ -179,22 +180,25 @@ sc_control_msg_log(const struct sc_control_msg *msg) {
             if (pointer_name) {
                 // string pointer id
                 LOG_CMSG("touch [id=%s] %-4s position=%" PRIi32 ",%" PRIi32
-                             " pressure=%f buttons=%06lx",
+                             " pressure=%f action_button=%06lx buttons=%06lx",
                          pointer_name,
                          MOTIONEVENT_ACTION_LABEL(action),
                          msg->inject_touch_event.position.point.x,
                          msg->inject_touch_event.position.point.y,
                          msg->inject_touch_event.pressure,
+                         (long) msg->inject_touch_event.action_button,
                          (long) msg->inject_touch_event.buttons);
             } else {
                 // numeric pointer id
                 LOG_CMSG("touch [id=%" PRIu64_ "] %-4s position=%" PRIi32 ",%"
-                             PRIi32 " pressure=%f buttons=%06lx",
+                             PRIi32 " pressure=%f action_button=%06lx"
+                             " buttons=%06lx",
                          id,
                          MOTIONEVENT_ACTION_LABEL(action),
                          msg->inject_touch_event.position.point.x,
                          msg->inject_touch_event.position.point.y,
                          msg->inject_touch_event.pressure,
+                         (long) msg->inject_touch_event.action_button,
                          (long) msg->inject_touch_event.buttons);
             }
             break;

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -65,6 +65,7 @@ struct sc_control_msg {
         } inject_text;
         struct {
             enum android_motionevent_action action;
+            enum android_motionevent_buttons action_button;
             enum android_motionevent_buttons buttons;
             uint64_t pointer_id;
             struct sc_position position;

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -339,6 +339,7 @@ simulate_virtual_finger(struct sc_input_manager *im,
         im->forward_all_clicks ? POINTER_ID_VIRTUAL_MOUSE
                                : POINTER_ID_VIRTUAL_FINGER;
     msg.inject_touch_event.pressure = up ? 0.0f : 1.0f;
+    msg.inject_touch_event.action_button = 0;
     msg.inject_touch_event.buttons = 0;
 
     if (!sc_controller_push_msg(im->controller, &msg)) {

--- a/app/src/mouse_inject.c
+++ b/app/src/mouse_inject.c
@@ -93,6 +93,7 @@ sc_mouse_processor_process_mouse_click(struct sc_mouse_processor *mp,
             .pointer_id = event->pointer_id,
             .position = event->position,
             .pressure = event->action == SC_ACTION_DOWN ? 1.f : 0.f,
+            .action_button = convert_mouse_buttons(event->button),
             .buttons = convert_mouse_buttons(event->buttons_state),
         },
     };

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -90,13 +90,14 @@ static void test_serialize_inject_touch_event(void) {
                 },
             },
             .pressure = 1.0f,
+            .action_button = AMOTION_EVENT_BUTTON_PRIMARY,
             .buttons = AMOTION_EVENT_BUTTON_PRIMARY,
         },
     };
 
     unsigned char buf[SC_CONTROL_MSG_MAX_SIZE];
     size_t size = sc_control_msg_serialize(&msg, buf);
-    assert(size == 28);
+    assert(size == 32);
 
     const unsigned char expected[] = {
         SC_CONTROL_MSG_TYPE_INJECT_TOUCH_EVENT,
@@ -105,7 +106,8 @@ static void test_serialize_inject_touch_event(void) {
         0x00, 0x00, 0x00, 0x64, 0x00, 0x00, 0x00, 0xc8, // 100 200
         0x04, 0x38, 0x07, 0x80, // 1080 1920
         0xff, 0xff, // pressure
-        0x00, 0x00, 0x00, 0x01 // AMOTION_EVENT_BUTTON_PRIMARY
+        0x00, 0x00, 0x00, 0x01, // AMOTION_EVENT_BUTTON_PRIMARY (action button)
+        0x00, 0x00, 0x00, 0x01, // AMOTION_EVENT_BUTTON_PRIMARY (buttons)
     };
     assert(!memcmp(buf, expected, sizeof(expected)));
 }

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessage.java
@@ -29,6 +29,7 @@ public final class ControlMessage {
     private int metaState; // KeyEvent.META_*
     private int action; // KeyEvent.ACTION_* or MotionEvent.ACTION_* or POWER_MODE_*
     private int keycode; // KeyEvent.KEYCODE_*
+    private int actionButton; // MotionEvent.BUTTON_*
     private int buttons; // MotionEvent.BUTTON_*
     private long pointerId;
     private float pressure;
@@ -60,13 +61,15 @@ public final class ControlMessage {
         return msg;
     }
 
-    public static ControlMessage createInjectTouchEvent(int action, long pointerId, Position position, float pressure, int buttons) {
+    public static ControlMessage createInjectTouchEvent(int action, long pointerId, Position position, float pressure, int actionButton,
+            int buttons) {
         ControlMessage msg = new ControlMessage();
         msg.type = TYPE_INJECT_TOUCH_EVENT;
         msg.action = action;
         msg.pointerId = pointerId;
         msg.pressure = pressure;
         msg.position = position;
+        msg.actionButton = actionButton;
         msg.buttons = buttons;
         return msg;
     }
@@ -138,6 +141,10 @@ public final class ControlMessage {
 
     public int getKeycode() {
         return keycode;
+    }
+
+    public int getActionButton() {
+        return actionButton;
     }
 
     public int getButtons() {

--- a/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ControlMessageReader.java
@@ -9,7 +9,7 @@ import java.nio.charset.StandardCharsets;
 public class ControlMessageReader {
 
     static final int INJECT_KEYCODE_PAYLOAD_LENGTH = 13;
-    static final int INJECT_TOUCH_EVENT_PAYLOAD_LENGTH = 27;
+    static final int INJECT_TOUCH_EVENT_PAYLOAD_LENGTH = 31;
     static final int INJECT_SCROLL_EVENT_PAYLOAD_LENGTH = 20;
     static final int BACK_OR_SCREEN_ON_LENGTH = 1;
     static final int SET_SCREEN_POWER_MODE_PAYLOAD_LENGTH = 1;
@@ -140,8 +140,9 @@ public class ControlMessageReader {
         long pointerId = buffer.getLong();
         Position position = readPosition(buffer);
         float pressure = Binary.u16FixedPointToFloat(buffer.getShort());
+        int actionButton = buffer.getInt();
         int buttons = buffer.getInt();
-        return ControlMessage.createInjectTouchEvent(action, pointerId, position, pressure, buttons);
+        return ControlMessage.createInjectTouchEvent(action, pointerId, position, pressure, actionButton, buttons);
     }
 
     private ControlMessage parseInjectScrollEvent() {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -196,22 +196,23 @@ public class Controller {
         Pointer pointer = pointersState.get(pointerIndex);
         pointer.setPoint(point);
         pointer.setPressure(pressure);
-        pointer.setUp(action == MotionEvent.ACTION_UP);
 
         int source;
-        int pointerCount = pointersState.update(pointerProperties, pointerCoords);
         if (pointerId == POINTER_ID_MOUSE || pointerId == POINTER_ID_VIRTUAL_MOUSE) {
             // real mouse event (forced by the client when --forward-on-click)
             pointerProperties[pointerIndex].toolType = MotionEvent.TOOL_TYPE_MOUSE;
             source = InputDevice.SOURCE_MOUSE;
+            pointer.setUp(buttons == 0);
         } else {
             // POINTER_ID_GENERIC_FINGER, POINTER_ID_VIRTUAL_FINGER or real touch from device
             pointerProperties[pointerIndex].toolType = MotionEvent.TOOL_TYPE_FINGER;
             source = InputDevice.SOURCE_TOUCHSCREEN;
             // Buttons must not be set for touch events
             buttons = 0;
+            pointer.setUp(action == MotionEvent.ACTION_UP);
         }
 
+        int pointerCount = pointersState.update(pointerProperties, pointerCoords);
         if (pointerCount == 1) {
             if (action == MotionEvent.ACTION_DOWN) {
                 lastTouchDown = now;

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
@@ -3,6 +3,7 @@ package com.genymobile.scrcpy.wrappers;
 import com.genymobile.scrcpy.Ln;
 
 import android.view.InputEvent;
+import android.view.MotionEvent;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -17,6 +18,7 @@ public final class InputManager {
     private Method injectInputEventMethod;
 
     private static Method setDisplayIdMethod;
+    private static Method setActionButtonMethod;
 
     public InputManager(android.hardware.input.InputManager manager) {
         this.manager = manager;
@@ -53,6 +55,24 @@ public final class InputManager {
             return true;
         } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
             Ln.e("Cannot associate a display id to the input event", e);
+            return false;
+        }
+    }
+
+    private static Method getSetActionButtonMethod() throws NoSuchMethodException {
+        if (setActionButtonMethod == null) {
+            setActionButtonMethod = MotionEvent.class.getMethod("setActionButton", int.class);
+        }
+        return setActionButtonMethod;
+    }
+
+    public static boolean setActionButton(MotionEvent motionEvent, int actionButton) {
+        try {
+            Method method = getSetActionButtonMethod();
+            method.invoke(motionEvent, actionButton);
+            return true;
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            Ln.e("Cannot set action button on MotionEvent", e);
             return false;
         }
     }

--- a/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/ControlMessageReaderTest.java
@@ -94,7 +94,8 @@ public class ControlMessageReaderTest {
         dos.writeShort(1080);
         dos.writeShort(1920);
         dos.writeShort(0xffff); // pressure
-        dos.writeInt(MotionEvent.BUTTON_PRIMARY);
+        dos.writeInt(MotionEvent.BUTTON_PRIMARY); // action button
+        dos.writeInt(MotionEvent.BUTTON_PRIMARY); // buttons
 
         byte[] packet = bos.toByteArray();
 
@@ -112,6 +113,7 @@ public class ControlMessageReaderTest {
         Assert.assertEquals(1080, event.getPosition().getScreenSize().getWidth());
         Assert.assertEquals(1920, event.getPosition().getScreenSize().getHeight());
         Assert.assertEquals(1f, event.getPressure(), 0f); // must be exact
+        Assert.assertEquals(MotionEvent.BUTTON_PRIMARY, event.getActionButton());
         Assert.assertEquals(MotionEvent.BUTTON_PRIMARY, event.getButtons());
     }
 


### PR DESCRIPTION
This is a mix of two branches made by @yume-chan to fix #3635:
 - https://github.com/Genymobile/scrcpy/issues/3635#issuecomment-1371833716
 - https://github.com/Genymobile/scrcpy/issues/3635#issuecomment-1375001124

---

@yume-chan Thank you, great work :+1:

On `fix-chrome-mouse` (the branch with events synthesized on the server), I like that the client don't have to handle the Android-specific sequence `ACTION_DOWN`, `ACTION_BUTTON_PRESS`, `ACTION_BUTTON_RELEASE`, `ACTION_UP` (IMO, this should be done on the server).

However, on `fix-chrome-mouse-v2` (the branch with events synthesized on the client), I like that the `action_button` forwarded by the client to the server (since it provided by the client, it's better than let the server "guess" using a diff of buttons state).

This is a mix of these two branches.

It works fine on my device. Please review and test before I merge.