### PR TITLE
Simulate tilt multitouch event by pressing Shift

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -76,6 +76,8 @@ sc_input_manager_init(struct sc_input_manager *im,
     im->sdl_shortcut_mods.count = shortcut_mods->count;
 
     im->vfinger_down = false;
+    im->vfinger_invert_x = false;
+    im->vfinger_invert_y = false;
 
     im->last_keycode = SDLK_UNKNOWN;
     im->last_mod = 0;
@@ -347,9 +349,14 @@ simulate_virtual_finger(struct sc_input_manager *im,
 }
 
 static struct sc_point
-inverse_point(struct sc_point point, struct sc_size size) {
-    point.x = size.width - point.x;
-    point.y = size.height - point.y;
+inverse_point(struct sc_point point, struct sc_size size,
+              bool invert_x, bool invert_y) {
+    if (invert_x) {
+        point.x = size.width - point.x;
+    }
+    if (invert_y) {
+        point.y = size.height - point.y;
+    }
     return point;
 }
 
@@ -605,7 +612,9 @@ sc_input_manager_process_mouse_motion(struct sc_input_manager *im,
         struct sc_point mouse =
            sc_screen_convert_window_to_frame_coords(im->screen, event->x,
                                                     event->y);
-        struct sc_point vfinger = inverse_point(mouse, im->screen->frame_size);
+        struct sc_point vfinger = inverse_point(mouse, im->screen->frame_size,
+                                                im->vfinger_invert_x,
+                                                im->vfinger_invert_y);
         simulate_virtual_finger(im, AMOTION_EVENT_ACTION_MOVE, vfinger);
     }
 }
@@ -726,7 +735,7 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
         return;
     }
 
-    // Pinch-to-zoom simulation.
+    // Pinch-to-zoom, rotate and tilt simulation.
     //
     // If Ctrl is hold when the left-click button is pressed, then
     // pinch-to-zoom mode is enabled: on every mouse event until the left-click
@@ -735,14 +744,28 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
     //
     // In other words, the center of the rotation/scaling is the center of the
     // screen.
-#define CTRL_PRESSED (SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL))
+    //
+    // To simulate a tilt gesture Shift can be used instead of Ctrl. The "virtual
+    // finger" has the x coordinate inverted through the center of the screen
+    // while the y coordinate is unchanged.
+    const SDL_Keymod keymod = SDL_GetModState();
+    const bool ctrl_pressed = keymod & KMOD_CTRL;
+    const bool shift_pressed = keymod & KMOD_SHIFT;
     if (event->button == SDL_BUTTON_LEFT &&
-            ((down && !im->vfinger_down && CTRL_PRESSED) ||
+            ((down && !im->vfinger_down &&
+              ((ctrl_pressed && !shift_pressed) ||
+               (!ctrl_pressed && shift_pressed))) ||
              (!down && im->vfinger_down))) {
         struct sc_point mouse =
             sc_screen_convert_window_to_frame_coords(im->screen, event->x,
                                                                  event->y);
-        struct sc_point vfinger = inverse_point(mouse, im->screen->frame_size);
+        if (down) {
+            im->vfinger_invert_x = ctrl_pressed || shift_pressed;
+            im->vfinger_invert_y = ctrl_pressed;
+        }
+        struct sc_point vfinger = inverse_point(mouse, im->screen->frame_size,
+                                                im->vfinger_invert_x,
+                                                im->vfinger_invert_y);
         enum android_motionevent_action action = down
                                                ? AMOTION_EVENT_ACTION_DOWN
                                                : AMOTION_EVENT_ACTION_UP;

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -32,6 +32,8 @@ struct sc_input_manager {
     } sdl_shortcut_mods;
 
     bool vfinger_down;
+    bool vfinger_invert_x;
+    bool vfinger_invert_y;
 
     // Tracks the number of identical consecutive shortcut key down events.
     // Not to be confused with event->repeat, which counts the number of

--- a/doc/control.md
+++ b/doc/control.md
@@ -85,7 +85,7 @@ way as <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd>).
 To disable automatic clipboard synchronization, use
 `--no-clipboard-autosync`.
 
-## Pinch-to-zoom
+## Pinch-to-zoom, rotate and tilt simulation
 
 To simulate "pinch-to-zoom": <kbd>Ctrl</kbd>+_click-and-move_.
 
@@ -93,8 +93,12 @@ More precisely, hold down <kbd>Ctrl</kbd> while pressing the left-click button.
 Until the left-click button is released, all mouse movements scale and rotate
 the content (if supported by the app) relative to the center of the screen.
 
+To simulate a tilt gesture: <kbd>Shift</kbd>+_click-and-move-up-or-down_.
+
 Technically, _scrcpy_ generates additional touch events from a "virtual finger"
-at a location inverted through the center of the screen.
+at a location inverted through the center of the screen. When pressing
+<kbd>Ctrl</kbd> the x and y coordinates are inverted. Using <kbd>Shift</kbd>
+only inverts x.
 
 
 ## Key repeat


### PR DESCRIPTION
I missed simulating tilt multitouch events (two fingers moving up or down) for map apps.
Here is an implementation for that.