### PR TITLE
Fix incorrect capture when using DisplayManager API

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -51,6 +51,11 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
             Rect videoRect = screenInfo.getVideoSize().toRect();
             virtualDisplay = ServiceManager.getDisplayManager()
                     .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), device.getDisplayId(), surface);
+            // 'createVirtualDisplay' will copy the configuration of the original display (including the rotation),
+            // but 'videoRect' is already rotated according to the device rotation,
+            // so we need to freeze the rotation to 0 to avoid a double rotation
+            int displayId = virtualDisplay.getDisplay().getDisplayId();
+            ServiceManager.getWindowManager().freezeRotation(displayId, 0);
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
             try {


### PR DESCRIPTION
Fix the incorrect capture like this
![image](https://github.com/Genymobile/scrcpy/assets/52876220/d17b5388-2a15-4d00-aa9e-ec00fc56e07f)