### PR TITLE
Fix bash completion syntax

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -115,8 +115,8 @@ _scrcpy() {
             COMPREPLY=($(compgen -W 'front back external' -- "$cur"))
             return
             ;;
-        --orientation
-        --display-orientation)
+        --orientation \
+        |--display-orientation)
             COMPREPLY=($(compgen -> '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
             return
             ;;

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -117,11 +117,11 @@ _scrcpy() {
             ;;
         --orientation \
         |--display-orientation)
-            COMPREPLY=($(compgen -> '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
+            COMPREPLY=($(compgen -W '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
             return
             ;;
         --record-orientation)
-            COMPREPLY=($(compgen -> '0 90 180 270' -- "$cur"))
+            COMPREPLY=($(compgen -W '0 90 180 270' -- "$cur"))
             return
             ;;
         --lock-video-orientation)


### PR DESCRIPTION
When the `--orientation` flag was introduced [here](https://github.com/Genymobile/scrcpy/commit/b43a9e8e7a70e3b847d13eeb17ebf18708c4d7fc#diff-7b907f364b065644e30409136875f4620b346208ad9e466e92e7e9a2ca6c4a66R118) the bash-completion file also gained a syntax error which breaks completions.
