### PR TITLE
Simplify/restrict shortcut mods

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -424,9 +424,9 @@ Turn the device screen off immediately.
 .BI "\-\-shortcut\-mod " key\fR[+...]][,...]
 Specify the modifiers to use for scrcpy shortcuts. Possible keys are "lctrl", "rctrl", "lalt", "ralt", "lsuper" and "rsuper".
 
-A shortcut can consist in several keys, separated by '+'. Several shortcuts can be specified, separated by ','.
+Several shortcut modifiers can be specified, separated by ','.
 
-For example, to use either LCtrl+LAlt or LSuper for scrcpy shortcuts, pass "lctrl+lalt,lsuper".
+For example, to use either LCtrl or LSuper for scrcpy shortcuts, pass "lctrl,lsuper".
 
 Default is "lalt,lsuper" (left-Alt or left-Super).
 

--- a/app/src/cli.h
+++ b/app/src/cli.h
@@ -28,7 +28,7 @@ scrcpy_parse_args(struct scrcpy_cli_args *args, int argc, char *argv[]);
 
 #ifdef SC_TEST
 bool
-sc_parse_shortcut_mods(const char *s, struct sc_shortcut_mods *mods);
+sc_parse_shortcut_mods(const char *s, uint8_t *shortcut_mods);
 #endif
 
 #endif

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -10,7 +10,7 @@
 #define SC_SDL_SHORTCUT_MODS_MASK (KMOD_CTRL | KMOD_ALT | KMOD_GUI)
 
 static inline uint16_t
