### PR TITLE
Forward mouse hover events

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -50,6 +50,7 @@ _scrcpy() {
         --no-downsize-on-error
         --no-key-repeat
         --no-mipmaps
+        --no-mouse-hover
         --no-power-on
         --no-video
         --no-video-playback

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -56,6 +56,7 @@ arguments=(
     '--no-downsize-on-error[Disable lowering definition on MediaCodec error]'
     '--no-key-repeat[Do not forward repeated key events when a key is held down]'
     '--no-mipmaps[Disable the generation of mipmaps]'
+    '--no-mouse-hover[Do not forward mouse hover events]'
     '--no-power-on[Do not power on the device on start]'
     '--no-video[Disable video forwarding]'
     '--no-video-playback[Disable video playback]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -318,6 +318,10 @@ Do not forward repeated key events when a key is held down.
 If the renderer is OpenGL 3.0+ or OpenGL ES 2.0+, then mipmaps are automatically generated to improve downscaling quality. This option disables the generation of mipmaps.
 
 .TP
+.B \-\-no\-mouse\-hover
+Do not forward mouse hover (mouse motion without any clicks) events.
+
+.TP
 .B \-\-no\-power\-on
 Do not power on the device on start.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -99,6 +99,7 @@ enum {
     OPT_HID_MOUSE_DEPRECATED,
     OPT_NO_WINDOW,
     OPT_MOUSE_BIND,
+    OPT_NO_MOUSE_HOVER,
 };
 
 struct sc_option {
@@ -567,6 +568,12 @@ static const struct sc_option options[] = {
         .text = "If the renderer is OpenGL 3.0+ or OpenGL ES 2.0+, then "
                 "mipmaps are automatically generated to improve downscaling "
                 "quality. This option disables the generation of mipmaps.",
+    },
+    {
+        .longopt_id = OPT_NO_MOUSE_HOVER,
+        .longopt = "no-mouse-hover",
+        .text = "Do not forward mouse hover (mouse motion without any clicks) "
+                "events.",
     },
     {
         .longopt_id = OPT_NO_POWER_ON,
@@ -2198,6 +2205,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                     return false;
                 }
                 break;
+            case OPT_NO_MOUSE_HOVER:
+                opts->mouse_hover = false;
+                break;
             case OPT_HID_MOUSE_DEPRECATED:
                 LOGE("--hid-mouse has been removed, use --mouse=aoa or "
                      "--mouse=uhid instead.");
@@ -2756,6 +2766,12 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             LOGE("--no-key-repeat is specific to --keyboard=sdk");
             return false;
         }
+    }
+
+    if (opts->mouse_input_mode != SC_MOUSE_INPUT_MODE_SDK
+            && !opts->mouse_hover) {
+        LOGE("--no-mouse-over is specific to --mouse=sdk");
+        return false;
     }
 
     if ((opts->tunnel_host || opts->tunnel_port) && !opts->force_adb_forward) {

--- a/app/src/mouse_sdk.h
+++ b/app/src/mouse_sdk.h
@@ -13,9 +13,11 @@ struct sc_mouse_sdk {
     struct sc_mouse_processor mouse_processor; // mouse processor trait
 
     struct sc_controller *controller;
+    bool mouse_hover;
 };
 
 void
-sc_mouse_sdk_init(struct sc_mouse_sdk *m, struct sc_controller *controller);
+sc_mouse_sdk_init(struct sc_mouse_sdk *m, struct sc_controller *controller,
+                  bool mouse_hover);
 
 #endif

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -92,6 +92,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .camera_high_speed = false,
     .list = 0,
     .window = true,
+    .mouse_hover = true,
 };
 
 enum sc_orientation

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -290,6 +290,7 @@ struct scrcpy_options {
 #define SC_OPTION_LIST_CAMERA_SIZES 0x8
     uint8_t list;
     bool window;
+    bool mouse_hover;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -681,7 +681,8 @@ scrcpy(struct scrcpy_options *options) {
         }
 
         if (options->mouse_input_mode == SC_MOUSE_INPUT_MODE_SDK) {
-            sc_mouse_sdk_init(&s->mouse_sdk, &s->controller);
+            sc_mouse_sdk_init(&s->mouse_sdk, &s->controller,
+                              options->mouse_hover);
             mp = &s->mouse_sdk.mouse_processor;
         } else if (options->mouse_input_mode == SC_MOUSE_INPUT_MODE_UHID) {
             bool ok = sc_mouse_uhid_init(&s->mouse_uhid, &s->controller);

--- a/doc/mouse.md
+++ b/doc/mouse.md
@@ -18,6 +18,14 @@ Note that on some devices, an additional option must be enabled in developer
 options for this mouse mode to work. See
 [prerequisites](/README.md#prerequisites).
 
+### Mouse hover
+
+By default, mouse hover (mouse motion without any clicks) events are forwarded
+to the device. This can be disabled with:
+
+```
+scrcpy --no-mouse-hover
+```
 
 ## Physical mouse simulation
 


### PR DESCRIPTION
Also add an option `--no-mouse-hover` to get the old behavior.

Fixes #2743
Fixes #3070