### PR TITLE
Turn device screen off _after_ everything has been set up

### DIFF
--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -631,16 +631,6 @@ aoa_hid_end:
         controller_started = true;
         controller = &s->controller;
 
-        if (options->turn_screen_off) {
-            struct sc_control_msg msg;
-            msg.type = SC_CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE;
-            msg.set_screen_power_mode.mode = SC_SCREEN_POWER_MODE_OFF;
-
-            if (!sc_controller_push_msg(&s->controller, &msg)) {
-                LOGW("Could not request 'set screen power mode'");
-            }
-        }
-
     }
 
     // There is a controller if and only if control is enabled
@@ -726,6 +716,20 @@ aoa_hid_end:
             goto end;
         }
         audio_demuxer_started = true;
+    }
+
+    // If the device screen is to be turned off, it is done _after_
+    // everything is set up - for continuity
+    if (options->control) {
+        if (options->turn_screen_off) {
+            struct sc_control_msg msg;
+            msg.type = SC_CONTROL_MSG_TYPE_SET_SCREEN_POWER_MODE;
+            msg.set_screen_power_mode.mode = SC_SCREEN_POWER_MODE_OFF;
+
+            if (!sc_controller_push_msg(&s->controller, &msg)) {
+                LOGW("Could not request 'set screen power mode'");
+            }
+        }
     }
 
     ret = event_loop(s);


### PR DESCRIPTION
Sometimes it can take quite a while for everything to get set up and the screen to appear.

Note:
Intentionally kept the double `if` construct so it matches the previous blocks.