### PR TITLE
Get better OpenGL version than 2.1 on macOS

### DIFF
--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -470,6 +470,21 @@ sc_screen_init(struct sc_screen *screen,
     // starts with "opengl"
     bool use_opengl = renderer_name && !strncmp(renderer_name, "opengl", 6);
     if (use_opengl) {
+
+#ifdef __APPLE__
+        // Persuade macOS to give us something better than OpenGL 2.1
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+        LOGD("Creating GL Context");
+        SDL_GLContext *gl_context;
+        gl_context = SDL_GL_CreateContext(screen->window);
+        if (!gl_context) {
+            LOGE("Could not create OpenGL context. Error: %s", SDL_GetError());
+            goto error_destroy_renderer;
+        }
+#endif
+
         struct sc_opengl *gl = &screen->gl;
         sc_opengl_init(gl);
 

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -475,15 +475,13 @@ sc_screen_init(struct sc_screen *screen,
 
 #ifdef __APPLE__
         // Persuade macOS to give us something better than OpenGL 2.1
-        // Since macOS 10.7.5 we can use OpenGL 3.2, according to page 24 of
-        // https://developer.apple.com/opengl/OpenGL-Capabilities-Tables.pdf
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-        LOGD("Creating OpenGL 3.2 Context");
+        // If we create a Core Profile context, we get the best OpenGL version.
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
+                            SDL_GL_CONTEXT_PROFILE_CORE);
+        LOGD("Creating OpenGL Core Profile Context");
         screen->gl_context = SDL_GL_CreateContext(screen->window);
         if (!screen->gl_context) {
-            LOGW("Could not create OpenGL 3.2 context. Error: %s", SDL_GetError());
+            LOGE("Could not create OpenGL context. Error: %s", SDL_GetError());
             goto error_delete_gl_context;
         }
 #endif

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -40,6 +40,7 @@ struct sc_screen {
 
     SDL_Window *window;
     SDL_Renderer *renderer;
+    SDL_GLContext *gl_context;
     SDL_Texture *texture;
     struct sc_opengl gl;
     struct sc_size frame_size;


### PR DESCRIPTION
Normally macOS gives us only OpenGL 2.1, but if we request 3.3 and create a new context, we get the best OpenGL version it has to offer.

Before:
INFO: Renderer: opengl
INFO: OpenGL version: 2.1 NVIDIA-14.0.32 355.11.11.10.10.143
WARN: Trilinear filtering disabled (OpenGL 3.0+ or ES 2.0+ required)

After:
INFO: Renderer: opengl
DEBUG: Creating GL Context
INFO: OpenGL version: 4.1 NVIDIA-14.0.32 355.11.11.10.10.143
INFO: Trilinear filtering enabled

when running with
--verbosity=verbose --render-driver=opengl

Note:
Since SDL_CreateRenderer causes a fallback to OpenGL 2.1, the profile and version attributes have to be set and the context created _after_.
This took a while to figure out.