### PR TITLE
Add isolated build environment based on Docker; implements #3136

### DIFF
--- a/Dockerfile-ubuntu-20.04
+++ b/Dockerfile-ubuntu-20.04
@@ -1,0 +1,15 @@
+FROM ubuntu:focal-20220302
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq
+RUN apt-get install -qy \
+        ffmpeg libsdl2-2.0-0 adb wget \
+        gcc git pkg-config meson ninja-build libsdl2-dev \
+        libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev \
+        libusb-1.0-0 libusb-1.0-0-dev
+
+WORKDIR /src
+ENV BUILDDIR=build-auto
+
+CMD ["/src/build.sh"]

--- a/Dockerfile-ubuntu-22.04
+++ b/Dockerfile-ubuntu-22.04
@@ -1,0 +1,15 @@
+FROM ubuntu:jammy
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq
+RUN apt-get install -qy \
+        ffmpeg libsdl2-2.0-0 adb wget \
+        gcc git pkg-config meson ninja-build libsdl2-dev \
+        libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev \
+        libusb-1.0-0 libusb-1.0-0-dev
+
+WORKDIR /src
+ENV BUILDDIR=build-auto
+
+CMD ["/src/build.sh"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env sh
+# Build the current state depending on a prebuld server.
+# Rquired env paramter "BUILDDIR": target path of the build
+set -e
+set -u
+
+# fetch the prebuilt server
+PREBUILT_SERVER_URL=https://github.com/Genymobile/scrcpy/releases/download/v2.3.1/scrcpy-server-v2.3.1
+PREBUILT_SERVER_SHA256=f6814822fc308a7a532f253485c9038183c6296a6c5df470a9e383b4f8e7605b
+
+echo "[scrcpy] Downloading prebuilt server..."
+wget "$PREBUILT_SERVER_URL" -O scrcpy-server
+echo "[scrcpy] Verifying prebuilt server..."
+echo "$PREBUILT_SERVER_SHA256  scrcpy-server" | sha256sum --check
+
+echo "[scrcpy] Building client..."
+rm -rf "$BUILDDIR"
+
+# prepare the build
+meson setup "$BUILDDIR" --buildtype=release --strip -Db_lto=true \
+    -Dprebuilt_server=scrcpy-server
+
+# build
+ninja -C "$BUILDDIR"
+
+# clean up
+rm scrcpy-server

--- a/doc/linux.md
+++ b/doc/linux.md
@@ -2,6 +2,8 @@
 
 ## Install
 
+### Stable Release
+
 <a href="https://repology.org/project/scrcpy/versions"><img src="https://repology.org/badge/vertical-allrepos/scrcpy.svg" alt="Packaging status" align="right"></a>
 
 Scrcpy is packaged in several distributions and package managers:
@@ -17,6 +19,26 @@ Scrcpy is packaged in several distributions and package managers:
 
 However, the packaged version is not always the latest release. To install the
 latest release from `master`, follow this simplified process.
+
+#### Docker based
+
+Using docker allows you to build the latest state without cluttering you system with any developer packages.
+
+In an empty folder:
+
+```sh
+curl -sL "https://api.github.com/repos/Genymobile/scrcpy/tarball/master" | tar -xz --strip-components 1
+docker build -f "Dockerfile-ubuntu-22.04" -t "scrcpy/scrcpy-build-env" .
+docker run -u $UID:$(id -g ${USER}) --rm -v "$PWD:/src" "scrcpy/scrcpy-build-env"
+```
+
+Output: `./build-auto/app/scrcpy`
+
+Optional install instructions:
+
+    sudo cp build-auto/app/scrcpy /usr/local/bin/
+
+#### Native
 
 First, you need to install the required packages:
 

--- a/install_release.sh
+++ b/install_release.sh
@@ -1,21 +1,13 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
+# This script executes three steps:
+# - fetch the latest prebuild_server
+# - invoke the build script
+# - run the install process
 set -e
 
-BUILDDIR=build-auto
-PREBUILT_SERVER_URL=https://github.com/Genymobile/scrcpy/releases/download/v2.3.1/scrcpy-server-v2.3.1
-PREBUILT_SERVER_SHA256=f6814822fc308a7a532f253485c9038183c6296a6c5df470a9e383b4f8e7605b
+export BUILDDIR=build-auto
 
-echo "[scrcpy] Downloading prebuilt server..."
-wget "$PREBUILT_SERVER_URL" -O scrcpy-server
-echo "[scrcpy] Verifying prebuilt server..."
-echo "$PREBUILT_SERVER_SHA256  scrcpy-server" | sha256sum --check
-
-echo "[scrcpy] Building client..."
-rm -rf "$BUILDDIR"
-meson setup "$BUILDDIR" --buildtype=release --strip -Db_lto=true \
-    -Dprebuilt_server=scrcpy-server
-cd "$BUILDDIR"
-ninja
+./build.sh
 
 echo "[scrcpy] Installing (sudo)..."
-sudo ninja install
+sudo ninja -C "$BUILDDIR" install


### PR DESCRIPTION
So here is my approach to solve #3136.

Additional improvements:

- clean up the fetched `prebuild_server` artifact after the compilation process
- use the more lightweight `sh` instead of `bash` in the shell scripts

Usage instructions are documented in `docs/linux.sh`.

Let me know what you think.