### PR TITLE
Add workaround for Android U

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
@@ -94,6 +94,11 @@ public final class Workarounds {
             mustFillConfigurationController = true;
         }
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            // For Android U, some api like InputManager must use application to initilize
+            mustFillAppContext = true;
+        }
+
         if (mustFillConfigurationController) {
             // Must be call before fillAppContext() because it is necessary to get a valid system context
             fillConfigurationController();


### PR DESCRIPTION
On android U, InputManager.getInstance() calls ActivityThread.currentApplication(), which requires a non-null Application.
