### PR TITLE
Added Autostart instructions for Windows without AutoADB

### DIFF
--- a/doc/connection.md
+++ b/doc/connection.md
@@ -122,4 +122,52 @@ new Android device is connected: [AutoAdb]. It can be used to start scrcpy:
 autoadb scrcpy -s '{}'
 ```
 
+Alternatively, on Windows, Task Scheduler and Event Viewer can be used to run
+scrcpy when a particular device is connected:
+
+1. Open Event Viewer & go to Applications and Services Logs > Microsoft >
+   Windows > DeviceSetupManager > Admin.
+2. (If connected, disconnect the device you want to use scrcpy with, then)
+   Connect the device (you may need to select MTP/File Transfer or Charge
+   Only), and refresh the Admin view with F5.
+4. Look for a recent event with Level: Information & Event ID: 112.
+5. Click the event to open it, then open the Details tab and select XML View.
+6. The XML should look similar to the screenshot below, with a unique ID
+   for the device concerned (highlighted in the red box). Make note of this
+   entire ID, including '{}', for use in the next steps.  
+   ![Event Viewer Screenshot](https://github.com/Genymobile/scrcpy/assets/58115698/b85dcb05-d68b-44b2-ac73-87f878f68aad)
+8. Open Task Scheduler, and select Create Task from the right hand side panel.
+9. Give your task a name, then select the Triggers tab.
+10. Create a new trigger, and select Begin the task: On an event.
+11. Select Custom, then click New Event Filter.
+12. Select the XML tab and check the Edit query manually box.
+13. Replace any existing XML if there is any present, and paste the following:
+    ```xml
+    <QueryList>
+      <Query Id="0" Path="Microsoft-Windows-DeviceSetupManager/Admin">
+        <Select Path="Microsoft-Windows-DeviceSetupManager/Admin">*[System[Provider[@Name='Microsoft-Windows-DeviceSetupManager'] and (Level=4 or Level=0) and (EventID=112)]] and *[EventData[Data[@Name='Prop_ContainerId'] and (Data='YOUR_DEVICE_ID_HERE')]]</Select>
+      </Query>
+    </QueryList>
+    ```
+ 14. Replace "YOUR_DEVICE_ID_HERE" with the device ID from step 6, and verify
+     that that your secreen appears similar to the following screenshot.  
+     ![Task Scheduler Triggers Screenshot](https://github.com/Genymobile/scrcpy/assets/58115698/fa808038-a133-4e6b-9491-65b674a2f003)
+ 15. Select OK, then ensure that only the Enabled checkbox is checked on the
+     window, then select OK again.
+ 16. Select the Actions tab.
+ 17. Select New, and input "cmd.exe" into Program/script.
+ 18. Paste `/c "taskkill /im scrcpy.exe /t /f"` into Add arguments.
+ 19. Select OK, then add another New action.
+ 20. In Program/script, use the path to whichever script for scrpy you wish
+     to run.
+ 21. Select OK.  
+     ![Task Scheduler Complete Screenshot](https://github.com/Genymobile/scrcpy/assets/58115698/c0c6516e-023f-4c0e-a10b-3a0099db918d)
+ 22. Change Conditions and Settings to taste.  
+     Note that the actual task execution duration does not include the duration
+     of scrcpy's execution.
+ 23. Select OK to create the task.
+
+
+
+
 [AutoAdb]: https://github.com/rom1v/autoadb


### PR DESCRIPTION
The instructions guide through the setup of a task in Task Scheduler based on a device connection event in Event Viewer, to open scrcpy only when a particular device is connected.