### PR TITLE
Add GitHub actions for scrcpy server

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -9,8 +9,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: |
-        ANDROID_BUILD_TOOLS="33.0.1" BUILD_DIR="./out" ./server/build_without_gradle.sh
+        ./gradlew -p server assembleRelease
     - uses: actions/upload-artifact@v2
       with:
         name: scrcpy
-        path: ./out
+        path: ./server/build/outputs/apk/release/

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -1,0 +1,16 @@
+on:
+  push:
+
+jobs:
+  server:
+    runs-on: ubuntu-latest
+    container: cimg/android:2022.12.1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: |
+        ANDROID_BUILD_TOOLS="33.0.1" BUILD_DIR="./out" ./server/build_without_gradle.sh
+    - uses: actions/upload-artifact@v2
+      with:
+        name: scrcpy
+        path: ./out

--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -50,6 +50,7 @@ echo "Compiling java sources..."
 cd ../java
 javac -bootclasspath "$ANDROID_JAR" -cp "$CLASSES_DIR" -d "$CLASSES_DIR" \
     -source 1.8 -target 1.8 \
+    -encoding UTF-8 \
     com/genymobile/scrcpy/*.java \
     com/genymobile/scrcpy/wrappers/*.java
 


### PR DESCRIPTION
This PR adds a GitHub action which:
- Builds the latest version of the scrcpy server, using a Circle CI container
- Publishes that as a build artifact

This can be useful as CI (making sure the server compiles) and for folks that want to build the scrcpy server using CI infrastructure.