### PR TITLE
Notify ScreenEncoder when a folding event occurs

### DIFF
--- a/server/src/main/aidl/android/view/IDisplayFoldListener.aidl
+++ b/server/src/main/aidl/android/view/IDisplayFoldListener.aidl
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package android.view;
+/**
+ * {@hide}
+ */
+oneway interface IDisplayFoldListener
+{
+    /** Called when the foldedness of a display changes */
+    void onDisplayFoldChanged(int displayId, boolean folded);
+}

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -37,7 +37,7 @@ public final class Device {
     }
 
     public interface FoldListener {
-        void onFoldChanged(int displayId);
+        void onFoldChanged(int displayId, boolean folded);
     }
 
     public interface ClipboardListener {
@@ -112,7 +112,7 @@ public final class Device {
                     screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), displayInfo.getSize(), options.getCrop(), options.getMaxSize(), options.getLockVideoOrientation());
                     // notify
                     if (foldListener != null) {
-                        foldListener.onFoldChanged(displayId);
+                        foldListener.onFoldChanged(displayId, folded);
                     }
                 }
             }

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.IBinder;
 import android.os.SystemClock;
 import android.view.IRotationWatcher;
+import android.view.IDisplayFoldListener;
 import android.view.InputDevice;
 import android.view.InputEvent;
 import android.view.KeyCharacterMap;
@@ -35,6 +36,10 @@ public final class Device {
         void onRotationChanged(int rotation);
     }
 
+    public interface FoldListener {
+        void onFoldChanged(int displayId);
+    }
+
     public interface ClipboardListener {
         void onClipboardTextChanged(String text);
     }
@@ -46,6 +51,7 @@ public final class Device {
 
     private ScreenInfo screenInfo;
     private RotationListener rotationListener;
+    private FoldListener foldListener;
     private ClipboardListener clipboardListener;
     private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
 
@@ -92,6 +98,25 @@ public final class Device {
                 }
             }
         }, displayId);
+
+        ServiceManager.getWindowManager().registerDisplayFoldListener(new IDisplayFoldListener.Stub() {
+            @Override
+            public void onDisplayFoldChanged(int displayId, boolean folded) {
+                synchronized (Device.this) {
+                    DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
+                    if (displayInfo == null) {
+                        Ln.e("Display " + displayId + " not found\n" + LogUtils.buildDisplayListMessage());
+                        return;
+                    }
+
+                    screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), displayInfo.getSize(), options.getCrop(), options.getMaxSize(), options.getLockVideoOrientation());
+                    // notify
+                    if (foldListener != null) {
+                        foldListener.onFoldChanged(displayId); // what to do here?
+                    }
+                }
+            }
+        });
 
         if (options.getControl() && options.getClipboardAutosync()) {
             // If control and autosync are enabled, synchronize Android clipboard to the computer automatically
@@ -222,6 +247,10 @@ public final class Device {
 
     public synchronized void setRotationListener(RotationListener rotationListener) {
         this.rotationListener = rotationListener;
+    }
+
+    public synchronized void setFoldListener(FoldListener foldlistener) {
+        this.foldListener = foldlistener;
     }
 
     public synchronized void setClipboardListener(ClipboardListener clipboardListener) {

--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -112,7 +112,7 @@ public final class Device {
                     screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), displayInfo.getSize(), options.getCrop(), options.getMaxSize(), options.getLockVideoOrientation());
                     // notify
                     if (foldListener != null) {
-                        foldListener.onFoldChanged(displayId); // what to do here?
+                        foldListener.onFoldChanged(displayId);
                     }
                 }
             }

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -51,7 +51,7 @@ public class ScreenEncoder implements Device.RotationListener, Device.FoldListen
     }
 
     @Override
-    public void onFoldChanged(int displayId) {
+    public void onFoldChanged(int displayId, boolean folded) {
         // TODO: rename rotationChanged to something like displayChanged? To discuss with @rom1v
         rotationChanged.set(true);
     }

--- a/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenEncoder.java
@@ -16,7 +16,7 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class ScreenEncoder implements Device.RotationListener {
+public class ScreenEncoder implements Device.RotationListener, Device.FoldListener {
 
     private static final int DEFAULT_I_FRAME_INTERVAL = 10; // seconds
     private static final int REPEAT_FRAME_DELAY_US = 100_000; // repeat after 100ms
@@ -51,6 +51,12 @@ public class ScreenEncoder implements Device.RotationListener {
     }
 
     @Override
+    public void onFoldChanged(int displayId) {
+        // TODO: rename rotationChanged to something like displayChanged? To discuss with @rom1v
+        rotationChanged.set(true);
+    }
+
+    @Override
     public void onRotationChanged(int rotation) {
         rotationChanged.set(true);
     }
@@ -65,6 +71,7 @@ public class ScreenEncoder implements Device.RotationListener {
         MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
         IBinder display = createDisplay();
         device.setRotationListener(this);
+        device.setFoldListener(this);
 
         streamer.writeVideoHeader(device.getScreenInfo().getVideoSize());
 
@@ -112,6 +119,7 @@ public class ScreenEncoder implements Device.RotationListener {
         } finally {
             mediaCodec.release();
             device.setRotationListener(null);
+            device.setFoldListener(null);
             SurfaceControl.destroyDisplay(display);
         }
     }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -4,6 +4,7 @@ import com.genymobile.scrcpy.Ln;
 
 import android.os.IInterface;
 import android.view.IRotationWatcher;
+import android.view.IDisplayFoldListener;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -104,6 +105,15 @@ public final class WindowManager {
                 // old version
                 cls.getMethod("watchRotation", IRotationWatcher.class).invoke(manager, rotationWatcher);
             }
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    public void registerDisplayFoldListener(IDisplayFoldListener foldListener) {
+        try {
+            Class<?> cls = manager.getClass();
+            cls.getMethod("registerDisplayFoldListener", IDisplayFoldListener.class).invoke(manager, foldListener);
         } catch (Exception e) {
             throw new AssertionError(e);
         }


### PR DESCRIPTION
Hello :wave: 
It's been a while since my last contribution, it's a pleasure to be able to contribute again to this amazing project!

I'm a lucky owner of a foldable phone ( Z fold 4 ) and I've seen that scrcpy does not handle the fold events ( The SDL Window does not update its size when I bend my phone ). 

I just fixed this issue ( it is implemented the same way as RotationWatcher ).

Btw I have a little concern about the naming of the boolean `ScreenEncoder.rotationChanged` which may not have a good name after this PR.