### PR TITLE
Modify `virtualDisplay` API priority and use `DisplayManager` first.

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/ScreenCapture.java
@@ -45,18 +45,18 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
         }
 
         try {
-            display = createDisplay();
-            setDisplaySurface(display, surface, videoRotation, contentRect, unlockedVideoRect, layerStack);
-            Ln.d("Display: using SurfaceControl API");
-        } catch (Exception surfaceControlException) {
             Rect videoRect = screenInfo.getVideoSize().toRect();
-            try {
-                virtualDisplay = ServiceManager.getDisplayManager()
+            virtualDisplay = ServiceManager.getDisplayManager()
                         .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), device.getDisplayId(), surface);
                 Ln.d("Display: using DisplayManager API");
-            } catch (Exception displayManagerException) {
-                Ln.e("Could not create display using SurfaceControl", surfaceControlException);
+        } catch (Exception displayManagerException) {
+            try{
+                display = createDisplay();
+                setDisplaySurface(display, surface, videoRotation, contentRect, unlockedVideoRect, layerStack);
+                Ln.d("Display: using SurfaceControl API");
+            } catch (Exception surfaceControlException) {
                 Ln.e("Could not create display using DisplayManager", displayManagerException);
+                Ln.e("Could not create display using SurfaceControl", surfaceControlException);
                 throw new AssertionError("Could not create display");
             }
         }
@@ -68,6 +68,10 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
         device.setFoldListener(null);
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
+        }
+        if (virtualDisplay != null) {
+            virtualDisplay.release();
+            virtualDisplay = null;
         }
     }
 


### PR DESCRIPTION
Hi @rom1v 
This PR is about modify the ScreenCapture `virtualDisplay` API priority.

The Android kernel team removed the `createDisplay` method on December 21, 2023. [CL: Delete Unsupported APIs](https://cs.android.com/android/_/android/platform/frameworks/base/+/e35fd6654f3ff6572b52fe125110af4d716a4974)\
Official ROM updates for Pixel devices (Pixel 5a and newer) released after March 2024 incorporate this kernel change.\
Considering the wide range of affected devices – Pixel 5a, 6, 7, 8, and the upcoming Pixel 9.\
Prioritizing the `virtualDisplay` method over `createDisplay` is recommended, rather than triggering an exception with `createDisplay` before falling back to `virtualDisplay`.

Refer to the [Pixel Official ROM list](https://developers.google.com/android/images?hl=en#barbet), `(AP1A.240305.019.A1, Mar 2024)` already merged to Pixel 5a and newer devices.

Thank you.
Derek.