### PR TITLE
Add the VirtualDisplay method to fix the SurfaceControl API changes.

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -1,5 +1,8 @@
 package com.genymobile.scrcpy.wrappers;
 
+import android.hardware.display.VirtualDisplay;
+import android.view.Display;
+import android.view.Surface;
 import com.genymobile.scrcpy.Command;
 import com.genymobile.scrcpy.DisplayInfo;
 import com.genymobile.scrcpy.Ln;
@@ -8,6 +11,7 @@ import com.genymobile.scrcpy.Size;
 import android.view.Display;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -85,6 +89,16 @@ public final class DisplayManager {
         } catch (Exception e) {
             throw new AssertionError(e);
         }
+    }
+
+    public static VirtualDisplay createVirtualDisplay(String name, int width, int height,
+            int displayIdToMirror, Surface surface)
+        throws ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        java.lang.Class<?> displayManagerClass =
+            java.lang.Class.forName("android.hardware.display.DisplayManager");
+        return (VirtualDisplay) displayManagerClass.getMethod("createVirtualDisplay",
+            String.class, int.class, int.class, int.class, Surface.class)
+            .invoke(null, name, width, height, displayIdToMirror, surface);
     }
 
     public int[] getDisplayIds() {

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/MediaProjectionGlobal.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/MediaProjectionGlobal.java
@@ -1,0 +1,67 @@
+package com.genymobile.scrcpy.wrappers;
+
+import android.hardware.display.VirtualDisplay;
+import android.view.Surface;
+import com.genymobile.scrcpy.Ln;
+import java.lang.reflect.Method;
+import android.os.Build;
+
+/**
+ * A wrapper for system API android.media.projection.MediaProjectionGlobal.
+ */
+public final class MediaProjectionGlobal {
+
+  private static java.lang.Class<?> MediaProjectionGlobalClass;
+  private static Method getInstanceMethod;
+  private static Method createVirtualDisplayMethod;
+
+  static {
+    try {
+      MediaProjectionGlobalClass = java.lang.Class.forName("android.media.projection.MediaProjectionGlobal");
+    } catch (ClassNotFoundException e) {
+      MediaProjectionGlobalClass = null;
+    }
+  }
+
+  private static Method getGetInstanceMethod() throws NoSuchMethodException {
+    if (MediaProjectionGlobalClass == null) {
+      throw new NullPointerException("MediaProjectionGlobalClass is null");
+    }
+    if (getInstanceMethod == null) {
+      getInstanceMethod = MediaProjectionGlobalClass.getMethod("getInstance");
+    }
+    return getInstanceMethod;
+  }
+
+  // String name, int width, int height, int displayIdToMirror
+  private static Method getCreateVirtualDisplayMethod() throws NoSuchMethodException {
+    if (MediaProjectionGlobalClass == null) {
+      throw new NullPointerException("MediaProjectionGlobalClass is null");
+    }
+    if (createVirtualDisplayMethod == null) {
+      createVirtualDisplayMethod =
+          MediaProjectionGlobalClass.getMethod(
+              "createVirtualDisplay", String.class, int.class, int.class, int.class, Surface.class);
+    }
+    return createVirtualDisplayMethod;
+  }
+
+  public static VirtualDisplay createVirtualDisplay(
+      String name, int width, int height, int displayIdToMirror, Surface surface)
+      throws NoSuchMethodException {
+    try {
+      Object instance = getGetInstanceMethod().invoke(null);
+      if (instance == null) {
+        Ln.e("instance == null!");
+      }
+      return (VirtualDisplay)
+          getCreateVirtualDisplayMethod()
+              .invoke(instance, name, width, height, displayIdToMirror, surface);
+    } catch (ReflectiveOperationException e) {
+      Ln.e("Could not invoke method", e);
+      return null;
+    }
+  }
+
+  private MediaProjectionGlobal() {}
+}


### PR DESCRIPTION
[#4646 ](https://github.com/Genymobile/scrcpy/issues/4646)

Use DisplayManager to create VirtualDisplay object replace origin SurfaceControl method.
Add the MediaProjectionGlobal workaround for some transitional version Android ROM.