### PR TITLE
fix freeze and thaw rotation for Android 15 preview

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -60,8 +60,8 @@ public final class WindowManager {
     }
 
     // Android 15 preview and 14 QPR3 Beta introduces a new signature for freeze and thaw rotation
-    // methods which includes a String parameters:
-    // public void android.view.IWindowManager$Stub$Proxy.freezeDisplayRotation(int,int,java.lang.String) throws android.os.RemoteException
+    // methods which includes a String caller parameter for debugging:
+    // <https://android.googlesource.com/platform/frameworks/base/+/670fb7f5c0d23cf51ead25538bcb017e03ed73ac%5E%21/>
     private Method getFreezeDisplayRotationStringMethod() throws NoSuchMethodException {
         if (freezeDisplayRotationMethod == null) {
             freezeDisplayRotationMethod = manager.getClass().getMethod("freezeDisplayRotation", int.class, int.class, String.class);
@@ -102,8 +102,8 @@ public final class WindowManager {
     }
 
     // Android 15 preview and 14 QPR3 Beta introduces a new signature for freeze and thaw rotation
-    // methods which includes a String parameters:
-    // public void android.view.IWindowManager$Stub$Proxy.thawDisplayRotation(int,java.lang.String) throws android.os.RemoteException
+    // methods which includes a String caller parameter for debugging:
+    // <https://android.googlesource.com/platform/frameworks/base/+/670fb7f5c0d23cf51ead25538bcb017e03ed73ac%5E%21/>
     private Method getThawDisplayRotationStringMethod() throws NoSuchMethodException {
         if (thawDisplayRotationMethod == null) {
             thawDisplayRotationMethod = manager.getClass().getMethod("thawDisplayRotation", int.class, String.class);
@@ -126,8 +126,7 @@ public final class WindowManager {
             try {
                 try {
                     Method method = getFreezeDisplayRotationStringMethod();
-                    // TODO: specify the String param once we know what it is for
-                    method.invoke(manager, displayId, rotation, "");
+                    method.invoke(manager, displayId, rotation, "scrcpy#freezeRotation");
                 } catch (ReflectiveOperationException e) {
                     Method method = getFreezeDisplayRotationMethod();
                     method.invoke(manager, displayId, rotation);
@@ -170,8 +169,7 @@ public final class WindowManager {
             try {
                 try {
                     Method method = getThawDisplayRotationStringMethod();
-                    // TODO: specify the String param once we know what it is for
-                    method.invoke(manager, displayId, "");
+                    method.invoke(manager, displayId, "scrcpy#thawRotation");
                 } catch (ReflectiveOperationException e) {
                     Method method = getThawDisplayRotationMethod();
                     method.invoke(manager, displayId);

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -59,6 +59,16 @@ public final class WindowManager {
         return freezeDisplayRotationMethod;
     }
 
+    // Android 15 preview and 14 QPR3 Beta introduces a new signature for freeze and thaw rotation
+    // methods which includes a String parameters:
+    // public void android.view.IWindowManager$Stub$Proxy.freezeDisplayRotation(int,int,java.lang.String) throws android.os.RemoteException
+    private Method getFreezeDisplayRotationStringMethod() throws NoSuchMethodException {
+        if (freezeDisplayRotationMethod == null) {
+            freezeDisplayRotationMethod = manager.getClass().getMethod("freezeDisplayRotation", int.class, int.class, String.class);
+        }
+        return freezeDisplayRotationMethod;
+    }
+
     private Method getIsRotationFrozenMethod() throws NoSuchMethodException {
         if (isRotationFrozenMethod == null) {
             isRotationFrozenMethod = manager.getClass().getMethod("isRotationFrozen");
@@ -91,6 +101,16 @@ public final class WindowManager {
         return thawDisplayRotationMethod;
     }
 
+    // Android 15 preview and 14 QPR3 Beta introduces a new signature for freeze and thaw rotation
+    // methods which includes a String parameters:
+    // public void android.view.IWindowManager$Stub$Proxy.thawDisplayRotation(int,java.lang.String) throws android.os.RemoteException
+    private Method getThawDisplayRotationStringMethod() throws NoSuchMethodException {
+        if (thawDisplayRotationMethod == null) {
+            thawDisplayRotationMethod = manager.getClass().getMethod("thawDisplayRotation", int.class, String.class);
+        }
+        return thawDisplayRotationMethod;
+    }
+
     public int getRotation() {
         try {
             Method method = getGetRotationMethod();
@@ -104,8 +124,14 @@ public final class WindowManager {
     public void freezeRotation(int displayId, int rotation) {
         try {
             try {
-                Method method = getFreezeDisplayRotationMethod();
-                method.invoke(manager, displayId, rotation);
+                try {
+                    Method method = getFreezeDisplayRotationStringMethod();
+                    // TODO: specify the String param once we know what it is for
+                    method.invoke(manager, displayId, rotation, "");
+                } catch (ReflectiveOperationException e) {
+                    Method method = getFreezeDisplayRotationMethod();
+                    method.invoke(manager, displayId, rotation);
+                }
             } catch (ReflectiveOperationException e) {
                 if (displayId == 0) {
                     Method method = getFreezeRotationMethod();
@@ -142,8 +168,14 @@ public final class WindowManager {
     public void thawRotation(int displayId) {
         try {
             try {
-                Method method = getThawDisplayRotationMethod();
-                method.invoke(manager, displayId);
+                try {
+                    Method method = getThawDisplayRotationStringMethod();
+                    // TODO: specify the String param once we know what it is for
+                    method.invoke(manager, displayId, "");
+                } catch (ReflectiveOperationException e) {
+                    Method method = getThawDisplayRotationMethod();
+                    method.invoke(manager, displayId);
+                }
             } catch (ReflectiveOperationException e) {
                 if (displayId == 0) {
                     Method method = getThawRotationMethod();


### PR DESCRIPTION
On a device with Android 15 developer preview (and I think this also impacts the 14 QPR3 Beta) we get an error when trying to rotate the device:
```
scrcpy 2.3.1 <https://github.com/Genymobile/scrcpy>
INFO: ADB device found:
INFO:     --> (tcpip)  26101FDF6003UC           device  Pixel_6
x/server/scrcpy-server: 1 file pushed, 0 skipped. 3.1 MB/s (66691 bytes in 0.020s)
[server] INFO: Device: [Google] google Pixel 6 (Android 14)
INFO: Renderer: metal
INFO: Texture: 360x800
[server] INFO: Device rotation requested: landscape
[server] ERROR: Could not invoke method
java.lang.NoSuchMethodException: android.view.IWindowManager$Stub$Proxy.freezeRotation [int]
        at java.lang.Class.getMethod(Class.java:2950)
        at java.lang.Class.getMethod(Class.java:2450)
        at com.genymobile.scrcpy.wrappers.WindowManager.getFreezeRotationMethod(WindowManager.java:48)
        at com.genymobile.scrcpy.wrappers.WindowManager.freezeRotation(WindowManager.java:111)
        at com.genymobile.scrcpy.Device.rotateDevice(Device.java:372)
        at com.genymobile.scrcpy.Controller.handleEvent(Controller.java:183)
        at com.genymobile.scrcpy.Controller.control(Controller.java:85)
        at com.genymobile.scrcpy.Controller.lambda$start$0$com-genymobile-scrcpy-Controller(Controller.java:93)
        at com.genymobile.scrcpy.Controller$$ExternalSyntheticLambda1.run(Unknown Source:4)
        at java.lang.Thread.run(Thread.java:1012)
```

The source code is not out yet, but using reflection we can see that the freeze and thaw rotation methods all have a new signature with a `String` parameter added:

```
public void android.view.IWindowManager$Stub$Proxy.thawRotation(java.lang.String) throws android.os.RemoteException
public void android.view.IWindowManager$Stub$Proxy.thawDisplayRotation(int,java.lang.String) throws android.os.RemoteException
public void android.view.IWindowManager$Stub$Proxy.freezeRotation(int,java.lang.String) throws android.os.RemoteException
public void android.view.IWindowManager$Stub$Proxy.freezeDisplayRotation(int,int,java.lang.String) throws android.os.RemoteException
```

I tried passing an empty String and it works.

This PR adds these new method signatures to try first.