### PR TITLE
server: add root support

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
@@ -4,10 +4,19 @@ import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
 
 import android.graphics.Rect;
+import android.hardware.display.DisplayManager;
 import android.hardware.display.VirtualDisplay;
+import android.hardware.display.VirtualDisplayConfig;
 import android.os.Build;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Looper;
+import android.system.ErrnoException;
+import android.system.Os;
 import android.view.Surface;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
 
 public class ScreenCapture extends SurfaceCapture implements Device.RotationListener, Device.FoldListener {
 
@@ -26,15 +35,8 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
     }
 
     @Override
-    public void start(Surface surface) {
-        ScreenInfo screenInfo = device.getScreenInfo();
-        Rect contentRect = screenInfo.getContentRect();
-
-        // does not include the locked video orientation
-        Rect unlockedVideoRect = screenInfo.getUnlockedVideoSize().toRect();
-        int videoRotation = screenInfo.getVideoRotation();
-        int layerStack = device.getLayerStack();
-
+    @SuppressWarnings("deprecation")
+    public void start(Surface surface) throws IOException {
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
             display = null;
@@ -43,22 +45,59 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
             virtualDisplay.release();
             virtualDisplay = null;
         }
+        if (Os.getuid() == 0) {
+            Handler handler = new Handler(Looper.getMainLooper());
+            CountDownLatch latch = new CountDownLatch(1);
+            handler.post(() -> {
+                try {
+                    Os.seteuid(0);
+                    createDisplay(surface);
+                    Os.seteuid(2000);
+                } catch (ErrnoException ignored) {
+                }
+                latch.countDown();
+            });
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                throw new IOException(e);
+            }
+        } else {
+            createDisplay(surface);
+        }
+    }
+
+    private void createDisplay(Surface surface) {
+        ScreenInfo screenInfo = device.getScreenInfo();
+        Rect contentRect = screenInfo.getContentRect();
+
+        // does not include the locked video orientation
+        Rect unlockedVideoRect = screenInfo.getUnlockedVideoSize().toRect();
+        int videoRotation = screenInfo.getVideoRotation();
+        int layerStack = device.getLayerStack();
 
         try {
-            display = createDisplay();
-            setDisplaySurface(display, surface, videoRotation, contentRect, unlockedVideoRect, layerStack);
-            Ln.d("Display: using SurfaceControl API");
-        } catch (Exception surfaceControlException) {
-            Rect videoRect = screenInfo.getVideoSize().toRect();
-            try {
-                virtualDisplay = ServiceManager.getDisplayManager()
-                        .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), device.getDisplayId(), surface);
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU) {
+                display = createDisplay();
+                setDisplaySurface(display, surface, videoRotation, contentRect, unlockedVideoRect, layerStack);
+                Ln.d("Display: using SurfaceControl API");
+            } else {
+                int flags = DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR;
+                if (Os.getuid() == 0) {
+                    flags |= DisplayManager.VIRTUAL_DISPLAY_FLAG_SECURE;
+                }
+                VirtualDisplayConfig.Builder builder = new VirtualDisplayConfig.Builder("scrcpy",
+                        unlockedVideoRect.width(), unlockedVideoRect.height(), 1 /* densityDpi */)
+                        .setFlags(flags)
+                        .setSurface(surface);
+                //noinspection JavaReflectionMemberAccess
+                builder.getClass().getMethod("setDisplayIdToMirror", int.class).invoke(builder, device.getDisplayId());
+                virtualDisplay = ServiceManager.getDisplayManager().createVirtualDisplay(FakeContext.get(), builder.build());
                 Ln.d("Display: using DisplayManager API");
-            } catch (Exception displayManagerException) {
-                Ln.e("Could not create display using SurfaceControl", surfaceControlException);
-                Ln.e("Could not create display using DisplayManager", displayManagerException);
-                throw new AssertionError("Could not create display");
             }
+        } catch (Exception e) {
+            Ln.e("Could not create display", e);
+            throw new AssertionError("Could not create display");
         }
     }
 
@@ -68,6 +107,9 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
         device.setFoldListener(null);
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
+        }
+        if (virtualDisplay != null) {
+            virtualDisplay.release();
         }
     }
 