-to_sdl_mod(unsigned shortcut_mod) {
+to_sdl_mod(uint8_t shortcut_mod) {
     uint16_t sdl_mod = 0;
     if (shortcut_mod & SC_SHORTCUT_MOD_LCTRL) {
         sdl_mod |= KMOD_LCTRL;
@@ -38,15 +38,8 @@ is_shortcut_mod(struct sc_input_manager *im, uint16_t sdl_mod) {
     // keep only the relevant modifier keys
     sdl_mod &= SC_SDL_SHORTCUT_MODS_MASK;
 
-    assert(im->sdl_shortcut_mods.count);
-    assert(im->sdl_shortcut_mods.count < SC_MAX_SHORTCUT_MODS);
-    for (unsigned i = 0; i < im->sdl_shortcut_mods.count; ++i) {
-        if (im->sdl_shortcut_mods.data[i] == sdl_mod) {
-            return true;
-        }
-    }
-
-    return false;
+    // at least one shortcut mod pressed?
+    return sdl_mod & im->sdl_shortcut_mods;
 }
 
 void
@@ -68,15 +61,7 @@ sc_input_manager_init(struct sc_input_manager *im,
     im->legacy_paste = params->legacy_paste;
     im->clipboard_autosync = params->clipboard_autosync;
 
-    const struct sc_shortcut_mods *shortcut_mods = params->shortcut_mods;
-    assert(shortcut_mods->count);
-    assert(shortcut_mods->count < SC_MAX_SHORTCUT_MODS);
-    for (unsigned i = 0; i < shortcut_mods->count; ++i) {
-        uint16_t sdl_mod = to_sdl_mod(shortcut_mods->data[i]);
-        assert(sdl_mod);
-        im->sdl_shortcut_mods.data[i] = sdl_mod;
-    }
-    im->sdl_shortcut_mods.count = shortcut_mods->count;
+    im->sdl_shortcut_mods = to_sdl_mod(params->shortcut_mods);
 
     im->vfinger_down = false;
     im->vfinger_invert_x = false;

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -26,10 +26,7 @@ struct sc_input_manager {
     bool legacy_paste;
     bool clipboard_autosync;
 
-    struct {
-        unsigned data[SC_MAX_SHORTCUT_MODS];
-        unsigned count;
-    } sdl_shortcut_mods;
+    uint16_t sdl_shortcut_mods;
 
     bool vfinger_down;
     bool vfinger_invert_x;
@@ -55,7 +52,7 @@ struct sc_input_manager_params {
     bool forward_all_clicks;
     bool legacy_paste;
     bool clipboard_autosync;
-    const struct sc_shortcut_mods *shortcut_mods;
+    uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
 };
 
 void

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -30,10 +30,7 @@ const struct scrcpy_options scrcpy_options_default = {
     },
     .tunnel_host = 0,
     .tunnel_port = 0,
-    .shortcut_mods = {
-        .data = {SC_SHORTCUT_MOD_LALT, SC_SHORTCUT_MOD_LSUPER},
-        .count = 2,
-    },
+    .shortcut_mods = SC_SHORTCUT_MOD_LALT | SC_SHORTCUT_MOD_LSUPER,
     .max_size = 0,
     .video_bit_rate = 0,
     .audio_bit_rate = 0,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -169,8 +169,6 @@ enum sc_key_inject_mode {
     SC_KEY_INJECT_MODE_RAW,
 };
 
-#define SC_MAX_SHORTCUT_MODS 8
-
 enum sc_shortcut_mod {
     SC_SHORTCUT_MOD_LCTRL = 1 << 0,
     SC_SHORTCUT_MOD_RCTRL = 1 << 1,
@@ -178,11 +176,6 @@ enum sc_shortcut_mod {
     SC_SHORTCUT_MOD_RALT = 1 << 3,
     SC_SHORTCUT_MOD_LSUPER = 1 << 4,
     SC_SHORTCUT_MOD_RSUPER = 1 << 5,
-};
-
-struct sc_shortcut_mods {
-    unsigned data[SC_MAX_SHORTCUT_MODS];
-    unsigned count;
 };
 
 struct sc_port_range {
@@ -219,7 +212,7 @@ struct scrcpy_options {
     struct sc_port_range port_range;
     uint32_t tunnel_host;
     uint16_t tunnel_port;
-    struct sc_shortcut_mods shortcut_mods;
+    uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
     uint16_t max_size;
     uint32_t video_bit_rate;
     uint32_t audio_bit_rate;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -715,7 +715,7 @@ scrcpy(struct scrcpy_options *options) {
             .forward_all_clicks = options->forward_all_clicks,
             .legacy_paste = options->legacy_paste,
             .clipboard_autosync = options->clipboard_autosync,
-            .shortcut_mods = &options->shortcut_mods,
+            .shortcut_mods = options->shortcut_mods,
             .window_title = window_title,
             .always_on_top = options->always_on_top,
             .window_x = options->window_x,

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -82,7 +82,7 @@ struct sc_screen_params {
     bool forward_all_clicks;
     bool legacy_paste;
     bool clipboard_autosync;
-    const struct sc_shortcut_mods *shortcut_mods;
+    uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
 
     const char *window_title;
     bool always_on_top;

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -124,32 +124,22 @@ static void test_options2(void) {
 }
 
 static void test_parse_shortcut_mods(void) {
-    struct sc_shortcut_mods mods;
+    uint8_t mods;
     bool ok;
 
     ok = sc_parse_shortcut_mods("lctrl", &mods);
     assert(ok);
-    assert(mods.count == 1);
-    assert(mods.data[0] == SC_SHORTCUT_MOD_LCTRL);
-
-    ok = sc_parse_shortcut_mods("lctrl+lalt", &mods);
-    assert(ok);
-    assert(mods.count == 1);
-    assert(mods.data[0] == (SC_SHORTCUT_MOD_LCTRL | SC_SHORTCUT_MOD_LALT));
+    assert(mods == SC_SHORTCUT_MOD_LCTRL);
 
     ok = sc_parse_shortcut_mods("rctrl,lalt", &mods);
     assert(ok);
-    assert(mods.count == 2);
-    assert(mods.data[0] == SC_SHORTCUT_MOD_RCTRL);
-    assert(mods.data[1] == SC_SHORTCUT_MOD_LALT);
+    assert(mods == (SC_SHORTCUT_MOD_RCTRL | SC_SHORTCUT_MOD_LALT));
 
-    ok = sc_parse_shortcut_mods("lsuper,rsuper+lalt,lctrl+rctrl+ralt", &mods);
+    ok = sc_parse_shortcut_mods("lsuper,rsuper,lctrl", &mods);
     assert(ok);
-    assert(mods.count == 3);
-    assert(mods.data[0] == SC_SHORTCUT_MOD_LSUPER);
-    assert(mods.data[1] == (SC_SHORTCUT_MOD_RSUPER | SC_SHORTCUT_MOD_LALT));
-    assert(mods.data[2] == (SC_SHORTCUT_MOD_LCTRL | SC_SHORTCUT_MOD_RCTRL |
-                            SC_SHORTCUT_MOD_RALT));
+    assert(mods == (SC_SHORTCUT_MOD_LSUPER
+                  | SC_SHORTCUT_MOD_RSUPER
+                  | SC_SHORTCUT_MOD_LCTRL));
 
     ok = sc_parse_shortcut_mods("", &mods);
     assert(!ok);

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -13,8 +13,8 @@ It can be changed using `--shortcut-mod`. Possible keys are `lctrl`, `rctrl`,
 # use RCtrl for shortcuts
 scrcpy --shortcut-mod=rctrl
 
-# use either LCtrl+LAlt or LSuper for shortcuts
-scrcpy --shortcut-mod=lctrl+lalt,lsuper
+# use either LCtrl or LSuper for shortcuts
+scrcpy --shortcut-mod=lctrl,lsuper
 ```
 
 _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._


### PR DESCRIPTION
Restrict shortcut modifiers to be composed of only one item each.
    
Currently, it is possible to select a list of multiple combinations of modifier keys, like `--shortcut-mod='lctrl+lalt,rctrl+rsuper'`, meaning that shortcuts would be triggered either by <kbd>LCtrl</kbd>+<kbd>LAlt</kbd>+<kbd>key</kbd> or <kbd>RCtrl</kbd>+<kbd>RSuper</kbd>+<kbd>key</kbd>.
    
This was overly generic, probably not used very much, and it prevents to solve easily inconsistencies between UP and DOWN events of modifier keys sent to the device.

This change allows to ignore the keycodes associated to a shortcut modifier (which was not directly possible when a combination of modifiers was required).

(EDIT: not all issues are solved though, it is still possible to generate a key down without the matching key up or vice-versa)

Refs #4732