### PR TITLE
Configure clean up actions dynamically

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -1,11 +1,8 @@
 package com.genymobile.scrcpy;
 
-import android.os.Parcel;
-import android.os.Parcelable;
-import android.util.Base64;
-
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Handle the cleanup of scrcpy, even if the main process is killed.
@@ -14,127 +11,59 @@ import java.io.IOException;
  */
 public final class CleanUp {
 
-    // A simple struct to be passed from the main process to the cleanup process
-    public static class Config implements Parcelable {
+    private static final int MSG_TYPE_MASK = 0b11;
+    private static final int MSG_TYPE_RESTORE_STAY_ON = 0;
+    private static final int MSG_TYPE_DISABLE_SHOW_TOUCHES = 1;
+    private static final int MSG_TYPE_RESTORE_NORMAL_POWER_MODE = 2;
+    private static final int MSG_TYPE_POWER_OFF_SCREEN = 3;
 
-        public static final Creator<Config> CREATOR = new Creator<Config>() {
-            @Override
-            public Config createFromParcel(Parcel in) {
-                return new Config(in);
-            }
+    private static final int MSG_PARAM_SHIFT = 2;
 
-            @Override
-            public Config[] newArray(int size) {
-                return new Config[size];
-            }
-        };
+    private final OutputStream out;
 
-        private static final int FLAG_DISABLE_SHOW_TOUCHES = 1;
-        private static final int FLAG_RESTORE_NORMAL_POWER_MODE = 2;
-        private static final int FLAG_POWER_OFF_SCREEN = 4;
-
-        private int displayId;
-
-        // Restore the value (between 0 and 7), -1 to not restore
-        // <https://developer.android.com/reference/android/provider/Settings.Global#STAY_ON_WHILE_PLUGGED_IN>
-        private int restoreStayOn = -1;
-
-        private boolean disableShowTouches;
-        private boolean restoreNormalPowerMode;
-        private boolean powerOffScreen;
-
-        public Config() {
-            // Default constructor, the fields are initialized by CleanUp.configure()
-        }
-
-        protected Config(Parcel in) {
-            displayId = in.readInt();
-            restoreStayOn = in.readInt();
-            byte options = in.readByte();
-            disableShowTouches = (options & FLAG_DISABLE_SHOW_TOUCHES) != 0;
-            restoreNormalPowerMode = (options & FLAG_RESTORE_NORMAL_POWER_MODE) != 0;
-            powerOffScreen = (options & FLAG_POWER_OFF_SCREEN) != 0;
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            dest.writeInt(displayId);
-            dest.writeInt(restoreStayOn);
-            byte options = 0;
-            if (disableShowTouches) {
-                options |= FLAG_DISABLE_SHOW_TOUCHES;
-            }
-            if (restoreNormalPowerMode) {
-                options |= FLAG_RESTORE_NORMAL_POWER_MODE;
-            }
-            if (powerOffScreen) {
-                options |= FLAG_POWER_OFF_SCREEN;
-            }
-            dest.writeByte(options);
-        }
-
-        private boolean hasWork() {
-            return disableShowTouches || restoreStayOn != -1 || restoreNormalPowerMode || powerOffScreen;
-        }
-
-        @Override
-        public int describeContents() {
-            return 0;
-        }
-
-        byte[] serialize() {
-            Parcel parcel = Parcel.obtain();
-            writeToParcel(parcel, 0);
-            byte[] bytes = parcel.marshall();
-            parcel.recycle();
-            return bytes;
-        }
-
-        static Config deserialize(byte[] bytes) {
-            Parcel parcel = Parcel.obtain();
-            parcel.unmarshall(bytes, 0, bytes.length);
-            parcel.setDataPosition(0);
-            return CREATOR.createFromParcel(parcel);
-        }
-
-        static Config fromBase64(String base64) {
-            byte[] bytes = Base64.decode(base64, Base64.NO_WRAP);
-            return deserialize(bytes);
-        }
-
-        String toBase64() {
-            byte[] bytes = serialize();
-            return Base64.encodeToString(bytes, Base64.NO_WRAP);
-        }
+    public CleanUp(OutputStream out) {
+        this.out = out;
     }
 
-    private CleanUp() {
-        // not instantiable
-    }
-
-    public static void configure(int displayId, int restoreStayOn, boolean disableShowTouches, boolean restoreNormalPowerMode, boolean powerOffScreen)
-            throws IOException {
-        Config config = new Config();
-        config.displayId = displayId;
-        config.disableShowTouches = disableShowTouches;
-        config.restoreStayOn = restoreStayOn;
-        config.restoreNormalPowerMode = restoreNormalPowerMode;
-        config.powerOffScreen = powerOffScreen;
-
-        if (config.hasWork()) {
-            startProcess(config);
-        } else {
-            // There is no additional clean up to do when scrcpy dies
-            unlinkSelf();
-        }
-    }
-
-    private static void startProcess(Config config) throws IOException {
-        String[] cmd = {"app_process", "/", CleanUp.class.getName(), config.toBase64()};
+    public static CleanUp configure(int displayId) throws IOException {
+        String[] cmd = {"app_process", "/", CleanUp.class.getName(), String.valueOf(displayId)};
 
         ProcessBuilder builder = new ProcessBuilder(cmd);
         builder.environment().put("CLASSPATH", Server.SERVER_PATH);
-        builder.start();
+        Process process = builder.start();
+        return new CleanUp(process.getOutputStream());
+    }
+
+    private boolean sendMessage(int type, int param) {
+        assert (type & ~MSG_TYPE_MASK) == 0;
+        int msg = type | param << MSG_PARAM_SHIFT;
+        try {
+            out.write(msg);
+            out.flush();
+            return true;
+        } catch (IOException e) {
+            Ln.w("Could not configure cleanup (type=" + type + ", param=" + param + ")", e);
+            return false;
+        }
+    }
+
+    public boolean setRestoreStayOn(int restoreValue) {
+        // Restore the value (between 0 and 7), -1 to not restore
+        // <https://developer.android.com/reference/android/provider/Settings.Global#STAY_ON_WHILE_PLUGGED_IN>
+        assert restoreValue >= -1 && restoreValue <= 7;
+        return sendMessage(MSG_TYPE_RESTORE_STAY_ON, restoreValue & 0b1111);
+    }
+
+    public boolean setDisableShowTouches(boolean disableOnExit) {
+        return sendMessage(MSG_TYPE_DISABLE_SHOW_TOUCHES, disableOnExit ? 1 : 0);
+    }
+
+    public boolean setRestoreNormalPowerMode(boolean restoreOnExit) {
+        return sendMessage(MSG_TYPE_RESTORE_NORMAL_POWER_MODE, restoreOnExit ? 1 : 0);
+    }
+
+    public boolean setPowerOffScreen(boolean powerOffScreenOnExit) {
+        return sendMessage(MSG_TYPE_POWER_OFF_SCREEN, powerOffScreenOnExit ? 1 : 0);
     }
 
     public static void unlinkSelf() {
@@ -148,41 +77,66 @@ public final class CleanUp {
     public static void main(String... args) {
         unlinkSelf();
 
+        int displayId = Integer.parseInt(args[0]);
+
+        int restoreStayOn = -1;
+        boolean disableShowTouches = false;
+        boolean restoreNormalPowerMode = false;
+        boolean powerOffScreen = false;
+
         try {
             // Wait for the server to die
-            System.in.read();
+            int msg;
+            while ((msg = System.in.read()) != -1) {
+                int type = msg & MSG_TYPE_MASK;
+                int param = msg >> MSG_PARAM_SHIFT;
+                switch (type) {
+                    case MSG_TYPE_RESTORE_STAY_ON:
+                        restoreStayOn = param > 7 ? -1 : param;
+                        break;
+                    case MSG_TYPE_DISABLE_SHOW_TOUCHES:
+                        disableShowTouches = param != 0;
+                        break;
+                    case MSG_TYPE_RESTORE_NORMAL_POWER_MODE:
+                        restoreNormalPowerMode = param != 0;
+                        break;
+                    case MSG_TYPE_POWER_OFF_SCREEN:
+                        powerOffScreen = param != 0;
+                        break;
+                    default:
+                        Ln.w("Unexpected msg type: " + type);
+                        break;
+                }
+            }
         } catch (IOException e) {
             // Expected when the server is dead
         }
 
         Ln.i("Cleaning up");
 
-        Config config = Config.fromBase64(args[0]);
-
-        if (config.disableShowTouches || config.restoreStayOn != -1) {
-            if (config.disableShowTouches) {
-                Ln.i("Disabling \"show touches\"");
-                try {
-                    Settings.putValue(Settings.TABLE_SYSTEM, "show_touches", "0");
-                } catch (SettingsException e) {
-                    Ln.e("Could not restore \"show_touches\"", e);
-                }
+        if (disableShowTouches) {
+            Ln.i("Disabling \"show touches\"");
+            try {
+                Settings.putValue(Settings.TABLE_SYSTEM, "show_touches", "0");
+            } catch (SettingsException e) {
+                Ln.e("Could not restore \"show_touches\"", e);
             }
-            if (config.restoreStayOn != -1) {
-                Ln.i("Restoring \"stay awake\"");
-                try {
-                    Settings.putValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(config.restoreStayOn));
-                } catch (SettingsException e) {
-                    Ln.e("Could not restore \"stay_on_while_plugged_in\"", e);
-                }
+        }
+
+        if (restoreStayOn != -1) {
+            Ln.i("Restoring \"stay awake\"");
+            try {
+                Settings.putValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(restoreStayOn));
+            } catch (SettingsException e) {
+                Ln.e("Could not restore \"stay_on_while_plugged_in\"", e);
             }
         }
 
         if (Device.isScreenOn()) {
-            if (config.powerOffScreen) {
+            if (powerOffScreen) {
                 Ln.i("Power off screen");
-                Device.powerOffScreen(config.displayId);
-            } else if (config.restoreNormalPowerMode) {
+                Device.powerOffScreen(displayId);
+            } else if (restoreNormalPowerMode) {
                 Ln.i("Restoring normal power mode");
                 Device.setScreenPowerMode(Device.POWER_MODE_NORMAL);
             }

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -28,6 +28,7 @@ public class Controller implements AsyncProcessor {
 
     private final Device device;
     private final DesktopConnection connection;
+    private final CleanUp cleanUp;
     private final DeviceMessageSender sender;
     private final boolean clipboardAutosync;
     private final boolean powerOn;
@@ -41,9 +42,10 @@ public class Controller implements AsyncProcessor {
 
     private boolean keepPowerModeOff;
 
-    public Controller(Device device, DesktopConnection connection, boolean clipboardAutosync, boolean powerOn) {
+    public Controller(Device device, DesktopConnection connection, CleanUp cleanUp, boolean clipboardAutosync, boolean powerOn) {
         this.device = device;
         this.connection = connection;
+        this.cleanUp = cleanUp;
         this.clipboardAutosync = clipboardAutosync;
         this.powerOn = powerOn;
         initPointers();
@@ -170,6 +172,10 @@ public class Controller implements AsyncProcessor {
                     if (setPowerModeOk) {
                         keepPowerModeOff = mode == Device.POWER_MODE_OFF;
                         Ln.i("Device screen turned " + (mode == Device.POWER_MODE_OFF ? "off" : "on"));
+                        if (cleanUp != null) {
+                            boolean mustRestoreOnExit = mode != Device.POWER_MODE_NORMAL;
+                            cleanUp.setRestoreNormalPowerMode(mustRestoreOnExit);
+                        }
                     }
                 }
                 break;

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -51,46 +51,47 @@ public final class Server {
         // not instantiable
     }
 
-    private static void initAndCleanUp(Options options) {
-        boolean mustDisableShowTouchesOnCleanUp = false;
-        int restoreStayOn = -1;
-        boolean restoreNormalPowerMode = options.getControl(); // only restore power mode if control is enabled
-        if (options.getShowTouches() || options.getStayAwake()) {
-            if (options.getShowTouches()) {
-                try {
-                    String oldValue = Settings.getAndPutValue(Settings.TABLE_SYSTEM, "show_touches", "1");
-                    // If "show touches" was disabled, it must be disabled back on clean up
-                    mustDisableShowTouchesOnCleanUp = !"1".equals(oldValue);
-                } catch (SettingsException e) {
-                    Ln.e("Could not change \"show_touches\"", e);
-                }
-            }
+    private static void initAndCleanUp(Options options, CleanUp cleanUp) {
+        // This method is called from its own thread, so it may only configure cleanup actions which are NOT dynamic (i.e. they are configured once
+        // and for all, they cannot be changed from another thread)
 
-            if (options.getStayAwake()) {
-                int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB | BatteryManager.BATTERY_PLUGGED_WIRELESS;
-                try {
-                    String oldValue = Settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
-                    try {
-                        restoreStayOn = Integer.parseInt(oldValue);
-                        if (restoreStayOn == stayOn) {
-                            // No need to restore
-                            restoreStayOn = -1;
-                        }
-                    } catch (NumberFormatException e) {
-                        restoreStayOn = 0;
+        if (options.getShowTouches()) {
+            try {
+                String oldValue = Settings.getAndPutValue(Settings.TABLE_SYSTEM, "show_touches", "1");
+                // If "show touches" was disabled, it must be disabled back on clean up
+                if (!"1".equals(oldValue)) {
+                    if (!cleanUp.setDisableShowTouches(true)) {
+                        Ln.e("Could not disable show touch on exit");
                     }
-                } catch (SettingsException e) {
-                    Ln.e("Could not change \"stay_on_while_plugged_in\"", e);
                 }
+            } catch (SettingsException e) {
+                Ln.e("Could not change \"show_touches\"", e);
             }
         }
 
-        if (options.getCleanup()) {
+        if (options.getStayAwake()) {
+            int stayOn = BatteryManager.BATTERY_PLUGGED_AC | BatteryManager.BATTERY_PLUGGED_USB | BatteryManager.BATTERY_PLUGGED_WIRELESS;
             try {
-                CleanUp.configure(options.getDisplayId(), restoreStayOn, mustDisableShowTouchesOnCleanUp, restoreNormalPowerMode,
-                        options.getPowerOffScreenOnClose());
-            } catch (IOException e) {
-                Ln.e("Could not configure cleanup", e);
+                String oldValue = Settings.getAndPutValue(Settings.TABLE_GLOBAL, "stay_on_while_plugged_in", String.valueOf(stayOn));
+                try {
+                    int restoreStayOn = Integer.parseInt(oldValue);
+                    if (restoreStayOn != stayOn) {
+                        // Restore only if the current value is different
+                        if (!cleanUp.setRestoreStayOn(restoreStayOn)) {
+                            Ln.e("Could not restore stay on on exit");
+                        }
+                    }
+                } catch (NumberFormatException e) {
+                    // ignore
+                }
+            } catch (SettingsException e) {
+                Ln.e("Could not change \"stay_on_while_plugged_in\"", e);
+            }
+        }
+
+        if (options.getPowerOffScreenOnClose()) {
+            if (!cleanUp.setPowerOffScreen(true)) {
+                Ln.e("Could not power off screen on exit");
             }
         }
     }
@@ -101,7 +102,13 @@ public final class Server {
             throw new ConfigurationException("Camera mirroring is not supported");
         }
 
-        Thread initThread = startInitThread(options);
+        CleanUp cleanUp = null;
+        Thread initThread = null;
+
+        if (options.getCleanup()) {
+            cleanUp = CleanUp.configure(options.getDisplayId());
+            initThread = startInitThread(options, cleanUp);
+        }
 
         int scid = options.getScid();
         boolean tunnelForward = options.isTunnelForward();
@@ -124,7 +131,7 @@ public final class Server {
             }
 
             if (control) {
-                Controller controller = new Controller(device, connection, options.getClipboardAutosync(), options.getPowerOn());
+                Controller controller = new Controller(device, connection, cleanUp, options.getClipboardAutosync(), options.getPowerOn());
                 device.setClipboardListener(text -> controller.getSender().pushClipboardText(text));
                 asyncProcessors.add(controller);
             }
@@ -167,7 +174,9 @@ public final class Server {
 
             completion.await();
         } finally {
-            initThread.interrupt();
+            if (initThread != null) {
+                initThread.interrupt();
+            }
             for (AsyncProcessor asyncProcessor : asyncProcessors) {
                 asyncProcessor.stop();
             }
@@ -175,7 +184,9 @@ public final class Server {
             connection.shutdown();
 
             try {
-                initThread.join();
+                if (initThread != null) {
+                    initThread.join();
+                }
                 for (AsyncProcessor asyncProcessor : asyncProcessors) {
                     asyncProcessor.join();
                 }
@@ -187,8 +198,8 @@ public final class Server {
         }
     }
 
-    private static Thread startInitThread(final Options options) {
-        Thread thread = new Thread(() -> initAndCleanUp(options), "init-cleanup");
+    private static Thread startInitThread(final Options options, final CleanUp cleanUp) {
+        Thread thread = new Thread(() -> initAndCleanUp(options, cleanUp), "init-cleanup");
         thread.start();
         return thread;
     }


### PR DESCRIPTION
Some actions may be performed when scrcpy exits, currently:
 - disable "show touches"
 - restore "stay on while plugged in"
 - power off screen
 - restore "power mode" (to disable "turn screen off")

They are performed from a separate process so that they can be executed even when scrcpy-server is killed (e.g. if the device is unplugged).

The clean up actions to perform were configured when scrcpy started. Given that there is no method to read the current "power mode" in Android, and that "turn screen off" can be applied at any time using an scrcpy shortcut, there was no way to determine if "power mode" had to be restored on exit. Therefore, it was always restored to "normal", even when not necessary.

However, setting the "power mode" is quite fragile on some devices, and may cause some issues, so it is preferable to call it only when necessary (when "turn screen off" has actually been called).

For that purpose, make the scrcpy-server main process and the clean up process communicate the actions to perform over the stdout/stdin, so that they can be changed dynamically. In particular, when the power mode is changed at runtime, notify the clean up process.

Refs 1beec99f8283713b1fbf0b3704eb4dceecc9a590
Refs #4456
Refs #4624