### PR TITLE
Fix some warnings

### DIFF
--- a/app/src/server.c
+++ b/app/src/server.c
@@ -86,14 +86,14 @@ sc_server_params_copy(struct sc_server_params *dst,
     // The params reference user-allocated memory, so we must copy them to
     // handle them from another thread
 
-#define COPY(FIELD) \
+#define COPY(FIELD) do {\
     dst->FIELD = NULL; \
     if (src->FIELD) { \
         dst->FIELD = strdup(src->FIELD); \
-        if (!dst->FIELD) { \
+        if (!dst->FIELD) \
             goto error; \
-        } \
-    }
+    } \
+} while(0)
 
     COPY(req_serial);
     COPY(crop);
@@ -215,13 +215,13 @@ execute_server(struct sc_server *server,
     cmd[count++] = SCRCPY_VERSION;
 
     unsigned dyn_idx = count; // from there, the strings are allocated
-#define ADD_PARAM(fmt, ...) { \
+#define ADD_PARAM(fmt, ...) do { \
         char *p; \
         if (asprintf(&p, fmt, ## __VA_ARGS__) == -1) { \
             goto end; \
         } \
         cmd[count++] = p; \
-    }
+    } while(0)
 
     ADD_PARAM("scid=%08x", params->scid);
     ADD_PARAM("log_level=%s", log_level_to_server_string(params->log_level));

--- a/app/src/util/vecdeque.h
+++ b/app/src/util/vecdeque.h
@@ -190,10 +190,10 @@ sc_vecdeque_reallocdata_(void *ptr, size_t newcap, size_t item_size,
 
     size_t right_len = MIN(size, oldcap - oldorigin);
     assert(right_len);
-    memcpy(newptr, ptr + (oldorigin * item_size), right_len * item_size);
+    memcpy(newptr, (char *)ptr + (oldorigin * item_size), right_len * item_size);
 
     if (size > right_len) {
-        memcpy(newptr + (right_len * item_size), ptr,
+        memcpy((char *)newptr + (right_len * item_size), ptr,
                (size - right_len) * item_size);
     }
 

--- a/app/tests/test_bytebuf.c
+++ b/app/tests/test_bytebuf.c
@@ -5,7 +5,7 @@
 
 #include "util/bytebuf.h"
 
-void test_bytebuf_simple(void) {
+static void test_bytebuf_simple(void) {
     struct sc_bytebuf buf;
     uint8_t data[20];
 
@@ -34,7 +34,7 @@ void test_bytebuf_simple(void) {
     sc_bytebuf_destroy(&buf);
 }
 
-void test_bytebuf_boundaries(void) {
+static void test_bytebuf_boundaries(void) {
     struct sc_bytebuf buf;
     uint8_t data[20];
 
@@ -71,7 +71,7 @@ void test_bytebuf_boundaries(void) {
     sc_bytebuf_destroy(&buf);
 }
 
-void test_bytebuf_two_steps_write(void) {
+static void test_bytebuf_two_steps_write(void) {
     struct sc_bytebuf buf;
     uint8_t data[20];
 


### PR DESCRIPTION
Hello!

This PR fixes some warnings like:
```
../app/src/util/vecdeque.h:193:24: warning: arithmetic on a pointer to void is a GNU extension [-Wpointer-arith]
    memcpy(newptr, ptr + (oldorigin * item_size), right_len * item_size);
                   ~~~ ^
../app/src/util/vecdeque.h:196:23: warning: arithmetic on a pointer to void is a GNU extension [-Wpointer-arith]
        memcpy(newptr + (right_len * item_size), ptr,
               ~~~~~~ ^
...
../app/src/server.c:303:45: warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
        ADD_PARAM("downsize_on_error=false");
```