### PR TITLE
Fix AV1 demuxing

### DIFF
--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -227,8 +227,9 @@ run_demuxer(void *data) {
     }
 
     // Config packets must be merged with the next non-config packet only for
-    // video streams
-    bool must_merge_config_packet = codec->type == AVMEDIA_TYPE_VIDEO;
+    // H.26x
+    bool must_merge_config_packet = raw_codec_id == SC_CODEC_ID_H264
+                                 || raw_codec_id == SC_CODEC_ID_H265;
 
     struct sc_packet_merger merger;
 


### PR DESCRIPTION
Pixel 8 devices have AV1 encoders:

```console
$ scrcpy --list-encoders
scrcpy 2.3 <https://github.com/Genymobile/scrcpy>
…
[server] INFO: Device: [Google] google Pixel 8 (Android 14)
[server] INFO: List of video encoders:
    --video-codec=h264 --video-encoder='c2.exynos.h264.encoder'
    --video-codec=h264 --video-encoder='c2.android.avc.encoder'
    --video-codec=h264 --video-encoder='OMX.google.h264.encoder'
    --video-codec=h265 --video-encoder='c2.exynos.hevc.encoder'
    --video-codec=h265 --video-encoder='c2.android.hevc.encoder'
    --video-codec=av1 --video-encoder='c2.google.av1.encoder'
    --video-codec=av1 --video-encoder='c2.android.av1.encoder'
[server] INFO: List of audio encoders:
    --audio-codec=opus --audio-encoder='c2.android.opus.encoder'
    --audio-codec=aac --audio-encoder='c2.android.aac.encoder'
    --audio-codec=aac --audio-encoder='OMX.google.aac.encoder'
    --audio-codec=flac --audio-encoder='c2.android.flac.encoder'
    --audio-codec=flac --audio-encoder='OMX.google.flac.encoder'
```

In practice, it is not very usable (unless you limit resolution and frame rate), but it is sufficient to detect that AV1 demuxing was broken:

```console
$ scrcpy --video-codec=av1
…
INFO: [FFmpeg] libdav1d 1.3.0
ERROR: [FFmpeg] Unknown OBU type 0 of size 29393
ERROR: [FFmpeg] Error parsing OBU data
ERROR: Decoder 'video': could not send video packet: -1094995529
```

For AV1, the config packet must not be merged with the next non-config packet.