### PR TITLE
Force fullscreen when using the KMSDRM video driver

### DIFF
--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -661,6 +661,7 @@ void
 sc_screen_switch_fullscreen(struct sc_screen *screen) {
     if (screen->is_kmsdrm && screen->fullscreen) {
         LOGD("Ignored mode switch");
+        return;
     }
 
     uint32_t new_mode = screen->fullscreen ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -362,12 +362,14 @@ sc_screen_init(struct sc_screen *screen,
     screen->maximized = false;
     screen->minimized = false;
     screen->mouse_capture_key_pressed = 0;
+    screen->is_kmsdrm = strcmp(SDL_GetCurrentVideoDriver(), "KMSDRM") == 0;
 
     screen->req.x = params->window_x;
     screen->req.y = params->window_y;
     screen->req.width = params->window_width;
     screen->req.height = params->window_height;
-    screen->req.fullscreen = params->fullscreen;
+    // The kmsdrm video driver switches to a low resolution on "windowed" mode
+    screen->req.fullscreen = screen->is_kmsdrm ? true : params->fullscreen;
     screen->req.start_fps_counter = params->start_fps_counter;
 
     bool ok = sc_frame_buffer_init(&screen->fb);
@@ -657,6 +659,10 @@ sc_screen_update_frame(struct sc_screen *screen) {
 
 void
 sc_screen_switch_fullscreen(struct sc_screen *screen) {
+    if (screen->is_kmsdrm && screen->fullscreen) {
+        LOGD("Ignored mode switch");
+    }
+
     uint32_t new_mode = screen->fullscreen ? 0 : SDL_WINDOW_FULLSCREEN_DESKTOP;
     if (SDL_SetWindowFullscreen(screen->window, new_mode)) {
         LOGW("Could not switch fullscreen mode: %s", SDL_GetError());

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -58,6 +58,7 @@ struct sc_screen {
     bool fullscreen;
     bool maximized;
     bool minimized;
+    bool is_kmsdrm;
 
     // To enable/disable mouse capture, a mouse capture key (LALT, LGUI or
     // RGUI) must be pressed. This variable tracks the pressed capture key.


### PR DESCRIPTION
When running from a virtual console on a Raspberry Pi Zero 2W, SDL will use the KMSDRM video driver. Without any extra options, it automatically switches to ~800x600~ 640x480, while the `--fullscreen` flag keeps the current resolution.

This patch automatically enables fullscreen (and prevents it from being disabled) if the KMSDRM driver is used.

PS: I couldn't test on other systems at the moment, so I'd also like some help in testing whether this behavior is present on other systems and whether this patch fixes it.