### PR TITLE
Fix an "expected expression" error

### DIFF
--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -816,7 +816,7 @@ sc_screen_handle_event(struct sc_screen *screen, SDL_Event *event) {
     bool relative_mode = sc_screen_is_relative_mode(screen);
 
     switch (event->type) {
-        case SC_EVENT_SCREEN_INIT_SIZE:
+        case SC_EVENT_SCREEN_INIT_SIZE: {
             // The initial size is passed via screen->frame_size
             bool ok = sc_screen_init_size(screen);
             if (!ok) {
@@ -824,6 +824,7 @@ sc_screen_handle_event(struct sc_screen *screen, SDL_Event *event) {
                 return false;
             }
             return true;
+        }
         case SC_EVENT_NEW_FRAME: {
             bool ok = sc_screen_update_frame(screen);
             if (!ok) {


### PR DESCRIPTION
In C, a label can only be followed by a statement, not a declaration. An error in `app/src/screen.c` violated this, and led to a build error with an error message similar to the one below:

```
  ../app/src/screen.c:821:13: error: expected expression
              bool ok = sc_screen_init_size(screen);
              ^
  /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.0.0/include/stdbool.h:15:14: note: expanded from macro 'bool'
  #define bool _Bool
               ^
  ../app/src/screen.c:822:18: error: use of undeclared identifier 'ok'
              if (!ok) {
                   ^
  2 errors generated.
```

This could be fixed by introducing a new block (or compound statement; as is already being done in the next `case`). That is a statement.

Fixes #3785.
