### PR TITLE
Update desktop entry file exec keys

### DIFF
--- a/app/data/scrcpy-console.desktop
+++ b/app/data/scrcpy-console.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/bash --norc --noprofile -i -c "\"\\$SHELL\" -i -c scrcpy || read -p 'Press any key to quit...'"
+Exec=/bin/bash --norc --noprofile -i -c "\\"\\$SHELL\\" -i -c scrcpy || read -p 'Press any key to quit...'"
 Icon=scrcpy
 Terminal=true
 Type=Application

--- a/app/data/scrcpy-console.desktop
+++ b/app/data/scrcpy-console.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/sh -i -c "\\$SHELL -i -c scrcpy;echo 'Press Enter to quit...';read"
+Exec=/bin/bash --norc --noprofile -i -c "\"\\$SHELL\" -i -c scrcpy || read -p 'Press any key to quit...'"
 Icon=scrcpy
 Terminal=true
 Type=Application

--- a/app/data/scrcpy-console.desktop
+++ b/app/data/scrcpy-console.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/bash --norc --noprofile -i -c "\"\\$SHELL\" -i -c scrcpy || read -p 'Press any key to quit...'"
+Exec=/bin/sh -i -c "\\$SHELL -i -c scrcpy;echo 'Press Enter to quit...';read"
 Icon=scrcpy
 Terminal=true
 Type=Application

--- a/app/data/scrcpy.desktop
+++ b/app/data/scrcpy.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/sh -c "\"\\$SHELL\" -i -c scrcpy"
+Exec=/bin/sh -c "\\"\\$SHELL\\" -c scrcpy"
 Icon=scrcpy
 Terminal=false
 Type=Application

--- a/app/data/scrcpy.desktop
+++ b/app/data/scrcpy.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/sh -c "\"\\$SHELL\" -i -c scrcpy"
+Exec=/bin/sh -c "\\$SHELL -c scrcpy"
 Icon=scrcpy
 Terminal=false
 Type=Application

--- a/app/data/scrcpy.desktop
+++ b/app/data/scrcpy.desktop
@@ -5,7 +5,7 @@ Comment=Display and control your Android device
 # For some users, the PATH or ADB environment variables are set from the shell
 # startup file, like .bashrc or .zshrc… Run an interactive shell to get
 # environment correctly initialized.
-Exec=/bin/sh -c "\\$SHELL -c scrcpy"
+Exec=/bin/sh -c "\"\\$SHELL\" -i -c scrcpy"
 Icon=scrcpy
 Terminal=false
 Type=Application


### PR DESCRIPTION
Hello,
I tried to download [scrcpy-console.desktop](https://github.com/Genymobile/scrcpy/blob/d2b7315ba693e11bd9b9a0421a75b7df8a31c5cc/app/data/scrcpy-console.desktop) from dev branch and running it, but it seems broken to me. When I run it, it warns "Can't find `/usr/bin/bash -i`".

So I suggest this update. This update has 2 behavier changes:
1. Press any key -> Press Enter key
2. Users has to press the key after scrcpy running correctly and closed as well

As a user I think these are fine. At least the `Exec` keys in desktop entry files are going to have less backslashes. And they are working fine both on my local `bash` and `fish` login shell environments. And they passed desktop entry validation.

I removed the quotes (and the backslahes they need) around `$SHELL`, I guess the quotes are unnecessary?

I also removed `-i` option in `scrcpy.desktop`, because we obviously don't need any interactive shell session in `scrcpy.desktop`.