### PR TITLE
使用代理服务器下载安装包 先安装依赖所需软件

### DIFF
--- a/install_release.sh
+++ b/install_release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+sudo apt install -y meson libavdevice-dev libusb-1.0-0-dev
 set -e
 
 BUILDDIR=build-auto
@@ -6,7 +7,7 @@ PREBUILT_SERVER_URL=https://github.com/Genymobile/scrcpy/releases/download/v2.4/
 PREBUILT_SERVER_SHA256=93c272b7438605c055e127f7444064ed78fa9ca49f81156777fd201e79ce7ba3
 
 echo "[scrcpy] Downloading prebuilt server..."
-wget "$PREBUILT_SERVER_URL" -O scrcpy-server
+wget -e use_proxy=yes -e http_proxy=192.168.1.20:8889 -e https_proxy=192.168.1.20:8889  "$PREBUILT_SERVER_URL" -O scrcpy-server
 echo "[scrcpy] Verifying prebuilt server..."
 echo "$PREBUILT_SERVER_SHA256  scrcpy-server" | sha256sum --check
 


### PR DESCRIPTION

+  first install the required software.
These are necessary software on debian bookworm
+ Use a proxy server to download thenstallation package 
In some countries and regions we must use a proxy to access github