### PR TITLE
Add new option to show clipboard updates in verbose mode

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -72,6 +72,7 @@ enum {
     OPT_REQUIRE_AUDIO,
     OPT_AUDIO_BUFFER,
     OPT_AUDIO_OUTPUT_BUFFER,
+    OPT_SHOW_CLIPBOARD,
 };
 
 struct sc_option {
@@ -515,6 +516,12 @@ static const struct sc_option options[] = {
                 "For example, to use either LCtrl+LAlt or LSuper for scrcpy "
                 "shortcuts, pass \"lctrl+lalt,lsuper\".\n"
                 "Default is \"lalt,lsuper\" (left-Alt or left-Super).",
+    },
+    {
+        .longopt_id = OPT_SHOW_CLIPBOARD,
+        .longopt = "show-clipboard",
+        .text = "Print the content of a clipboard when it is changed if the "
+                "log level is high enough."
     },
     {
         .shortopt = 'S',
@@ -1860,6 +1867,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                                                &opts->audio_output_buffer)) {
                     return false;
                 }
+                break;
+            case OPT_SHOW_CLIPBOARD:
+                opts->show_clipboard = true;
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/controller.c
+++ b/app/src/controller.c
@@ -125,7 +125,7 @@ run_controller(void *data) {
 }
 
 bool
-sc_controller_start(struct sc_controller *controller) {
+sc_controller_start(struct sc_controller *controller, const bool show_clipboard_value) {
     LOGD("Starting controller thread");
 
     bool ok = sc_thread_create(&controller->thread, run_controller,
@@ -135,7 +135,7 @@ sc_controller_start(struct sc_controller *controller) {
         return false;
     }
 
-    if (!sc_receiver_start(&controller->receiver)) {
+    if (!sc_receiver_start(&controller->receiver, show_clipboard_value)) {
         sc_controller_stop(controller);
         sc_thread_join(&controller->thread, NULL);
         return false;

--- a/app/src/controller.h
+++ b/app/src/controller.h
@@ -32,7 +32,7 @@ void
 sc_controller_destroy(struct sc_controller *controller);
 
 bool
-sc_controller_start(struct sc_controller *controller);
+sc_controller_start(struct sc_controller *controller, const bool show_clipboard_value);
 
 void
 sc_controller_stop(struct sc_controller *controller);

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -77,4 +77,5 @@ const struct scrcpy_options scrcpy_options_default = {
     .require_audio = false,
     .list_encoders = false,
     .list_displays = false,
+    .show_clipboard = false,
 };

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -160,6 +160,7 @@ struct scrcpy_options {
     bool require_audio;
     bool list_encoders;
     bool list_displays;
+    bool show_clipboard;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/receiver.h
+++ b/app/src/receiver.h
@@ -27,7 +27,7 @@ void
 sc_receiver_destroy(struct sc_receiver *receiver);
 
 bool
-sc_receiver_start(struct sc_receiver *receiver);
+sc_receiver_start(struct sc_receiver *receiver, const bool show_clipboard_value);
 
 // no sc_receiver_stop(), it will automatically stop on control_socket shutdown
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -362,6 +362,7 @@ scrcpy(struct scrcpy_options *options) {
         .power_on = options->power_on,
         .list_encoders = options->list_encoders,
         .list_displays = options->list_displays,
+        .show_clipboard = options->show_clipboard,
     };
 
     static const struct sc_server_callbacks cbs = {
@@ -625,7 +626,7 @@ aoa_hid_end:
         }
         controller_initialized = true;
 
-        if (!sc_controller_start(&s->controller)) {
+        if (!sc_controller_start(&s->controller, options->show_clipboard)) {
             goto end;
         }
         controller_started = true;

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -308,6 +308,9 @@ execute_server(struct sc_server *server,
     if (params->list_displays) {
         ADD_PARAM("list_displays=true");
     }
+    if (params->show_clipboard) {
+        ADD_PARAM("show_clipboard=true");
+    }
 
 #undef ADD_PARAM
 

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -56,6 +56,7 @@ struct sc_server_params {
     bool power_on;
     bool list_encoders;
     bool list_displays;
+    bool show_clipboard;
 };
 
 struct sc_server {

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -31,6 +31,7 @@ public class Controller implements AsyncProcessor {
     private final DeviceMessageSender sender;
     private final boolean clipboardAutosync;
     private final boolean powerOn;
+    private final boolean showClipboard;
 
     private final KeyCharacterMap charMap = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
 
@@ -41,11 +42,12 @@ public class Controller implements AsyncProcessor {
 
     private boolean keepPowerModeOff;
 
-    public Controller(Device device, DesktopConnection connection, boolean clipboardAutosync, boolean powerOn) {
+    public Controller(Device device, DesktopConnection connection, boolean clipboardAutosync, boolean powerOn, boolean showClipboard) {
         this.device = device;
         this.connection = connection;
         this.clipboardAutosync = clipboardAutosync;
         this.powerOn = powerOn;
+        this.showClipboard = showClipboard;
         initPointers();
         sender = new DeviceMessageSender(connection);
     }
@@ -393,7 +395,11 @@ public class Controller implements AsyncProcessor {
     private boolean setClipboard(String text, boolean paste, long sequence) {
         boolean ok = device.setClipboardText(text);
         if (ok) {
-            Ln.i("Device clipboard set");
+            String deviceInfo = "Device clipboard set";
+            if (showClipboard) {
+                deviceInfo += ": " + text;
+            }
+            Ln.i(deviceInfo);
         }
 
         // On Android >= 7, also press the PASTE key if requested

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -33,6 +33,7 @@ public class Options {
     private boolean downsizeOnError = true;
     private boolean cleanup = true;
     private boolean powerOn = true;
+    private boolean showClipboard = false;
 
     private boolean listEncoders;
     private boolean listDisplays;
@@ -141,6 +142,10 @@ public class Options {
 
     public boolean getPowerOn() {
         return powerOn;
+    }
+
+    public boolean getShowClipboard() {
+        return showClipboard;
     }
 
     public boolean getListEncoders() {
@@ -279,6 +284,9 @@ public class Options {
                     break;
                 case "power_on":
                     options.powerOn = Boolean.parseBoolean(value);
+                    break;
+                case "show_clipboard":
+                    options.showClipboard = Boolean.parseBoolean(value);
                     break;
                 case "list_encoders":
                     options.listEncoders = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -98,7 +98,7 @@ public final class Server {
             }
 
             if (control) {
-                Controller controller = new Controller(device, connection, options.getClipboardAutosync(), options.getPowerOn());
+                Controller controller = new Controller(device, connection, options.getClipboardAutosync(), options.getPowerOn(), options.getShowClipboard());
                 device.setClipboardListener(text -> controller.getSender().pushClipboardText(text));
                 asyncProcessors.add(controller);
             }


### PR DESCRIPTION
 This implements the feature suggested by #3475.

When copying from the device, then copy-pasting from the computer to the device using <kbd>Ctrl</kbd>+<kbd>V</kbd>, and running with `-Vdebug --show-clipboard` :
* Before:
```
INFO: Device clipboard copied
DEBUG: Computer clipboard set

[server] INFO: Device clipboard set
DEBUG: Computer clipboard unchanged
```

* After:
```
INFO: Device clipboard copied: This application mirrors Android devices
DEBUG: Computer clipboard set: This application mirrors Android devices

[server] INFO: Device clipboard set: It works on Linux
DEBUG: Computer clipboard unchanged
```

Running without `--show-clipboard` has the same behavior as "Before".