@@ -93,11 +135,13 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
     }
 
     private static IBinder createDisplay() throws Exception {
-        // Since Android 12 (preview), secure displays could not be created with shell permissions anymore.
-        // On Android 12 preview, SDK_INT is still R (not S), but CODENAME is "S".
-        boolean secure = Build.VERSION.SDK_INT < Build.VERSION_CODES.R || (Build.VERSION.SDK_INT == Build.VERSION_CODES.R && !"S".equals(
-                Build.VERSION.CODENAME));
-        return SurfaceControl.createDisplay("scrcpy", secure);
+        // Since Android 12, secure displays could not be created with shell permissions anymore.
+        // Since Android 14, this method is deprecated.
+        IBinder display = SurfaceControl.createDisplay("scrcpy", true);
+        if (display == null) {
+            display = SurfaceControl.createDisplay("scrcpy", false);
+        }
+        return display;
     }
 
     private static void setDisplaySurface(IBinder display, Surface surface, int orientation, Rect deviceRect, Rect displayRect, int layerStack) {

--- a/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
@@ -26,9 +26,9 @@ public final class Workarounds {
     private static final Object ACTIVITY_THREAD;
 
     static {
-        prepareMainLooper();
-
         try {
+            prepareMainLooper();
+
             // ActivityThread activityThread = new ActivityThread();
             ACTIVITY_THREAD_CLASS = Class.forName("android.app.ActivityThread");
             Constructor<?> activityThreadConstructor = ACTIVITY_THREAD_CLASS.getDeclaredConstructor();
@@ -106,8 +106,7 @@ public final class Workarounds {
         }
     }
 
-    @SuppressWarnings("deprecation")
-    private static void prepareMainLooper() {
+    private static void prepareMainLooper() throws ReflectiveOperationException {
         // Some devices internally create a Handler when creating an input Surface, causing an exception:
         //   "Can't create handler inside thread that has not called Looper.prepare()"
         // <https://github.com/Genymobile/scrcpy/issues/240>
@@ -116,7 +115,10 @@ public final class Workarounds {
         //   "Attempt to read from field 'android.os.MessageQueue android.os.Looper.mQueue'
         //    on a null object reference"
         // <https://github.com/Genymobile/scrcpy/issues/921>
-        Looper.prepareMainLooper();
+        Looper.prepare();
+        Field mainLooper = Looper.class.getDeclaredField("sMainLooper");
+        mainLooper.setAccessible(true);
+        mainLooper.set(null, Looper.myLooper());
     }
 
     private static void fillAppInfo() {

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -6,12 +6,17 @@ import com.genymobile.scrcpy.Ln;
 import com.genymobile.scrcpy.Size;
 
 import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
 import android.hardware.display.VirtualDisplay;
+import android.hardware.display.VirtualDisplayConfig;
+import android.media.projection.MediaProjection;
+import android.os.Build;
 import android.view.Display;
-import android.view.Surface;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.Executor;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -112,16 +117,20 @@ public final class DisplayManager {
         }
     }
 
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     private Method getCreateVirtualDisplayMethod() throws NoSuchMethodException {
         if (createVirtualDisplayMethod == null) {
-            createVirtualDisplayMethod = android.hardware.display.DisplayManager.class
-                    .getMethod("createVirtualDisplay", String.class, int.class, int.class, int.class, Surface.class);
+            createVirtualDisplayMethod = manager.getClass()
+                    .getMethod("createVirtualDisplay", Context.class,
+                            MediaProjection.class, VirtualDisplayConfig.class,
+                            VirtualDisplay.Callback.class, Executor.class);
         }
         return createVirtualDisplayMethod;
     }
 
-    public VirtualDisplay createVirtualDisplay(String name, int width, int height, int displayIdToMirror, Surface surface) throws Exception {
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    public VirtualDisplay createVirtualDisplay(Context context, VirtualDisplayConfig virtualDisplayConfig) throws Exception {
         Method method = getCreateVirtualDisplayMethod();
-        return (VirtualDisplay) method.invoke(null, name, width, height, displayIdToMirror, surface);
+        return (VirtualDisplay) method.invoke(manager, context, null, virtualDisplayConfig, null, null);
     }
 }


### PR DESCRIPTION
The service can now run with root. It will auto change the main thread's euid to 2000 for binder calls. If a binder call requires root user, notify the main thread to switch to euid 0.

Tested on Android 14, can display secure content.


[scrcpy-server.zip](https://github.com/Genymobile/scrcpy/files/15448218/scrcpy-server.zip)

usage:
```sh
adb root
scrcpy
```

