### PR TITLE
Some more small fixes

### DIFF
--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -218,7 +218,7 @@ sc_adb_forward(struct sc_intr *intr, const char *serial, uint16_t local_port,
                const char *device_socket_name, unsigned flags) {
     char local[4 + 5 + 1]; // tcp:PORT
     char remote[108 + 14 + 1]; // localabstract:NAME
-    sprintf(local, "tcp:%" PRIu16, local_port);
+    snprintf(local, sizeof(local), "tcp:%" PRIu16, local_port);
     snprintf(remote, sizeof(remote), "localabstract:%s", device_socket_name);
 
     assert(serial);
@@ -233,7 +233,7 @@ bool
 sc_adb_forward_remove(struct sc_intr *intr, const char *serial,
                       uint16_t local_port, unsigned flags) {
     char local[4 + 5 + 1]; // tcp:PORT
-    sprintf(local, "tcp:%" PRIu16, local_port);
+    snprintf(local, sizeof(local), "tcp:%" PRIu16, local_port);
 
     assert(serial);
     const char *const argv[] =
@@ -249,7 +249,7 @@ sc_adb_reverse(struct sc_intr *intr, const char *serial,
                unsigned flags) {
     char local[4 + 5 + 1]; // tcp:PORT
     char remote[108 + 14 + 1]; // localabstract:NAME
-    sprintf(local, "tcp:%" PRIu16, local_port);
+    snprintf(local, sizeof(local), "tcp:%" PRIu16, local_port);
     snprintf(remote, sizeof(remote), "localabstract:%s", device_socket_name);
     assert(serial);
     const char *const argv[] =
@@ -333,7 +333,7 @@ bool
 sc_adb_tcpip(struct sc_intr *intr, const char *serial, uint16_t port,
              unsigned flags) {
     char port_string[5 + 1];
-    sprintf(port_string, "%" PRIu16, port);
+    snprintf(port_string, sizeof(port_string), "%" PRIu16, port);
 
     assert(serial);
     const char *const argv[] =

--- a/app/src/usb/hid_keyboard.c
+++ b/app/src/usb/hid_keyboard.c
@@ -27,7 +27,7 @@
 // keyboard support, though OS could support more keys via modifying the report
 // desc. 6 should be enough for scrcpy.
 #define HID_KEYBOARD_MAX_KEYS 6
-#define HID_KEYBOARD_EVENT_SIZE (2 + HID_KEYBOARD_MAX_KEYS)
+#define HID_KEYBOARD_EVENT_SIZE (HID_KEYBOARD_INDEX_KEYS + HID_KEYBOARD_MAX_KEYS)
 
 #define HID_RESERVED 0x00
 #define HID_ERROR_ROLL_OVER 0x01
@@ -240,7 +240,7 @@ sc_hid_keyboard_event_init(struct sc_hid_event *hid_event) {
 
     buffer[HID_KEYBOARD_INDEX_MODIFIER] = HID_MODIFIER_NONE;
     buffer[1] = HID_RESERVED;
-    memset(&buffer[HID_KEYBOARD_INDEX_KEYS], 0, HID_KEYBOARD_MAX_KEYS);
+    memset(buffer + HID_KEYBOARD_INDEX_KEYS, 0, HID_KEYBOARD_MAX_KEYS);
 
     sc_hid_event_init(hid_event, HID_KEYBOARD_ACCESSORY_ID, buffer,
                       HID_KEYBOARD_EVENT_SIZE);
@@ -398,9 +398,6 @@ sc_hid_keyboard_init(struct sc_hid_keyboard *kb, struct sc_aoa *aoa) {
         LOGW("Register HID keyboard failed");
         return false;
     }
-
-    // Reset all states
-    memset(kb->keys, false, SC_HID_KEYBOARD_KEYS);
 
     kb->mod_lock_synchronized = false;
 

--- a/app/src/util/strbuf.c
+++ b/app/src/util/strbuf.c
@@ -71,7 +71,7 @@ sc_strbuf_append_n(struct sc_strbuf *buf, const char c, size_t n) {
         return false;
     }
 
-    memset(&buf->s[buf->len], c, n);
+    memset(buf->s + buf->len, c, n);
     buf->len += n;
     buf->s[buf->len] = '\0';
 

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -68,7 +68,7 @@ static void test_serialize_inject_text_long(void) {
     expected[2] = 0x00;
     expected[3] = 0x01;
     expected[4] = 0x2c; // text length (32 bits)
-    memset(&expected[5], 'a', SC_CONTROL_MSG_INJECT_TEXT_MAX_LENGTH);
+    memset(expected + 5, 'a', SC_CONTROL_MSG_INJECT_TEXT_MAX_LENGTH);
 
     assert(!memcmp(buf, expected, sizeof(expected)));
 }

--- a/app/tests/test_str.c
+++ b/app/tests/test_str.c
@@ -269,21 +269,21 @@ static void test_parse_integer_with_suffix(void) {
 
     char buf[32];
 
-    sprintf(buf, "%ldk", LONG_MAX / 2000);
+    snprintf(buf, sizeof(buf), "%ldk", LONG_MAX / 2000);
     ok = sc_str_parse_integer_with_suffix(buf, &value);
     assert(ok);
     assert(value == LONG_MAX / 2000 * 1000);
 
-    sprintf(buf, "%ldm", LONG_MAX / 2000);
+    snprintf(buf, sizeof(buf), "%ldm", LONG_MAX / 2000);
     ok = sc_str_parse_integer_with_suffix(buf, &value);
     assert(!ok);
 
-    sprintf(buf, "%ldk", LONG_MIN / 2000);
+    snprintf(buf, sizeof(buf), "%ldk", LONG_MIN / 2000);
     ok = sc_str_parse_integer_with_suffix(buf, &value);
     assert(ok);
     assert(value == LONG_MIN / 2000 * 1000);
 
-    sprintf(buf, "%ldm", LONG_MIN / 2000);
+    snprintf(buf, sizeof(buf), "%ldm", LONG_MIN / 2000);
     ok = sc_str_parse_integer_with_suffix(buf, &value);
     assert(!ok);
 }


### PR DESCRIPTION
This PR also changes patterns like `memset(&a[b], ...)` to `memset(a + b, ...)` for consistency. Currently, we have the mix of both.