### PR TITLE
Add a missing separator between patterns

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -115,8 +115,7 @@ _scrcpy() {
             COMPREPLY=($(compgen -W 'front back external' -- "$cur"))
             return
             ;;
-        --orientation
-        --display-orientation)
+        --orientation|--display-orientation)
             COMPREPLY=($(compgen -> '0 90 180 270 flip0 flip90 flip180 flip270' -- "$cur"))
             return
             ;;


### PR DESCRIPTION
Without this change the bash-completion script produces the following error:
```
bash: /usr/local/etc/bash_completion.d/scrcpy: line 118: syntax error near unexpected token `newline'
bash: /usr/local/etc/bash_completion.d/scrcpy: line 118: `        --orientation'
```