### PR TITLE
Add a shortcut to pause/unpause display

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -578,6 +578,14 @@ Flip display horizontally
 Flip display vertically
 
 .TP
+.B MOD+z
+Pause or re-pause display
+
+.TP
+.B MOD+Shift+z
+Unpause display
+
+.TP
 .B MOD+g
 Resize window to 1:1 (pixel\-perfect)
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -901,6 +901,14 @@ static const struct sc_shortcut shortcuts[] = {
         .text = "Flip display vertically",
     },
     {
+        .shortcuts = { "MOD+z" },
+        .text = "Pause or re-pause display",
+    },
+    {
+        .shortcuts = { "MOD+Shift+z" },
+        .text = "Unpause display",
+    },
+    {
         .shortcuts = { "MOD+g" },
         .text = "Resize window to 1:1 (pixel-perfect)",
     },

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -64,6 +64,9 @@ struct sc_screen {
     SDL_Keycode mouse_capture_key_pressed;
 
     AVFrame *frame;
+
+    bool paused;
+    AVFrame *resume_frame;
 };
 
 struct sc_screen_params {
@@ -134,6 +137,10 @@ sc_screen_resize_to_pixel_perfect(struct sc_screen *screen);
 void
 sc_screen_set_orientation(struct sc_screen *screen,
                           enum sc_orientation orientation);
+
+// set the display pause state
+void
+sc_screen_set_paused(struct sc_screen *screen, bool paused);
 
 // react to SDL events
 // If this function returns false, scrcpy must exit with an error.

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -28,6 +28,8 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
  | Rotate display right                        | <kbd>MOD</kbd>+<kbd>→</kbd> _(right)_
  | Flip display horizontally                   | <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>←</kbd> _(left)_ \| <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>→</kbd> _(right)_
  | Flip display vertically                     | <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>↑</kbd> _(up)_ \| <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>↓</kbd> _(down)_
+ | Pause or re-pause display                   | <kbd>MOD</kbd>+<kbd>z</kbd>
+ | Unpause display                             | <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>z</kbd>
  | Resize window to 1:1 (pixel-perfect)        | <kbd>MOD</kbd>+<kbd>g</kbd>
  | Resize window to remove black borders       | <kbd>MOD</kbd>+<kbd>w</kbd> \| _Double-left-click¹_
  | Click on `HOME`                             | <kbd>MOD</kbd>+<kbd>h</kbd> \| _Middle-click_


### PR DESCRIPTION
Pause/unpause display on <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>p</kbd>.

It only impacts rendering, the device is still captured, the video stream transmitted to the device, and recorded if recording is enabled.

Fixes #1632

---

Here is a binary (replace `scrcpy.exe` in your scrcpy 2.4 release folder):

- [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/4748/2/scrcpy.exe) <sub>`SHA-256: 64a44eb6f871bb752f1436c3bc78456747a1ec8ddb69c7af05dc5f7dc405c23`</sub>

<details><summary>v1 (old)</summary>

- [`scrcpy.exe`](https://tmp.rom1v.com/scrcpy/4748/1/scrcpy.exe) <sub>`SHA-256: c7661c5971145e0037f727568ecc61a8d2f6596f0a7bd9b99d45e381b0992d5`</sub>
- 
</details>