### PR TITLE
fix: window crash on tiling wayland WM

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -92,7 +92,8 @@ _scrcpy() {
         --window-x=
         --window-y=
         --window-width=
-        --window-height="
+        --window-height=
+        --system-resize"
 
     _init_completion -s || return
 

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -96,6 +96,7 @@ arguments=(
     '--window-y=[Set the initial window vertical position]'
     '--window-width=[Set the initial window width]'
     '--window-height=[Set the initial window height]'
+    '--system-resize[Leave the window size to be completely managed by the desktop manager]'
 )
 
 _arguments -s $arguments

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -97,6 +97,7 @@ enum {
     OPT_MOUSE,
     OPT_HID_KEYBOARD_DEPRECATED,
     OPT_HID_MOUSE_DEPRECATED,
+    OPT_SYSTEM_RESIZE,
 };
 
 struct sc_option {
@@ -876,6 +877,11 @@ static const struct sc_option options[] = {
         .argdesc = "value",
         .text = "Set the initial window height.\n"
                 "Default is 0 (automatic).",
+    },
+    {
+        .longopt_id = OPT_SYSTEM_RESIZE,
+        .longopt = "system-resize",
+        .text = "Leave the window size to be completely managed by the desktop manager",
     },
 };
 
@@ -2185,6 +2191,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_ALWAYS_ON_TOP:
                 opts->always_on_top = true;
+                break;
+            case OPT_SYSTEM_RESIZE:
+                opts->system_resize = true;
                 break;
             case 'v':
                 args->version = true;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -60,6 +60,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .show_touches = false,
     .fullscreen = false,
     .always_on_top = false,
+    .system_resize = false,
     .control = true,
     .video_playback = true,
     .audio_playback = true,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -246,6 +246,7 @@ struct scrcpy_options {
     bool show_touches;
     bool fullscreen;
     bool always_on_top;
+    bool system_resize;
     bool control;
     bool video_playback;
     bool audio_playback;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -699,6 +699,7 @@ scrcpy(struct scrcpy_options *options) {
             .shortcut_mods = &options->shortcut_mods,
             .window_title = window_title,
             .always_on_top = options->always_on_top,
+            .system_resize = options->system_resize,
             .window_x = options->window_x,
             .window_y = options->window_y,
             .window_width = options->window_width,

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -57,7 +57,9 @@ set_window_size(struct sc_screen *screen, struct sc_size new_size) {
     assert(!screen->fullscreen);
     assert(!screen->maximized);
     assert(!screen->minimized);
-    SDL_SetWindowSize(screen->window, new_size.width, new_size.height);
+    if(!(screen->req.system_resize)){
+        SDL_SetWindowSize(screen->window, new_size.width, new_size.height);
+    }
 }
 
 // get the preferred display bounds (i.e. the screen bounds with some margins)
@@ -365,6 +367,7 @@ sc_screen_init(struct sc_screen *screen,
 
     screen->req.x = params->window_x;
     screen->req.y = params->window_y;
+    screen->req.system_resize = params->system_resize;
     screen->req.width = params->window_width;
     screen->req.height = params->window_height;
     screen->req.fullscreen = params->fullscreen;

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -38,6 +38,7 @@ struct sc_screen {
         uint16_t width;
         uint16_t height;
         bool fullscreen;
+        bool system_resize;
         bool start_fps_counter;
     } req;
 
@@ -79,6 +80,7 @@ struct sc_screen_params {
 
     const char *window_title;
     bool always_on_top;
+    bool system_resize;
 
     int16_t window_x; // accepts SC_WINDOW_POSITION_UNDEFINED
     int16_t window_y; // accepts SC_WINDOW_POSITION_UNDEFINED

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -159,6 +159,7 @@ scrcpy_otg(struct scrcpy_options *options) {
         .mouse = mouse,
         .window_title = window_title,
         .always_on_top = options->always_on_top,
+        .system_resize = options->system_resize,
         .window_x = options->window_x,
         .window_y = options->window_y,
         .window_width = options->window_width,

--- a/app/src/usb/screen_otg.h
+++ b/app/src/usb/screen_otg.h
@@ -29,6 +29,7 @@ struct sc_screen_otg_params {
     bool always_on_top;
     int16_t window_x; // accepts SC_WINDOW_POSITION_UNDEFINED
     int16_t window_y; // accepts SC_WINDOW_POSITION_UNDEFINED
+    bool system_resize;
     uint16_t window_width;
     uint16_t window_height;
     bool window_borderless;


### PR DESCRIPTION
Add a system-resize parameter to hand over window resize to the window manager.

#4760 