### PR TITLE
Fix linux desktop files validation

### DIFF
--- a/app/data/scrcpy-console.desktop
+++ b/app/data/scrcpy-console.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/bash --norc --noprofile -i -c '"$SHELL" -i -c scrcpy || read -p "Press any key to quit..."'
+Exec=/bin/bash --norc --noprofile -i -c "\"\\$SHELL\" -i -c scrcpy || read -p 'Press any key to quit...'"
 Icon=scrcpy
 Terminal=true
 Type=Application

--- a/app/data/scrcpy.desktop
+++ b/app/data/scrcpy.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/sh -c '"$SHELL" -i -c scrcpy'
+Exec=/bin/sh -c "\"\\$SHELL\" -i -c scrcpy"
 Icon=scrcpy
 Terminal=false
 Type=Application


### PR DESCRIPTION
Follow quoting rules from:
https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables Also use /bin/sh for scrpy-console

This fixes #3633 <https://github.com/Genymobile/scrcpy/issues/3633>
Downstream Gentoo bug: https://bugs.gentoo.org/888133

It adds a few backslashes but makes desktop-file-validate happy
