### PR TITLE
Add support for H265 and AV1

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,10 +252,19 @@ This affects recording orientation.
 The [window may also be rotated](#rotation) independently.
 
 
-#### Encoder
+#### Codec
 
-Some devices have more than one encoder, and some of them may cause issues or
-crash. It is possible to select a different encoder:
+The video codec can be selected:
+
+```bash
+scrcpy --codec=h264  # default
+```
+
+
+##### Encoder
+
+Some devices have more than one encoder for a specific codec, and some of them
+may cause issues or crash. It is possible to select a different encoder:
 
 ```bash
 scrcpy --encoder=OMX.qcom.video.encoder.avc
@@ -265,7 +274,8 @@ To list the available encoders, you can pass an invalid encoder name; the
 error will give the available encoders:
 
 ```bash
-scrcpy --encoder=_
+scrcpy --encoder=_               # for the default codec
+scrcpy --codec=h264 --encoder=_  # for a specific codec
 ```
 
 ### Capture

--- a/README.md
+++ b/README.md
@@ -254,10 +254,12 @@ The [window may also be rotated](#rotation) independently.
 
 #### Codec
 
-The video codec can be selected:
+The video codec can be selected. The possible values are `h264` (default) and
+`h265`:
 
 ```bash
 scrcpy --codec=h264  # default
+scrcpy --codec=h265
 ```
 
 
@@ -275,7 +277,7 @@ error will give the available encoders:
 
 ```bash
 scrcpy --encoder=_               # for the default codec
-scrcpy --codec=h264 --encoder=_  # for a specific codec
+scrcpy --codec=h265 --encoder=_  # for a specific codec
 ```
 
 ### Capture

--- a/README.md
+++ b/README.md
@@ -254,12 +254,13 @@ The [window may also be rotated](#rotation) independently.
 
 #### Codec
 
-The video codec can be selected. The possible values are `h264` (default) and
-`h265`:
+The video codec can be selected. The possible values are `h264` (default),
+`h265` and `av1`:
 
 ```bash
 scrcpy --codec=h264  # default
 scrcpy --codec=h265
+scrcpy --codec=av1
 ```
 
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -26,6 +26,10 @@ Encode the video at the given bit\-rate, expressed in bits/s. Unit suffixes are 
 Default is 8000000.
 
 .TP
+.BI "\-\-codec " name
+Select a video codec (h264).
+
+.TP
 .BI "\-\-codec\-options " key\fR[:\fItype\fR]=\fIvalue\fR[,...]
 Set a list of comma-separated key:type=value options for the device encoder.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -27,7 +27,7 @@ Default is 8000000.
 
 .TP
 .BI "\-\-codec " name
-Select a video codec (h264 or h265).
+Select a video codec (h264, h265 or av1).
 
 .TP
 .BI "\-\-codec\-options " key\fR[:\fItype\fR]=\fIvalue\fR[,...]

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -27,7 +27,7 @@ Default is 8000000.
 
 .TP
 .BI "\-\-codec " name
-Select a video codec (h264).
+Select a video codec (h264 or h265).
 
 .TP
 .BI "\-\-codec\-options " key\fR[:\fItype\fR]=\fIvalue\fR[,...]

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -110,7 +110,7 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_CODEC,
         .longopt = "codec",
         .argdesc = "name",
-        .text = "Select a video codec (h264).",
+        .text = "Select a video codec (h264 or h265).",
     },
     {
         .longopt_id = OPT_CODEC_OPTIONS,
@@ -1390,7 +1390,11 @@ parse_codec(const char *optarg, enum sc_codec *codec) {
         *codec = SC_CODEC_H264;
         return true;
     }
-    LOGE("Unsupported codec: %s (expected h264)", optarg);
+    if (!strcmp(optarg, "h265")) {
+        *codec = SC_CODEC_H265;
+        return true;
+    }
+    LOGE("Unsupported codec: %s (expected h264 or h265)", optarg);
     return false;
 }
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -110,7 +110,7 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_CODEC,
         .longopt = "codec",
         .argdesc = "name",
-        .text = "Select a video codec (h264 or h265).",
+        .text = "Select a video codec (h264, h265 or av1).",
     },
     {
         .longopt_id = OPT_CODEC_OPTIONS,
@@ -1394,7 +1394,11 @@ parse_codec(const char *optarg, enum sc_codec *codec) {
         *codec = SC_CODEC_H265;
         return true;
     }
-    LOGE("Unsupported codec: %s (expected h264 or h265)", optarg);
+    if (!strcmp(optarg, "av1")) {
+        *codec = SC_CODEC_AV1;
+        return true;
+    }
+    LOGE("Unsupported codec: %s (expected h264, h265 or av1)", optarg);
     return false;
 }
 
@@ -1742,6 +1746,13 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                  opts->record_filename);
             return false;
         }
+    }
+
+    if (opts->record_format == SC_RECORD_FORMAT_MP4
+            && opts->codec == SC_CODEC_AV1) {
+        LOGE("Could not mux AV1 stream into MP4 container "
+             "(record to mkv or select another video codec)");
+        return false;
     }
 
     if (!opts->control) {

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -57,6 +57,7 @@
 #define OPT_NO_CLEANUP             1037
 #define OPT_PRINT_FPS              1038
 #define OPT_NO_POWER_ON            1039
+#define OPT_CODEC                  1040
 
 struct sc_option {
     char shortopt;
@@ -104,6 +105,12 @@ static const struct sc_option options[] = {
         .text = "Encode the video at the gitven bit-rate, expressed in bits/s. "
                 "Unit suffixes are supported: 'K' (x1000) and 'M' (x1000000).\n"
                 "Default is " STR(DEFAULT_BIT_RATE) ".",
+    },
+    {
+        .longopt_id = OPT_CODEC,
+        .longopt = "codec",
+        .argdesc = "name",
+        .text = "Select a video codec (h264).",
     },
     {
         .longopt_id = OPT_CODEC_OPTIONS,
@@ -1378,6 +1385,16 @@ guess_record_format(const char *filename) {
 }
 
 static bool
+parse_codec(const char *optarg, enum sc_codec *codec) {
+    if (!strcmp(optarg, "h264")) {
+        *codec = SC_CODEC_H264;
+        return true;
+    }
+    LOGE("Unsupported codec: %s (expected h264)", optarg);
+    return false;
+}
+
+static bool
 parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                        const char *optstring, const struct option *longopts) {
     struct scrcpy_options *opts = &args->opts;
@@ -1609,6 +1626,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_PRINT_FPS:
                 opts->start_fps_counter = true;
+                break;
+            case OPT_CODEC:
+                if (!parse_codec(optarg, &opts->codec)) {
+                    return false;
+                }
                 break;
             case OPT_OTG:
 #ifdef HAVE_USB

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -26,10 +26,13 @@ sc_demuxer_recv_codec_id(struct sc_demuxer *demuxer) {
     }
 
 #define SC_CODEC_ID_H264 UINT32_C(0x68323634) // "h264" in ASCII
+#define SC_CODEC_ID_H265 UINT32_C(0x68323635) // "h265" in ASCII
     uint32_t codec_id = sc_read32be(data);
     switch (codec_id) {
         case SC_CODEC_ID_H264:
             return AV_CODEC_ID_H264;
+        case SC_CODEC_ID_H265:
+            return AV_CODEC_ID_HEVC;
         default:
             LOGE("Unknown codec id 0x%08" PRIx32, codec_id);
             return AV_CODEC_ID_NONE;

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -27,12 +27,15 @@ sc_demuxer_recv_codec_id(struct sc_demuxer *demuxer) {
 
 #define SC_CODEC_ID_H264 UINT32_C(0x68323634) // "h264" in ASCII
 #define SC_CODEC_ID_H265 UINT32_C(0x68323635) // "h265" in ASCII
+#define SC_CODEC_ID_AV1 UINT32_C(0x00617631) // "av1" in ASCII
     uint32_t codec_id = sc_read32be(data);
     switch (codec_id) {
         case SC_CODEC_ID_H264:
             return AV_CODEC_ID_H264;
         case SC_CODEC_ID_H265:
             return AV_CODEC_ID_HEVC;
+        case SC_CODEC_ID_AV1:
+            return AV_CODEC_ID_AV1;
         default:
             LOGE("Unknown codec id 0x%08" PRIx32, codec_id);
             return AV_CODEC_ID_NONE;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -13,6 +13,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .v4l2_device = NULL,
 #endif
     .log_level = SC_LOG_LEVEL_INFO,
+    .codec = SC_CODEC_H264,
     .record_format = SC_RECORD_FORMAT_AUTO,
     .keyboard_input_mode = SC_KEYBOARD_INPUT_MODE_INJECT,
     .port_range = {

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -23,6 +23,10 @@ enum sc_record_format {
     SC_RECORD_FORMAT_MKV,
 };
 
+enum sc_codec {
+    SC_CODEC_H264,
+};
+
 enum sc_lock_video_orientation {
     SC_LOCK_VIDEO_ORIENTATION_UNLOCKED = -1,
     // lock the current orientation when scrcpy starts
@@ -93,6 +97,7 @@ struct scrcpy_options {
     const char *v4l2_device;
 #endif
     enum sc_log_level log_level;
+    enum sc_codec codec;
     enum sc_record_format record_format;
     enum sc_keyboard_input_mode keyboard_input_mode;
     enum sc_mouse_input_mode mouse_input_mode;

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -25,6 +25,7 @@ enum sc_record_format {
 
 enum sc_codec {
     SC_CODEC_H264,
+    SC_CODEC_H265,
 };
 
 enum sc_lock_video_orientation {

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -26,6 +26,7 @@ enum sc_record_format {
 enum sc_codec {
     SC_CODEC_H264,
     SC_CODEC_H265,
+    SC_CODEC_AV1,
 };
 
 enum sc_lock_video_orientation {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -315,6 +315,7 @@ scrcpy(struct scrcpy_options *options) {
         .select_usb = options->select_usb,
         .select_tcpip = options->select_tcpip,
         .log_level = options->log_level,
+        .codec = options->codec,
         .crop = options->crop,
         .port_range = options->port_range,
         .tunnel_host = options->tunnel_host,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -163,6 +163,8 @@ sc_server_get_codec_name(enum sc_codec codec) {
             return "h264";
         case SC_CODEC_H265:
             return "h265";
+        case SC_CODEC_AV1:
+            return "av1";
         default:
             return NULL;
     }

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -161,6 +161,8 @@ sc_server_get_codec_name(enum sc_codec codec) {
     switch (codec) {
         case SC_CODEC_H264:
             return "h264";
+        case SC_CODEC_H265:
+            return "h265";
         default:
             return NULL;
     }

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -156,6 +156,16 @@ sc_server_sleep(struct sc_server *server, sc_tick deadline) {
     return !stopped;
 }
 
+static const char *
+sc_server_get_codec_name(enum sc_codec codec) {
+    switch (codec) {
+        case SC_CODEC_H264:
+            return "h264";
+        default:
+            return NULL;
+    }
+}
+
 static sc_pid
 execute_server(struct sc_server *server,
                const struct sc_server_params *params) {
@@ -203,6 +213,9 @@ execute_server(struct sc_server *server,
     ADD_PARAM("log_level=%s", log_level_to_server_string(params->log_level));
     ADD_PARAM("bit_rate=%" PRIu32, params->bit_rate);
 
+    if (params->codec != SC_CODEC_H264) {
+        ADD_PARAM("codec=%s", sc_server_get_codec_name(params->codec));
+    }
     if (params->max_size) {
         ADD_PARAM("max_size=%" PRIu16, params->max_size);
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -25,6 +25,7 @@ struct sc_server_params {
     uint32_t uid;
     const char *req_serial;
     enum sc_log_level log_level;
+    enum sc_codec codec;
     const char *crop;
     const char *codec_options;
     const char *encoder_name;

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -5,9 +5,12 @@ import android.graphics.Rect;
 import java.util.List;
 
 public class Options {
+    private static final String VIDEO_CODEC_H264 = "h264";
+
     private Ln.Level logLevel = Ln.Level.DEBUG;
     private int uid = -1; // 31-bit non-negative value, or -1
     private int maxSize;
+    private VideoCodec codec = VideoCodec.H264;
     private int bitRate = 8000000;
     private int maxFps;
     private int lockVideoOrientation = -1;
@@ -29,6 +32,7 @@ public class Options {
     private boolean sendDeviceMeta = true; // send device name and size
     private boolean sendFrameMeta = true; // send PTS so that the client may record properly
     private boolean sendDummyByte = true; // write a byte on start to detect connection issues
+    private boolean sendCodecId = true; // write the codec ID (4 bytes) before the stream
 
     public Ln.Level getLogLevel() {
         return logLevel;
@@ -52,6 +56,14 @@ public class Options {
 
     public void setMaxSize(int maxSize) {
         this.maxSize = maxSize;
+    }
+
+    public VideoCodec getCodec() {
+        return codec;
+    }
+
+    public void setCodec(VideoCodec codec) {
+        this.codec = codec;
     }
 
     public int getBitRate() {
@@ -204,5 +216,13 @@ public class Options {
 
     public void setSendDummyByte(boolean sendDummyByte) {
         this.sendDummyByte = sendDummyByte;
+    }
+
+    public boolean getSendCodecId() {
+        return sendCodecId;
+    }
+
+    public void setSendCodecId(boolean sendCodecId) {
+        this.sendCodecId = sendCodecId;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/VideoCodec.java
+++ b/server/src/main/java/com/genymobile/scrcpy/VideoCodec.java
@@ -4,7 +4,8 @@ import android.media.MediaFormat;
 
 public enum VideoCodec {
     H264(0x68_32_36_34, "h264", MediaFormat.MIMETYPE_VIDEO_AVC),
-    H265(0x68_32_36_35, "h265", MediaFormat.MIMETYPE_VIDEO_HEVC);
+    H265(0x68_32_36_35, "h265", MediaFormat.MIMETYPE_VIDEO_HEVC),
+    AV1(0x00_61_76_31, "av1", MediaFormat.MIMETYPE_VIDEO_AV1);
 
     private final int id; // 4-byte ASCII representation of the name
     private final String name;

--- a/server/src/main/java/com/genymobile/scrcpy/VideoCodec.java
+++ b/server/src/main/java/com/genymobile/scrcpy/VideoCodec.java
@@ -3,7 +3,8 @@ package com.genymobile.scrcpy;
 import android.media.MediaFormat;
 
 public enum VideoCodec {
-    H264(0x68_32_36_34, "h264", MediaFormat.MIMETYPE_VIDEO_AVC);
+    H264(0x68_32_36_34, "h264", MediaFormat.MIMETYPE_VIDEO_AVC),
+    H265(0x68_32_36_35, "h265", MediaFormat.MIMETYPE_VIDEO_HEVC);
 
     private final int id; // 4-byte ASCII representation of the name
     private final String name;

--- a/server/src/main/java/com/genymobile/scrcpy/VideoCodec.java
+++ b/server/src/main/java/com/genymobile/scrcpy/VideoCodec.java
@@ -1,0 +1,34 @@
+package com.genymobile.scrcpy;
+
+import android.media.MediaFormat;
+
+public enum VideoCodec {
+    H264(0x68_32_36_34, "h264", MediaFormat.MIMETYPE_VIDEO_AVC);
+
+    private final int id; // 4-byte ASCII representation of the name
+    private final String name;
+    private final String mimeType;
+
+    VideoCodec(int id, String name, String mimeType) {
+        this.id = id;
+        this.name = name;
+        this.mimeType = mimeType;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public static VideoCodec findByName(String name) {
+        for (VideoCodec codec : values()) {
+            if (codec.name.equals(name)) {
+                return codec;
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/VideoStreamer.java
+++ b/server/src/main/java/com/genymobile/scrcpy/VideoStreamer.java
@@ -21,6 +21,13 @@ public final class VideoStreamer implements ScreenEncoder.Callbacks {
         this.sendFrameMeta = sendFrameMeta;
     }
 
+    public void writeHeader(int codecId) throws IOException {
+        ByteBuffer buffer = ByteBuffer.allocate(4);
+        buffer.putInt(codecId);
+        buffer.flip();
+        IO.writeFully(fd, buffer);
+    }
+
     @Override
     public void onPacket(ByteBuffer codecBuffer, MediaCodec.BufferInfo bufferInfo) throws IOException {
         if (sendFrameMeta) {


### PR DESCRIPTION
Add an option to select the video codec to use:

```bash
scrcpy --codec=h264  # default
scrcpy --codec=h265
scrcpy --codec=av1
```

Of course, these codecs only work if the device provides an encoder (recent devices should have H265, I don't know which devices support AV1 yet).

H264 is still the default, for two reasons:
 - it is supported everywhere
 - it is often encoded with a lower latency

Fixes #3092