### PR TITLE
Improve mouse events and add secondary bindings

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -258,10 +258,14 @@ LAlt, LSuper or RSuper toggle the capture mode, to give control of the mouse bac
 Also see \fB\-\-keyboard\fR.
 
 .TP
-.BI "\-\-mouse\-bind " xxxx
+.BI "\-\-mouse\-bind " xxxx[:xxxx]
 Configure bindings of secondary clicks.
 
-The argument must be exactly 4 characters, one for each secondary click (in order: right click, middle click, 4th click, 5th click).
+The argument must be one or two sequences (separated by ':') of exactly 4 characters, one for each secondary click (in order: right click, middle click, 4th click, 5th click).
+
+The first sequence defines the primary bindings, used when a mouse button is pressed alone. The second sequence defines the secondary bindings, used when a mouse button is pressed while the Shift key is held.
+
+If the second sequence of bindings is omitted, then it is the same as the first one.
 
 Each character must be one of the following:
 
@@ -272,7 +276,7 @@ Each character must be one of the following:
  - 's': trigger shortcut APP_SWITCH
  - 'n': trigger shortcut "expand notification panel"
 
-Default is 'bhsn' for SDK mouse, and '++++' for AOA and UHID.
+Default is 'bhsn:++++' for SDK mouse, and '++++:bhsn' for AOA and UHID.
 
 
 .TP

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -68,8 +68,6 @@ get_well_known_pointer_id_name(uint64_t pointer_id) {
             return "mouse";
         case SC_POINTER_ID_GENERIC_FINGER:
             return "finger";
-        case SC_POINTER_ID_VIRTUAL_MOUSE:
-            return "vmouse";
         case SC_POINTER_ID_VIRTUAL_FINGER:
             return "vfinger";
         default:

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -64,13 +64,13 @@ static const char *const copy_key_labels[] = {
 static inline const char *
 get_well_known_pointer_id_name(uint64_t pointer_id) {
     switch (pointer_id) {
-        case POINTER_ID_MOUSE:
+        case SC_POINTER_ID_MOUSE:
             return "mouse";
-        case POINTER_ID_GENERIC_FINGER:
+        case SC_POINTER_ID_GENERIC_FINGER:
             return "finger";
-        case POINTER_ID_VIRTUAL_MOUSE:
+        case SC_POINTER_ID_VIRTUAL_MOUSE:
             return "vmouse";
-        case POINTER_ID_VIRTUAL_FINGER:
+        case SC_POINTER_ID_VIRTUAL_FINGER:
             return "vfinger";
         default:
             return NULL;

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -18,12 +18,12 @@
 // type: 1 byte; sequence: 8 bytes; paste flag: 1 byte; length: 4 bytes
 #define SC_CONTROL_MSG_CLIPBOARD_TEXT_MAX_LENGTH (SC_CONTROL_MSG_MAX_SIZE - 14)
 
-#define POINTER_ID_MOUSE UINT64_C(-1)
-#define POINTER_ID_GENERIC_FINGER UINT64_C(-2)
+#define SC_POINTER_ID_MOUSE UINT64_C(-1)
+#define SC_POINTER_ID_GENERIC_FINGER UINT64_C(-2)
 
 // Used for injecting an additional virtual pointer for pinch-to-zoom
-#define POINTER_ID_VIRTUAL_MOUSE UINT64_C(-3)
-#define POINTER_ID_VIRTUAL_FINGER UINT64_C(-4)
+#define SC_POINTER_ID_VIRTUAL_MOUSE UINT64_C(-3)
+#define SC_POINTER_ID_VIRTUAL_FINGER UINT64_C(-4)
 
 enum sc_control_msg_type {
     SC_CONTROL_MSG_TYPE_INJECT_KEYCODE,

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -22,8 +22,7 @@
 #define SC_POINTER_ID_GENERIC_FINGER UINT64_C(-2)
 
 // Used for injecting an additional virtual pointer for pinch-to-zoom
-#define SC_POINTER_ID_VIRTUAL_MOUSE UINT64_C(-3)
-#define SC_POINTER_ID_VIRTUAL_FINGER UINT64_C(-4)
+#define SC_POINTER_ID_VIRTUAL_FINGER UINT64_C(-3)
 
 enum sc_control_msg_type {
     SC_CONTROL_MSG_TYPE_INJECT_KEYCODE,

--- a/app/src/input_events.h
+++ b/app/src/input_events.h
@@ -437,25 +437,11 @@ sc_mouse_button_from_sdl(uint8_t button) {
 }
 
 static inline uint8_t
-sc_mouse_buttons_state_from_sdl(uint32_t buttons_state,
-                                const struct sc_mouse_bindings *mb) {
+sc_mouse_buttons_state_from_sdl(uint32_t buttons_state) {
     assert(buttons_state < 0x100); // fits in uint8_t
 
-    uint8_t mask = SC_MOUSE_BUTTON_LEFT;
-    if (!mb || mb->right_click == SC_MOUSE_BINDING_CLICK) {
-        mask |= SC_MOUSE_BUTTON_RIGHT;
-    }
-    if (!mb || mb->middle_click == SC_MOUSE_BINDING_CLICK) {
-        mask |= SC_MOUSE_BUTTON_MIDDLE;
-    }
-    if (!mb || mb->click4 == SC_MOUSE_BINDING_CLICK) {
-        mask |= SC_MOUSE_BUTTON_X1;
-    }
-    if (!mb || mb->click5 == SC_MOUSE_BINDING_CLICK) {
-        mask |= SC_MOUSE_BUTTON_X2;
-    }
-
-    return buttons_state & mask;
+    // SC_MOUSE_BUTTON_* constants are initialized from SDL_BUTTON(index)
+    return buttons_state;
 }
 
 #endif

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -846,9 +846,9 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
     // can be used instead of Ctrl. The "virtual finger" has a position
     // inverted with respect to the vertical axis of symmetry in the middle of
     // the screen.
-    const SDL_Keymod keymod = SDL_GetModState();
-    const bool ctrl_pressed = keymod & KMOD_CTRL;
-    const bool shift_pressed = keymod & KMOD_SHIFT;
+    SDL_Keymod keymod = SDL_GetModState();
+    bool ctrl_pressed = keymod & KMOD_CTRL;
+    bool shift_pressed = keymod & KMOD_SHIFT;
     if (event->button == SDL_BUTTON_LEFT &&
             ((down && !im->vfinger_down &&
               ((ctrl_pressed && !shift_pressed) ||

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -376,8 +376,8 @@ simulate_virtual_finger(struct sc_input_manager *im,
     msg.inject_touch_event.position.screen_size = im->screen->frame_size;
     msg.inject_touch_event.position.point = point;
     msg.inject_touch_event.pointer_id =
-        im->has_secondary_click ? POINTER_ID_VIRTUAL_MOUSE
-                                : POINTER_ID_VIRTUAL_FINGER;
+        im->has_secondary_click ? SC_POINTER_ID_VIRTUAL_MOUSE
+                                : SC_POINTER_ID_VIRTUAL_FINGER;
     msg.inject_touch_event.pressure = up ? 0.0f : 1.0f;
     msg.inject_touch_event.action_button = 0;
     msg.inject_touch_event.buttons = 0;
@@ -662,8 +662,8 @@ sc_input_manager_process_mouse_motion(struct sc_input_manager *im,
 
     struct sc_mouse_motion_event evt = {
         .position = sc_input_manager_get_position(im, event->x, event->y),
-        .pointer_id = im->has_secondary_click ? POINTER_ID_MOUSE
-                                              : POINTER_ID_GENERIC_FINGER,
+        .pointer_id = im->has_secondary_click ? SC_POINTER_ID_MOUSE
+                                              : SC_POINTER_ID_GENERIC_FINGER,
         .xrel = event->xrel,
         .yrel = event->yrel,
         .buttons_state =
@@ -817,8 +817,8 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
         .position = sc_input_manager_get_position(im, event->x, event->y),
         .action = sc_action_from_sdl_mousebutton_type(event->type),
         .button = sc_mouse_button_from_sdl(event->button),
-        .pointer_id = im->has_secondary_click ? POINTER_ID_MOUSE
-                                              : POINTER_ID_GENERIC_FINGER,
+        .pointer_id = im->has_secondary_click ? SC_POINTER_ID_MOUSE
+                                              : SC_POINTER_ID_GENERIC_FINGER,
         .buttons_state = sc_mouse_buttons_state_from_sdl(sdl_buttons_state,
                                                          &im->mouse_bindings),
     };

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -52,14 +52,6 @@ is_shortcut_key(struct sc_input_manager *im, SDL_Keycode keycode) {
         || (im->sdl_shortcut_mods & KMOD_RGUI  && keycode == SDLK_RGUI);
 }
 
-static inline bool
-mouse_bindings_has_secondary_click(const struct sc_mouse_bindings *mb) {
-    return mb->right_click == SC_MOUSE_BINDING_CLICK
-        || mb->middle_click == SC_MOUSE_BINDING_CLICK
-        || mb->click4 == SC_MOUSE_BINDING_CLICK
-        || mb->click5 == SC_MOUSE_BINDING_CLICK;
-}
-
 void
 sc_input_manager_init(struct sc_input_manager *im,
                       const struct sc_input_manager_params *params) {
@@ -76,8 +68,6 @@ sc_input_manager_init(struct sc_input_manager *im,
     im->mp = params->mp;
 
     im->mouse_bindings = params->mouse_bindings;
-    im->has_secondary_click =
-        mouse_bindings_has_secondary_click(&im->mouse_bindings);
     im->legacy_paste = params->legacy_paste;
     im->clipboard_autosync = params->clipboard_autosync;
 
@@ -375,9 +365,7 @@ simulate_virtual_finger(struct sc_input_manager *im,
     msg.inject_touch_event.action = action;
     msg.inject_touch_event.position.screen_size = im->screen->frame_size;
     msg.inject_touch_event.position.point = point;
-    msg.inject_touch_event.pointer_id =
-        im->has_secondary_click ? SC_POINTER_ID_VIRTUAL_MOUSE
-                                : SC_POINTER_ID_VIRTUAL_FINGER;
+    msg.inject_touch_event.pointer_id = SC_POINTER_ID_VIRTUAL_MOUSE;
     msg.inject_touch_event.pressure = up ? 0.0f : 1.0f;
     msg.inject_touch_event.action_button = 0;
     msg.inject_touch_event.buttons = 0;
@@ -662,8 +650,7 @@ sc_input_manager_process_mouse_motion(struct sc_input_manager *im,
 
     struct sc_mouse_motion_event evt = {
         .position = sc_input_manager_get_position(im, event->x, event->y),
-        .pointer_id = im->has_secondary_click ? SC_POINTER_ID_MOUSE
-                                              : SC_POINTER_ID_GENERIC_FINGER,
+        .pointer_id = SC_POINTER_ID_MOUSE,
         .xrel = event->xrel,
         .yrel = event->yrel,
         .buttons_state =
@@ -817,8 +804,7 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
         .position = sc_input_manager_get_position(im, event->x, event->y),
         .action = sc_action_from_sdl_mousebutton_type(event->type),
         .button = sc_mouse_button_from_sdl(event->button),
-        .pointer_id = im->has_secondary_click ? SC_POINTER_ID_MOUSE
-                                              : SC_POINTER_ID_GENERIC_FINGER,
+        .pointer_id = SC_POINTER_ID_MOUSE,
         .buttons_state = sc_mouse_buttons_state_from_sdl(sdl_buttons_state,
                                                          &im->mouse_bindings),
     };

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -365,7 +365,7 @@ simulate_virtual_finger(struct sc_input_manager *im,
     msg.inject_touch_event.action = action;
     msg.inject_touch_event.position.screen_size = im->screen->frame_size;
     msg.inject_touch_event.position.point = point;
-    msg.inject_touch_event.pointer_id = SC_POINTER_ID_VIRTUAL_MOUSE;
+    msg.inject_touch_event.pointer_id = SC_POINTER_ID_VIRTUAL_FINGER;
     msg.inject_touch_event.pressure = up ? 0.0f : 1.0f;
     msg.inject_touch_event.action_button = 0;
     msg.inject_touch_event.buttons = 0;
@@ -650,7 +650,8 @@ sc_input_manager_process_mouse_motion(struct sc_input_manager *im,
 
     struct sc_mouse_motion_event evt = {
         .position = sc_input_manager_get_position(im, event->x, event->y),
-        .pointer_id = SC_POINTER_ID_MOUSE,
+        .pointer_id = im->vfinger_down ? SC_POINTER_ID_GENERIC_FINGER
+                                       : SC_POINTER_ID_MOUSE,
         .xrel = event->xrel,
         .yrel = event->yrel,
         .buttons_state =
@@ -800,11 +801,20 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
 
     uint32_t sdl_buttons_state = SDL_GetMouseState(NULL, NULL);
 
+    SDL_Keymod keymod = SDL_GetModState();
+    bool ctrl_pressed = keymod & KMOD_CTRL;
+    bool shift_pressed = keymod & KMOD_SHIFT;
+    bool change_vfinger = event->button == SDL_BUTTON_LEFT &&
+            ((down && !im->vfinger_down && (ctrl_pressed ^ shift_pressed)) ||
+             (!down && im->vfinger_down));
+    bool use_finger = im->vfinger_down || change_vfinger;
+
     struct sc_mouse_click_event evt = {
         .position = sc_input_manager_get_position(im, event->x, event->y),
         .action = sc_action_from_sdl_mousebutton_type(event->type),
         .button = sc_mouse_button_from_sdl(event->button),
-        .pointer_id = SC_POINTER_ID_MOUSE,
+        .pointer_id = use_finger ? SC_POINTER_ID_GENERIC_FINGER
+                                 : SC_POINTER_ID_MOUSE,
         .buttons_state = sc_mouse_buttons_state_from_sdl(sdl_buttons_state,
                                                          &im->mouse_bindings),
     };
@@ -832,12 +842,7 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
     // can be used instead of Ctrl. The "virtual finger" has a position
     // inverted with respect to the vertical axis of symmetry in the middle of
     // the screen.
-    SDL_Keymod keymod = SDL_GetModState();
-    bool ctrl_pressed = keymod & KMOD_CTRL;
-    bool shift_pressed = keymod & KMOD_SHIFT;
-    if (event->button == SDL_BUTTON_LEFT &&
-            ((down && !im->vfinger_down && (ctrl_pressed ^ shift_pressed)) ||
-             (!down && im->vfinger_down))) {
+    if (change_vfinger) {
         struct sc_point mouse =
             sc_screen_convert_window_to_frame_coords(im->screen, event->x,
                                                                  event->y);

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -850,9 +850,7 @@ sc_input_manager_process_mouse_button(struct sc_input_manager *im,
     bool ctrl_pressed = keymod & KMOD_CTRL;
     bool shift_pressed = keymod & KMOD_SHIFT;
     if (event->button == SDL_BUTTON_LEFT &&
-            ((down && !im->vfinger_down &&
-              ((ctrl_pressed && !shift_pressed) ||
-               (!ctrl_pressed && shift_pressed))) ||
+            ((down && !im->vfinger_down && (ctrl_pressed ^ shift_pressed)) ||
              (!down && im->vfinger_down))) {
         struct sc_point mouse =
             sc_screen_convert_window_to_frame_coords(im->screen, event->x,

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -32,6 +32,8 @@ struct sc_input_manager {
     bool vfinger_invert_x;
     bool vfinger_invert_y;
 
+    uint8_t mouse_buttons_state; // OR of enum sc_mouse_button values
+
     // Tracks the number of identical consecutive shortcut key down events.
     // Not to be confused with event->repeat, which counts the number of
     // system-generated repeated key presses.

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -23,7 +23,6 @@ struct sc_input_manager {
     struct sc_mouse_processor *mp;
 
     struct sc_mouse_bindings mouse_bindings;
-    bool has_secondary_click;
     bool legacy_paste;
     bool clipboard_autosync;
 

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -24,10 +24,18 @@ const struct scrcpy_options scrcpy_options_default = {
     .keyboard_input_mode = SC_KEYBOARD_INPUT_MODE_AUTO,
     .mouse_input_mode = SC_MOUSE_INPUT_MODE_AUTO,
     .mouse_bindings = {
-        .right_click = SC_MOUSE_BINDING_AUTO,
-        .middle_click = SC_MOUSE_BINDING_AUTO,
-        .click4 = SC_MOUSE_BINDING_AUTO,
-        .click5 = SC_MOUSE_BINDING_AUTO,
+        .pri = {
+            .right_click = SC_MOUSE_BINDING_AUTO,
+            .middle_click = SC_MOUSE_BINDING_AUTO,
+            .click4 = SC_MOUSE_BINDING_AUTO,
+            .click5 = SC_MOUSE_BINDING_AUTO,
+        },
+        .sec = {
+            .right_click = SC_MOUSE_BINDING_AUTO,
+            .middle_click = SC_MOUSE_BINDING_AUTO,
+            .click4 = SC_MOUSE_BINDING_AUTO,
+            .click5 = SC_MOUSE_BINDING_AUTO,
+        },
     },
     .camera_facing = SC_CAMERA_FACING_ANY,
     .port_range = {

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -165,11 +165,16 @@ enum sc_mouse_binding {
     SC_MOUSE_BINDING_EXPAND_NOTIFICATION_PANEL,
 };
 
-struct sc_mouse_bindings {
+struct sc_mouse_binding_set {
     enum sc_mouse_binding right_click;
     enum sc_mouse_binding middle_click;
     enum sc_mouse_binding click4;
     enum sc_mouse_binding click5;
+};
+
+struct sc_mouse_bindings {
+    struct sc_mouse_binding_set pri;
+    struct sc_mouse_binding_set sec; // When Shift is pressed
 };
 
 enum sc_key_inject_mode {

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -169,7 +169,7 @@ sc_screen_otg_process_mouse_motion(struct sc_screen_otg *screen,
         // .position not used for HID events
         .xrel = event->xrel,
         .yrel = event->yrel,
-        .buttons_state = sc_mouse_buttons_state_from_sdl(event->state, NULL),
+        .buttons_state = sc_mouse_buttons_state_from_sdl(event->state),
     };
 
     assert(mp->ops->process_mouse_motion);
@@ -188,8 +188,7 @@ sc_screen_otg_process_mouse_button(struct sc_screen_otg *screen,
         // .position not used for HID events
         .action = sc_action_from_sdl_mousebutton_type(event->type),
         .button = sc_mouse_button_from_sdl(event->button),
-        .buttons_state =
-            sc_mouse_buttons_state_from_sdl(sdl_buttons_state, NULL),
+        .buttons_state = sc_mouse_buttons_state_from_sdl(sdl_buttons_state),
     };
 
     assert(mp->ops->process_mouse_click);
@@ -208,8 +207,7 @@ sc_screen_otg_process_mouse_wheel(struct sc_screen_otg *screen,
         // .position not used for HID events
         .hscroll = event->x,
         .vscroll = event->y,
-        .buttons_state =
-            sc_mouse_buttons_state_from_sdl(sdl_buttons_state, NULL),
+        .buttons_state = sc_mouse_buttons_state_from_sdl(sdl_buttons_state),
     };
 
     assert(mp->ops->process_mouse_scroll);

--- a/doc/mouse.md
+++ b/doc/mouse.md
@@ -80,21 +80,37 @@ process like the _adb daemon_).
 
 ## Mouse bindings
 
-By default, with SDK mouse, right-click triggers BACK (or POWER on) and
-middle-click triggers HOME. In addition, the 4th click triggers APP_SWITCH and
-the 5th click expands the notification panel.
+By default, with SDK mouse:
+ - right-click triggers BACK (or POWER on)
+ - middle-click triggers HOME
+ - the 4th click triggers APP_SWITCH
+ - the 5th click expands the notification panel
 
-In AOA and UHID mouse modes, all clicks are forwarded by default.
+The secondary clicks may be forwarded to the device instead by pressing the
+<kbd>Shift</kbd> key (e.g. <kbd>Shift</kbd>+right-click injects a right click to
+the device).
 
-The shortcuts can be configured using `--mouse-bind=xxxx` for any mouse mode.
-The argument must be exactly 4 characters, one for each secondary click:
+In AOA and UHID mouse modes, the default bindings are reversed: all clicks are
+forwarded by default, and pressing <kbd>Shift</kbd> gives access to the
+shortcuts (since the cursor is handled on the device side, it makes more sense
+to forward all mouse buttons by default in these modes).
+
+The shortcuts can be configured using `--mouse-bind=xxxx:xxxx` for any mouse
+mode. The argument must be one or two sequences (separated by `:`) of exactly 4
+characters, one for each secondary click:
 
 ```
---mouse-bind=xxxx
+                  .---- Shift + right click
+       SECONDARY  |.--- Shift + middle click
+        BINDINGS  ||.-- Shift + 4th click
+                  |||.- Shift + 5th click
+                  ||||
+                  vvvv
+--mouse-bind=xxxx:xxxx
              ^^^^
              ||||
-             ||| `- 5th click
-             || `-- 4th click
+   PRIMARY   ||| `- 5th click
+  BINDINGS   || `-- 4th click
              | `--- middle click
               `---- right click
 ```
@@ -111,8 +127,18 @@ Each character must be one of the following:
 For example:
 
 ```bash
-scrcpy --mouse-bind=bhsn  # the default mode with SDK mouse
-scrcpy --mouse-bind=++++  # forward all clicks (default for AOA/UHID)
-scrcpy --mouse-bind=++bh  # forward right and middle clicks,
-                          # use 4th and 5th for BACK and HOME
+scrcpy --mouse-bind=bhsn:++++  # the default mode for SDK mouse
+scrcpy --mouse-bind=++++:bhsn  # the default mode for AOA and UHID
+scrcpy --mouse-bind=++bh:++sn  # forward right and middle clicks,
+                               # use 4th and 5th for BACK and HOME,
+                               # use Shift+4th and Shift+5th for APP_SWITCH
+                               # and expand notification panel
+```
+
+The second sequence of bindings may be omitted. In that case, it is the same as
+the first one:
+
+```bash
+scrcpy --mouse-bind=bhsn
+scrcpy --mouse-bind=bhsn:bhsn  # equivalent
 ```

--- a/server/src/main/java/com/genymobile/scrcpy/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Controller.java
@@ -22,7 +22,6 @@ public class Controller implements AsyncProcessor {
 
     // control_msg.h values of the pointerId field in inject_touch_event message
     private static final int POINTER_ID_MOUSE = -1;
-    private static final int POINTER_ID_VIRTUAL_MOUSE = -3;
 
     private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
 
@@ -273,8 +272,8 @@ public class Controller implements AsyncProcessor {
         pointer.setPressure(pressure);
 
         int source;
-        if (pointerId == POINTER_ID_MOUSE || pointerId == POINTER_ID_VIRTUAL_MOUSE) {
-            // real mouse event (forced by the client when --forward-on-click)
+        if (pointerId == POINTER_ID_MOUSE) {
+            // real mouse event
             pointerProperties[pointerIndex].toolType = MotionEvent.TOOL_TYPE_MOUSE;
             source = InputDevice.SOURCE_MOUSE;
             pointer.setUp(buttons == 0);


### PR DESCRIPTION
On Android, a `MotionEvent` may use either a `MOUSE` or `FINGER` as source. Since scrcpy 1.0, it used a `FINGER`. But when `--forward-all-clicks` (now deprecated in favor of `--mouse-bind=++++`) was added, this caused a problem: it was not possible to press secondary clicks with a `FINGER`, so if this flag was set, it used a `MOUSE` (c7b1d0ea9af8bb9603ec8f713f1a5fbf3f628b6a):

https://github.com/Genymobile/scrcpy/blob/cc8e6133b0c9975ef2ed16086960e822ab750404/server/src/main/java/com/genymobile/scrcpy/Controller.java#L276-L288

`FINGER` was still useful for simulating [pinch-to-zoom, rotate and tilt](https://github.com/Genymobile/scrcpy/blob/master/doc/control.md#pinch-to-zoom-rotate-and-tilt-simulation), because a double mouse pointer does not always work on all devices.

The fact that the decision to use either `MOUSE` or `FINGER` depends on the specific `--mouse-bind` value is weird, and cause issues: https://github.com/Genymobile/scrcpy/issues/5055#issuecomment-2209278528

The introduction of "mouse hover" in scrcpy v2.5 also causes issues on some devices, because in theory a "mouse hover" event should be with a `MOUSE` source: https://github.com/Genymobile/scrcpy/issues/5067

To fix both issues, always use a `MOUSE` source (regardless of the mouse bindings), except when simulating a virtual finger (pinch-to-zoom, rotate and tilt).

Fixes #5067

---

Then, improve `--mouse-bind` to support secondary mouse bindings with <kbd>Shift</kbd>+click.

It is now possible to pass a sequence of secondary bindings:

```
--mouse-bind=xxxx:xxxx
             <--> <-->
         primary   secondary
        bindings   bindings
```

If the second sequence is omitted, then it is the same as the first one.
    
By default, for SDK mouse, primary bindings trigger shortcuts and secondary bindings forward all clicks.
    
For AOA and UHID, the default bindings are reversed: all clicks are forwarded by default, whereas pressing Shift+click trigger shortcuts.
    
```bash
scrcpy --mouse-bind=bhsn:++++  # default for SDK
scrcpy --mouse-bind=++++:bhsn  # default for AOA and UHID
```

Fixes #5055

---

Here is a binary for Windows:

- [`scrcpy-win64-pr5076.zip`](https://tmp.rom1v.com/scrcpy/5076/1/scrcpy-win64-pr5076.zip) <sub>`SHA-256: ac38d4eb2577137f6846d41a82d8b76f7d1ed83ca5c2e0c499e6ba935bab276`</sub>

Thank you for your feedback :wink: