### PR TITLE
feat: boss key

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -670,6 +670,10 @@ Open keyboard settings on the device (for HID keyboard only)
 Enable/disable FPS counter (print frames/second in logs)
 
 .TP
+.B MOD+d
+Hides the window (press enter in console to recover)
+
+.TP
 .B Ctrl+click-and-move
 Pinch-to-zoom and rotate from the center of the screen
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -881,136 +881,141 @@ static const struct sc_option options[] = {
 
 static const struct sc_shortcut shortcuts[] = {
     {
-        .shortcuts = { "MOD+f" },
+        .shortcuts = {"MOD+f"},
         .text = "Switch fullscreen mode",
     },
     {
-        .shortcuts = { "MOD+Left" },
+        .shortcuts = {"MOD+Left"},
         .text = "Rotate display left",
     },
     {
-        .shortcuts = { "MOD+Right" },
+        .shortcuts = {"MOD+Right"},
         .text = "Rotate display right",
     },
     {
-        .shortcuts = { "MOD+Shift+Left", "MOD+Shift+Right" },
+        .shortcuts = {"MOD+Shift+Left", "MOD+Shift+Right"},
         .text = "Flip display horizontally",
     },
     {
-        .shortcuts = { "MOD+Shift+Up", "MOD+Shift+Down" },
+        .shortcuts = {"MOD+Shift+Up", "MOD+Shift+Down"},
         .text = "Flip display vertically",
     },
     {
-        .shortcuts = { "MOD+z" },
+        .shortcuts = {"MOD+z"},
         .text = "Pause or re-pause display",
     },
     {
-        .shortcuts = { "MOD+Shift+z" },
+        .shortcuts = {"MOD+Shift+z"},
         .text = "Unpause display",
     },
     {
-        .shortcuts = { "MOD+g" },
+        .shortcuts = {"MOD+g"},
         .text = "Resize window to 1:1 (pixel-perfect)",
     },
     {
-        .shortcuts = { "MOD+w", "Double-click on black borders" },
+        .shortcuts = {"MOD+w", "Double-click on black borders"},
         .text = "Resize window to remove black borders",
     },
     {
-        .shortcuts = { "MOD+h", "Middle-click" },
+        .shortcuts = {"MOD+h", "Middle-click"},
         .text = "Click on HOME",
     },
     {
-        .shortcuts = {
-            "MOD+b",
-            "MOD+Backspace",
-            "Right-click (when screen is on)",
-        },
+        .shortcuts =
+            {
+                "MOD+b",
+                "MOD+Backspace",
+                "Right-click (when screen is on)",
+            },
         .text = "Click on BACK",
     },
     {
-        .shortcuts = { "MOD+s", "4th-click" },
+        .shortcuts = {"MOD+s", "4th-click"},
         .text = "Click on APP_SWITCH",
     },
     {
-        .shortcuts = { "MOD+m" },
+        .shortcuts = {"MOD+m"},
         .text = "Click on MENU",
     },
     {
-        .shortcuts = { "MOD+Up" },
+        .shortcuts = {"MOD+Up"},
         .text = "Click on VOLUME_UP",
     },
     {
-        .shortcuts = { "MOD+Down" },
+        .shortcuts = {"MOD+Down"},
         .text = "Click on VOLUME_DOWN",
     },
     {
-        .shortcuts = { "MOD+p" },
+        .shortcuts = {"MOD+p"},
         .text = "Click on POWER (turn screen on/off)",
     },
     {
-        .shortcuts = { "Right-click (when screen is off)" },
+        .shortcuts = {"Right-click (when screen is off)"},
         .text = "Power on",
     },
     {
-        .shortcuts = { "MOD+o" },
+        .shortcuts = {"MOD+o"},
         .text = "Turn device screen off (keep mirroring)",
     },
     {
-        .shortcuts = { "MOD+Shift+o" },
+        .shortcuts = {"MOD+Shift+o"},
         .text = "Turn device screen on",
     },
     {
-        .shortcuts = { "MOD+r" },
+        .shortcuts = {"MOD+r"},
         .text = "Rotate device screen",
     },
     {
-        .shortcuts = { "MOD+n", "5th-click" },
+        .shortcuts = {"MOD+n", "5th-click"},
         .text = "Expand notification panel",
     },
     {
-        .shortcuts = { "MOD+Shift+n" },
+        .shortcuts = {"MOD+Shift+n"},
         .text = "Collapse notification panel",
     },
     {
-        .shortcuts = { "MOD+c" },
+        .shortcuts = {"MOD+c"},
         .text = "Copy to clipboard (inject COPY keycode, Android >= 7 only)",
     },
     {
-        .shortcuts = { "MOD+x" },
+        .shortcuts = {"MOD+x"},
         .text = "Cut to clipboard (inject CUT keycode, Android >= 7 only)",
     },
     {
-        .shortcuts = { "MOD+v" },
+        .shortcuts = {"MOD+v"},
         .text = "Copy computer clipboard to device, then paste (inject PASTE "
                 "keycode, Android >= 7 only)",
     },
     {
-        .shortcuts = { "MOD+Shift+v" },
+        .shortcuts = {"MOD+Shift+v"},
         .text = "Inject computer clipboard text as a sequence of key events",
     },
     {
-        .shortcuts = { "MOD+k" },
+        .shortcuts = {"MOD+k"},
         .text = "Open keyboard settings on the device (for HID keyboard only)",
     },
     {
-        .shortcuts = { "MOD+i" },
+        .shortcuts = {"MOD+i"},
         .text = "Enable/disable FPS counter (print frames/second in logs)",
     },
     {
-        .shortcuts = { "Ctrl+click-and-move" },
+        .shortcuts = {"MOD+d"},
+        .text = "Hides the window (press enter in console to recover)",
+    },
+    {
+        .shortcuts = {"Ctrl+click-and-move"},
         .text = "Pinch-to-zoom and rotate from the center of the screen",
     },
     {
-        .shortcuts = { "Shift+click-and-move" },
+        .shortcuts = {"Shift+click-and-move"},
         .text = "Tilt (slide vertically with two fingers)",
     },
     {
-        .shortcuts = { "Drag & drop APK file" },
+        .shortcuts = {"Drag & drop APK file"},
         .text = "Install APK from computer",
     },
     {
-        .shortcuts = { "Drag & drop non-APK file" },
+        .shortcuts = {"Drag & drop non-APK file"},
         .text = "Push file to device (see --push-target)",
     },
 };

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -361,6 +361,7 @@ sc_screen_init(struct sc_screen *screen,
     screen->fullscreen = false;
     screen->maximized = false;
     screen->minimized = false;
+    screen->hidden = false;
     screen->mouse_capture_key_pressed = 0;
     screen->paused = false;
     screen->resume_frame = NULL;
@@ -496,7 +497,22 @@ sc_screen_show_initial_window(struct sc_screen *screen) {
 
 void
 sc_screen_hide_window(struct sc_screen *screen) {
+    if (screen->hidden) {
+        return;
+    }
+
+    screen->hidden = true;
     SDL_HideWindow(screen->window);
+ }
+
+void
+sc_screen_show_window(struct sc_screen *screen) {
+    if (!screen->hidden) {
+        return;
+    }
+
+    screen->hidden = false;
+    SDL_ShowWindow(screen->window);
 }
 
 void

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -58,6 +58,7 @@ struct sc_screen {
     bool fullscreen;
     bool maximized;
     bool minimized;
+    bool hidden;
 
     // To enable/disable mouse capture, a mouse capture key (LALT, LGUI or
     // RGUI) must be pressed. This variable tracks the pressed capture key.
@@ -118,8 +119,13 @@ sc_screen_destroy(struct sc_screen *screen);
 //
 // It is used to hide the window immediately on closing without waiting for
 // screen_destroy()
+// It is also used for hide the window temporarly as a feature
 void
 sc_screen_hide_window(struct sc_screen *screen);
+
+// show the window
+void
+sc_screen_show_window(struct sc_screen *screen);
 
 // switch the fullscreen mode
 void

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -52,6 +52,7 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
  | Inject computer clipboard text              | <kbd>MOD</kbd>+<kbd>Shift</kbd>+<kbd>v</kbd>
  | Open keyboard settings (HID keyboard only)  | <kbd>MOD</kbd>+<kbd>k</kbd>
  | Enable/disable FPS counter (on stdout)      | <kbd>MOD</kbd>+<kbd>i</kbd>
+ | Hides the window                            | <kbd>MOD</kbd>+<kbd>d</kbd>
  | Pinch-to-zoom/rotate                        | <kbd>Ctrl</kbd>+_click-and-move_
  | Tilt (slide vertically with 2 fingers)      | <kbd>Shift</kbd>+_click-and-move_
  | Drag & drop APK file                        | Install APK from computer


### PR DESCRIPTION
Adds a feature to hide and resume the window by pressing <kbd>MOD</kbd>+<kbd>d</kbd>, the window can be resumed by pressing <kbd>Enter</kbd> in console.   
```
Window hidden, press [Enter] to restore...

Window resumed
```