### PR TITLE
Update scrcpy-noconsole.vbs

### DIFF
--- a/app/data/scrcpy-noconsole.vbs
+++ b/app/data/scrcpy-noconsole.vbs
@@ -1,7 +1,32 @@
-strCommand = "cmd /c scrcpy.exe"
+strProcessName = "scrcpy.exe"
+bFound = False
 
-For Each Arg In WScript.Arguments
-    strCommand = strCommand & " """ & replace(Arg, """", """""""""") & """"
+' Check if scrcpy.exe is already running
+Set objWMIService = GetObject("winmgmts:\\.\root\cimv2")
+Set colProcesses = objWMIService.ExecQuery("Select * from Win32_Process")
+
+For Each objProcess in colProcesses
+    If InStr(1, objProcess.Name, strProcessName, vbTextCompare) > 0 Then
+        ' scrcpy.exe is already running
+        bFound = True
+        Exit For
+    End If
 Next
 
-CreateObject("Wscript.Shell").Run strCommand, 0, false
+If bFound Then
+    ' Bring scrcpy window to the foreground, unless its minimized
+    Set objShell = CreateObject("WScript.Shell")
+
+    ' Activate the window by title
+    objShell.AppActivate("2201116PG")
+
+Else
+    ' scrcpy.exe is not running, so start it
+    strCommand = "cmd /c scrcpy.exe"
+
+    For Each Arg In WScript.Arguments
+        strCommand = strCommand & " """ & Replace(Arg, """", """""") & """"
+    Next
+
+    CreateObject("WScript.Shell").Run strCommand, 0, False
+End If


### PR DESCRIPTION
Doesnt Open a new Scrcpy window if one is already open. This prevents echoing when playing Audio on pc. In addition, if the window is already open, it will be brought to foregroud (unless it is minimized). This wont quite work yet, as the window title is dependent on the device. Maybe one could get this name dynamically or rename the window to scrcpy on all devices. just a suggestion