### PR TITLE
Fix hardcode deviceId while inject touch event.

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -7,6 +7,8 @@ import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 
+import com.genymobile.scrcpy.wrappers.InputManager;
+
 import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -226,10 +228,12 @@ public class Controller {
         }
 
         MotionEvent event = MotionEvent
-                .obtain(lastTouchDown, now, action, pointerCount, pointerProperties, pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0, source,
+                .obtain(lastTouchDown, now, action, pointerCount, pointerProperties, pointerCoords, 0, buttons, 1f, 1f, InputManager.getInputDeviceId(source), 0, source,
                         0);
         return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
     }
+
+
 
     private boolean injectScroll(Position position, float hScroll, float vScroll, int buttons) {
         long now = SystemClock.uptimeMillis();

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy.wrappers;
 
 import com.genymobile.scrcpy.Ln;
 
+import android.view.InputDevice;
 import android.view.InputEvent;
 
 import java.lang.reflect.InvocationTargetException;
@@ -55,5 +56,17 @@ public final class InputManager {
             Ln.e("Cannot associate a display id to the input event", e);
             return false;
         }
+    }
+
+    public static int getInputDeviceId(int inputSource) {
+        final int DEFAULT_DEVICE_ID = 0;
+        int[] devIds = InputDevice.getDeviceIds();
+        for (int devId : devIds) {
+            InputDevice inputDev = InputDevice.getDevice(devId);
+            if (inputDev.supportsSource(inputSource)) {
+                return devId;
+            }
+        }
+        return DEFAULT_DEVICE_ID;
     }
 }


### PR DESCRIPTION
AOSP:
<https://android.googlesource.com/platform/frameworks/base.git/+/refs/heads/android10-release/cmds/input/src/com/android/commands/input/Input.java#359>

fix touch events not working on some unity game