### PR TITLE
Add more accented characters decomposition

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/KeyComposition.java
+++ b/server/src/main/java/com/genymobile/scrcpy/KeyComposition.java
@@ -19,7 +19,9 @@ public final class KeyComposition {
     private static final String KEY_DEAD_ACUTE = "\u0301";
     private static final String KEY_DEAD_CIRCUMFLEX = "\u0302";
     private static final String KEY_DEAD_TILDE = "\u0303";
+    private static final String KEY_DEAD_DOTABOVE = "\u0307";
     private static final String KEY_DEAD_UMLAUT = "\u0308";
+    private static final String KEY_DEAD_OGONEK = "\u0328";
 
     private static final Map<Character, String> COMPOSITION_MAP = createDecompositionMap();
 
@@ -49,6 +51,14 @@ public final class KeyComposition {
 
     private static String umlaut(char c) {
         return KEY_DEAD_UMLAUT + c;
+    }
+
+    private static String dotabove(char c) {
+        return KEY_DEAD_DOTABOVE + c;
+    }
+
+    private static String ogonek(char c) {
+        return KEY_DEAD_OGONEK + c;
     }
 
     private static Map<Character, String> createDecompositionMap() {
@@ -168,6 +178,57 @@ public final class KeyComposition {
         map.put('Ẍ', umlaut('X'));
         map.put('ẍ', umlaut('x'));
         map.put('ẗ', umlaut('t'));
+
+        map.put('Ȧ', dotabove('A'));
+        map.put('Ḃ', dotabove('B'));
+        map.put('Ċ', dotabove('C'));
+        map.put('Ḋ', dotabove('D'));
+        map.put('Ė', dotabove('E'));
+        map.put('Ḟ', dotabove('F'));
+        map.put('Ġ', dotabove('G'));
+        map.put('Ḣ', dotabove('H'));
+        map.put('İ', dotabove('I'));
+        map.put('Ṁ', dotabove('M'));
+        map.put('Ṅ', dotabove('N'));
+        map.put('Ȯ', dotabove('O'));
+        map.put('Ṗ', dotabove('P'));
+        map.put('Ṙ', dotabove('R'));
+        map.put('Ṡ', dotabove('S'));
+        map.put('Ṫ', dotabove('T'));
+        map.put('Ẇ', dotabove('W'));
+        map.put('Ẋ', dotabove('X'));
+        map.put('Ẏ', dotabove('Y'));
+        map.put('Ż', dotabove('Z'));
+        map.put('ȧ', dotabove('a'));
+        map.put('ḃ', dotabove('b'));
+        map.put('ċ', dotabove('c'));
+        map.put('ḋ', dotabove('d'));
+        map.put('ė', dotabove('e'));
+        map.put('ḟ', dotabove('f'));
+        map.put('ġ', dotabove('g'));
+        map.put('ḣ', dotabove('h'));
+        map.put('ṁ', dotabove('m'));
+        map.put('ṅ', dotabove('n'));
+        map.put('ȯ', dotabove('o'));
+        map.put('ṗ', dotabove('p'));
+        map.put('ṙ', dotabove('r'));
+        map.put('ṡ', dotabove('s'));
+        map.put('ṫ', dotabove('t'));
+        map.put('ẇ', dotabove('w'));
+        map.put('ẋ', dotabove('x'));
+        map.put('ẏ', dotabove('y'));
+        map.put('ż', dotabove('z'));
+
+        map.put('Ą', ogonek('A'));
+        map.put('Ę', ogonek('E'));
+        map.put('Į', ogonek('I'));
+        map.put('Ǫ', ogonek('O'));
+        map.put('Ų', ogonek('U'));
+        map.put('ą', ogonek('a'));
+        map.put('ę', ogonek('e'));
+        map.put('į', ogonek('i'));
+        map.put('ǫ', ogonek('o'));
+        map.put('ų', ogonek('u'));
 
         return map;
     }


### PR DESCRIPTION
Hello!

Hopefully I've done everything right despite knowing next to nothing about C or Java.

The PR addresses mostly Polish language (which uses chars like "ż/Ż", "ą/Ą", "ę/Ę"), but I have included every available character in Windows' charmap which had either "dot above" or "ogonek", respectively (the terminology came from charmap, but "ogonek" literally means "a little tail" and is actually used by the Polish people to describe those two letters).

In the class I interjected the `dotabove` above umlaut since I was trying to preserve the UTF order. Below, in private static and mapping itself, I just added it to the end, so the grouping would hopefully make sense.

There is a nonsensical sentence `ZAŻÓŁĆ GĘŚLĄ JAŹŃ` used to test if a keyboard layout, a program, etc. can display all Polish diacritics. Right now, it ends up as `ZAÓĆ GŚL JAŹŃ`. After this PR is merged, it _should_ be almost correct - `ZAŻÓĆ GĘŚLĄ JAŹŃ`, missing only the `Ł` character. Sadly, `Ł` itself is _impossible_ to decompose because of no UTF chars exist for "connecting upwards stroke", so "ł/Ł" seems to be out of reach until this gets added (which it probably won't). I know "connecting short stroke" and "connecting long stroke" exist, but even if they did work (because I was not able to make them work properly), it would still be a different character (`L` + `-` != `Ł`).

Since there is addition, but no change or removal of anything, this should merge nicely.