### PR TITLE
Add Android version check in raw audio recorder

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/AudioRawRecorder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/AudioRawRecorder.java
@@ -1,6 +1,7 @@
 package com.genymobile.scrcpy;
 
 import android.media.MediaCodec;
+import android.os.Build;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -19,6 +20,12 @@ public final class AudioRawRecorder implements AsyncProcessor {
     }
 
     private void record() throws IOException, AudioCaptureForegroundException {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            Ln.w("Audio disabled: it is not supported before Android 11");
+            streamer.writeDisableStream(false);
+            return;
+        }
+
         final ByteBuffer buffer = ByteBuffer.allocateDirect(READ_SIZE);
         final MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
 


### PR DESCRIPTION
Before

```shell
> ./scrcpy --audio-codec=raw
scrcpy 2.0 <https://github.com/Genymobile/scrcpy>
C:\Users\simon\Downloads\scrcpy-win64-v2.0\scrcpy-win64-v2... file pushed, 0 skipped. 29.7 MB/s (52867 bytes in 0.002s)
[server] INFO: Device: HUAWEI MHA-AL00 (Android 9)
INFO: Renderer: direct3d
INFO: Initial texture: 1080x1920
ERROR: Demuxer 'audio': stream disabled due to connection error
WARN: Device disconnected
Segmentation fault
```

After

```shell
> ./scrcpy --audio-codec=raw
scrcpy 2.0 <https://github.com/Genymobile/scrcpy>
D:\dev\yume-chan\scrcpy-devcontainer\scrcpy\dist\scrcpy-wi... file pushed, 0 skipped. 87.8 MB/s (53451 bytes in 0.001s)
[server] INFO: Device: HUAWEI MHA-AL00 (Android 9)
[server] WARN: Audio disabled: it is not supported before Android 11
INFO: Renderer: direct3d
WARN: Demuxer 'audio': stream explicitly disabled by the device
INFO: Initial texture: 1080x1920
```