### PR TITLE
Add option to select audio source

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -7,6 +7,7 @@ _scrcpy() {
         --audio-codec=
         --audio-codec-options=
         --audio-encoder=
+        --audio-source=
         --audio-output-buffer=
         -b --video-bit-rate=
         --crop=
@@ -84,6 +85,10 @@ _scrcpy() {
             ;;
         --audio-codec)
             COMPREPLY=($(compgen -W 'opus aac raw' -- "$cur"))
+            return
+            ;;
+        --audio-source)
+            COMPREPLY=($(compgen -W 'output mic' -- "$cur"))
             return
             ;;
         --lock-video-orientation)

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -14,6 +14,7 @@ arguments=(
     '--audio-codec=[Select the audio codec]:codec:(opus aac raw)'
     '--audio-codec-options=[Set a list of comma-separated key\:type=value options for the device audio encoder]'
     '--audio-encoder=[Use a specific MediaCodec audio encoder]'
+    '--audio-source=[Select the audio source]:source:(output mic)'
     '--audio-output-buffer=[Configure the size of the SDL audio output buffer (in milliseconds)]'
     {-b,--video-bit-rate=}'[Encode the video at the given bit-rate]'
     '--crop=[\[width\:height\:x\:y\] Crop the device screen on the server]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -56,6 +56,12 @@ Use a specific MediaCodec audio encoder (depending on the codec provided by \fB\
 The available encoders can be listed by \-\-list\-encoders.
 
 .TP
+.BI "\-\-audio\-source " source
+Select the audio source (output or mic).
+
+Default is output.
+
+.TP
 .BI "\-\-audio\-output\-buffer ms
 Configure the size of the SDL audio output buffer (in milliseconds).
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -76,6 +76,7 @@ enum {
     OPT_NO_VIDEO,
     OPT_NO_AUDIO_PLAYBACK,
     OPT_NO_VIDEO_PLAYBACK,
+    OPT_AUDIO_SOURCE,
 };
 
 struct sc_option {
@@ -160,6 +161,13 @@ static const struct sc_option options[] = {
         .text = "Use a specific MediaCodec audio encoder (depending on the "
                 "codec provided by --audio-codec).\n"
                 "The available encoders can be listed by --list-encoders.",
+    },
+    {
+        .longopt_id = OPT_AUDIO_SOURCE,
+        .longopt = "audio-source",
+        .argdesc = "source",
+        .text = "Select the audio source (output or mic).\n"
+                "Default is output.",
     },
     {
         .longopt_id = OPT_AUDIO_OUTPUT_BUFFER,
@@ -1589,6 +1597,22 @@ parse_audio_codec(const char *optarg, enum sc_codec *codec) {
 }
 
 static bool
+parse_audio_source(const char *optarg, enum sc_audio_source *source) {
+    if (!strcmp(optarg, "mic")) {
+        *source = SC_AUDIO_SOURCE_MIC;
+        return true;
+    }
+
+    if (!strcmp(optarg, "output")) {
+        *source = SC_AUDIO_SOURCE_OUTPUT;
+        return true;
+    }
+
+    LOGE("Unsupported audio source: %s (expected output or mic)", optarg);
+    return false;
+}
+
+static bool
 parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                        const char *optstring, const struct option *longopts) {
     struct scrcpy_options *opts = &args->opts;
@@ -1912,6 +1936,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_AUDIO_OUTPUT_BUFFER:
                 if (!parse_audio_output_buffer(optarg,
                                                &opts->audio_output_buffer)) {
+                    return false;
+                }
+                break;
+            case OPT_AUDIO_SOURCE:
+                if (!parse_audio_source(optarg, &opts->audio_source)) {
                     return false;
                 }
                 break;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -14,6 +14,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .log_level = SC_LOG_LEVEL_INFO,
     .video_codec = SC_CODEC_H264,
     .audio_codec = SC_CODEC_OPUS,
+    .audio_source = SC_AUDIO_SOURCE_OUTPUT,
     .record_format = SC_RECORD_FORMAT_AUTO,
     .keyboard_input_mode = SC_KEYBOARD_INPUT_MODE_INJECT,
     .mouse_input_mode = SC_MOUSE_INPUT_MODE_INJECT,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -44,6 +44,11 @@ enum sc_codec {
     SC_CODEC_RAW,
 };
 
+enum sc_audio_source {
+    SC_AUDIO_SOURCE_OUTPUT,
+    SC_AUDIO_SOURCE_MIC,
+};
+
 enum sc_lock_video_orientation {
     SC_LOCK_VIDEO_ORIENTATION_UNLOCKED = -1,
     // lock the current orientation when scrcpy starts
@@ -115,6 +120,7 @@ struct scrcpy_options {
     enum sc_log_level log_level;
     enum sc_codec video_codec;
     enum sc_codec audio_codec;
+    enum sc_audio_source audio_source;
     enum sc_record_format record_format;
     enum sc_keyboard_input_mode keyboard_input_mode;
     enum sc_mouse_input_mode mouse_input_mode;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -334,6 +334,7 @@ scrcpy(struct scrcpy_options *options) {
         .log_level = options->log_level,
         .video_codec = options->video_codec,
         .audio_codec = options->audio_codec,
+        .audio_source = options->audio_source,
         .crop = options->crop,
         .port_range = options->port_range,
         .tunnel_host = options->tunnel_host,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -246,6 +246,10 @@ execute_server(struct sc_server *server,
         ADD_PARAM("audio_codec=%s",
             sc_server_get_codec_name(params->audio_codec));
     }
+    if (params->audio_source != SC_AUDIO_SOURCE_OUTPUT) {
+        assert(params->audio_source == SC_AUDIO_SOURCE_MIC);
+        ADD_PARAM("audio_source=mic");
+    }
     if (params->max_size) {
         ADD_PARAM("max_size=%" PRIu16, params->max_size);
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -26,6 +26,7 @@ struct sc_server_params {
     enum sc_log_level log_level;
     enum sc_codec video_codec;
     enum sc_codec audio_codec;
+    enum sc_audio_source audio_source;
     const char *crop;
     const char *video_codec_options;
     const char *audio_codec_options;

--- a/doc/audio.md
+++ b/doc/audio.md
@@ -41,6 +41,24 @@ interesting to add [buffering](#buffering) to minimize glitches:
 scrcpy --no-video --audio-buffer=200
 ```
 
+## Source
+
+By default, the device audio output is forwarded.
+
+It is possible to capture the device microphone instead:
+
+```
+scrcpy --audio-source=mic
+```
+
+For example, to use the device as a dictaphone and record a capture directly on
+the computer:
+
+```
+scrcpy --audio-source=mic --no-video --no-audio-playback --record=file.opus
+```
+
+
 ## Codec
 
 The audio codec can be selected. The possible values are `opus` (default), `aac`

--- a/server/src/main/java/com/genymobile/scrcpy/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/AudioEncoder.java
@@ -40,6 +40,7 @@ public final class AudioEncoder implements AsyncProcessor {
     private static final int READ_MS = 5; // milliseconds
     private static final int READ_SIZE = AudioCapture.millisToBytes(READ_MS);
 
+    private final AudioCapture capture;
     private final Streamer streamer;
     private final int bitRate;
     private final List<CodecOption> codecOptions;
@@ -58,7 +59,8 @@ public final class AudioEncoder implements AsyncProcessor {
 
     private boolean ended;
 
-    public AudioEncoder(Streamer streamer, int bitRate, List<CodecOption> codecOptions, String encoderName) {
+    public AudioEncoder(AudioCapture capture, Streamer streamer, int bitRate, List<CodecOption> codecOptions, String encoderName) {
+        this.capture = capture;
         this.streamer = streamer;
         this.bitRate = bitRate;
         this.codecOptions = codecOptions;
@@ -175,7 +177,6 @@ public final class AudioEncoder implements AsyncProcessor {
         }
 
         MediaCodec mediaCodec = null;
-        AudioCapture capture = new AudioCapture();
 
         boolean mediaCodecStarted = false;
         try {
@@ -192,10 +193,9 @@ public final class AudioEncoder implements AsyncProcessor {
             capture.start();
 
             final MediaCodec mediaCodecRef = mediaCodec;
-            final AudioCapture captureRef = capture;
             inputThread = new Thread(() -> {
                 try {
-                    inputThread(mediaCodecRef, captureRef);
+                    inputThread(mediaCodecRef, capture);
                 } catch (IOException | InterruptedException e) {
                     Ln.e("Audio capture error", e);
                 } finally {

--- a/server/src/main/java/com/genymobile/scrcpy/AudioRawRecorder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/AudioRawRecorder.java
@@ -8,6 +8,7 @@ import java.nio.ByteBuffer;
 
 public final class AudioRawRecorder implements AsyncProcessor {
 
+    private final AudioCapture capture;
     private final Streamer streamer;
 
     private Thread thread;
@@ -15,7 +16,8 @@ public final class AudioRawRecorder implements AsyncProcessor {
     private static final int READ_MS = 5; // milliseconds
     private static final int READ_SIZE = AudioCapture.millisToBytes(READ_MS);
 
-    public AudioRawRecorder(Streamer streamer) {
+    public AudioRawRecorder(AudioCapture capture, Streamer streamer) {
+        this.capture = capture;
         this.streamer = streamer;
     }
 
@@ -29,7 +31,6 @@ public final class AudioRawRecorder implements AsyncProcessor {
         final ByteBuffer buffer = ByteBuffer.allocateDirect(READ_SIZE);
         final MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
 
-        AudioCapture capture = new AudioCapture();
         try {
             capture.start();
 

--- a/server/src/main/java/com/genymobile/scrcpy/AudioSource.java
+++ b/server/src/main/java/com/genymobile/scrcpy/AudioSource.java
@@ -1,0 +1,30 @@
+package com.genymobile.scrcpy;
+
+import android.media.MediaRecorder;
+
+public enum AudioSource {
+    OUTPUT("output", MediaRecorder.AudioSource.REMOTE_SUBMIX),
+    MIC("mic", MediaRecorder.AudioSource.MIC);
+
+    private final String name;
+    private final int value;
+
+    AudioSource(String name, int value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    int value() {
+        return value;
+    }
+
+    static AudioSource findByName(String name) {
+        for (AudioSource audioSource : AudioSource.values()) {
+            if (name.equals(audioSource.name)) {
+                return audioSource;
+            }
+        }
+
+        return null;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -14,6 +14,7 @@ public class Options {
     private int maxSize;
     private VideoCodec videoCodec = VideoCodec.H264;
     private AudioCodec audioCodec = AudioCodec.OPUS;
+    private AudioSource audioSource = AudioSource.OUTPUT;
     private int videoBitRate = 8000000;
     private int audioBitRate = 128000;
     private int maxFps;
@@ -70,6 +71,10 @@ public class Options {
 
     public AudioCodec getAudioCodec() {
         return audioCodec;
+    }
+
+    public AudioSource getAudioSource() {
+        return audioSource;
     }
 
     public int getVideoBitRate() {
@@ -224,6 +229,13 @@ public class Options {
                         throw new IllegalArgumentException("Audio codec " + value + " not supported");
                     }
                     options.audioCodec = audioCodec;
+                    break;
+                case "audio_source":
+                    AudioSource audioSource = AudioSource.findByName(value);
+                    if (audioSource == null) {
+                        throw new IllegalArgumentException("Audio source " + value + " not supported");
+                    }
+                    options.audioSource = audioSource;
                     break;
                 case "max_size":
                     options.maxSize = Integer.parseInt(value) & ~7; // multiple of 8

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -136,13 +136,14 @@ public final class Server {
 
             if (audio) {
                 AudioCodec audioCodec = options.getAudioCodec();
+                AudioCapture audioCapture = new AudioCapture();
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendCodecMeta(),
                         options.getSendFrameMeta());
                 AsyncProcessor audioRecorder;
                 if (audioCodec == AudioCodec.RAW) {
-                    audioRecorder = new AudioRawRecorder(audioStreamer);
+                    audioRecorder = new AudioRawRecorder(audioCapture, audioStreamer);
                 } else {
-                    audioRecorder = new AudioEncoder(audioStreamer, options.getAudioBitRate(), options.getAudioCodecOptions(),
+                    audioRecorder = new AudioEncoder(audioCapture, audioStreamer, options.getAudioBitRate(), options.getAudioCodecOptions(),
                             options.getAudioEncoder());
                 }
                 asyncProcessors.add(audioRecorder);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -136,7 +136,7 @@ public final class Server {
 
             if (audio) {
                 AudioCodec audioCodec = options.getAudioCodec();
-                AudioCapture audioCapture = new AudioCapture();
+                AudioCapture audioCapture = new AudioCapture(options.getAudioSource());
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendCodecMeta(),
                         options.getSendFrameMeta());
                 AsyncProcessor audioRecorder;


### PR DESCRIPTION
By default, the device audio output is forwarded.

Add an option to capture the device microphone instead:

```
scrcpy --audio-source=mic
```

For example, to use the device as a dictaphone and record a capture directly on the computer:

```
scrcpy --audio-source=mic --no-video --no-audio-playback --record=file.opus
```