### PR TITLE
Restart capture when screen resolution changes

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
@@ -7,7 +7,7 @@ import android.os.Build;
 import android.os.IBinder;
 import android.view.Surface;
 
-public class ScreenCapture extends SurfaceCapture implements Device.RotationListener, Device.FoldListener {
+public class ScreenCapture extends SurfaceCapture implements Device.DisplayChangeListener, Device.FoldListener {
 
     private final Device device;
     private IBinder display;
@@ -18,7 +18,7 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
 
     @Override
     public void init() {
-        device.setRotationListener(this);
+        device.setDisplayChangeListener(this);
         device.setFoldListener(this);
     }
 
@@ -41,7 +41,7 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
 
     @Override
     public void release() {
-        device.setRotationListener(null);
+        device.setDisplayChangeListener(null);
         device.setFoldListener(null);
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
@@ -65,7 +65,7 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
     }
 
     @Override
-    public void onRotationChanged(int rotation) {
+    public void onDisplayChanged() {
         requestReset();
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -95,22 +95,6 @@ public final class WindowManager {
         }
     }
 
-    public void registerRotationWatcher(IRotationWatcher rotationWatcher, int displayId) {
-        try {
-            Class<?> cls = manager.getClass();
-            try {
-                // display parameter added since this commit:
-                // https://android.googlesource.com/platform/frameworks/base/+/35fa3c26adcb5f6577849fd0df5228b1f67cf2c6%5E%21/#F1
-                cls.getMethod("watchRotation", IRotationWatcher.class, int.class).invoke(manager, rotationWatcher, displayId);
-            } catch (NoSuchMethodException e) {
-                // old version
-                cls.getMethod("watchRotation", IRotationWatcher.class).invoke(manager, rotationWatcher);
-            }
-        } catch (Exception e) {
-            Ln.e("Could not register rotation watcher", e);
-        }
-    }
-
     @TargetApi(29)
     public void registerDisplayFoldListener(IDisplayFoldListener foldListener) {
         try {


### PR DESCRIPTION
Fixes #1918
Fixes #161
Might affect #4152

Found this API by accident when researching https://github.com/Genymobile/scrcpy/pull/4446#issuecomment-1827164429.

Some devices have a resolution option in their Settings app, and on all devices the resolution can be changed by `adb shell wm size 1080x1920`. This event will react to both cases.

Tested on Xiaomi Mi 11 (Android 13, both system settings and `wm size`), Samsung Galaxy S9 (Android 10, both system settings and `wm size`), Onyx  BOOX Nova Pro (Android 6.0.1, only `wm size`).