### PR TITLE
Add option to keep audio playing on device while mirroring

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -6,6 +6,7 @@ _scrcpy() {
         --audio-buffer=
         --audio-codec=
         --audio-codec-options=
+        --audio-dup
         --audio-encoder=
         --audio-source=
         --audio-output-buffer=

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -111,7 +111,7 @@ _scrcpy() {
             return
             ;;
         --audio-source)
-            COMPREPLY=($(compgen -W 'output mic' -- "$cur"))
+            COMPREPLY=($(compgen -W 'output mic playback' -- "$cur"))
             return
             ;;
         --camera-facing)

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -13,6 +13,7 @@ arguments=(
     '--audio-buffer=[Configure the audio buffering delay (in milliseconds)]'
     '--audio-codec=[Select the audio codec]:codec:(opus aac flac raw)'
     '--audio-codec-options=[Set a list of comma-separated key\:type=value options for the device audio encoder]'
+    '--audio-dup=[Duplicate audio]'
     '--audio-encoder=[Use a specific MediaCodec audio encoder]'
     '--audio-source=[Select the audio source]:source:(output mic playback)'
     '--audio-output-buffer=[Configure the size of the SDL audio output buffer (in milliseconds)]'

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -14,7 +14,7 @@ arguments=(
     '--audio-codec=[Select the audio codec]:codec:(opus aac flac raw)'
     '--audio-codec-options=[Set a list of comma-separated key\:type=value options for the device audio encoder]'
     '--audio-encoder=[Use a specific MediaCodec audio encoder]'
-    '--audio-source=[Select the audio source]:source:(output mic)'
+    '--audio-source=[Select the audio source]:source:(output mic playback)'
     '--audio-output-buffer=[Configure the size of the SDL audio output buffer (in milliseconds)]'
     {-b,--video-bit-rate=}'[Encode the video at the given bit-rate]'
     '--camera-ar=[Select the camera size by its aspect ratio]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -57,7 +57,13 @@ The available encoders can be listed by \fB\-\-list\-encoders\fR.
 
 .TP
 .BI "\-\-audio\-source " source
-Select the audio source (output or mic).
+Select the audio source (output, mic or playback).
+
+The "output" source forwards the whole audio output, and disables playback on the device.
+
+The "playback" source captures the audio playback (Android apps can opt-out, so the whole output is not necessarily captured).
+
+The "mic" source captures the microphone.
 
 Default is output.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -50,6 +50,12 @@ The list of possible codec options is available in the Android documentation:
 <https://d.android.com/reference/android/media/MediaFormat>
 
 .TP
+.B \-\-audio\-dup
+Duplicate audio (capture and keep playing on the device).
+
+This feature is only available with --audio-source=playback.
+
+.TP
 .BI "\-\-audio\-encoder " name
 Use a specific MediaCodec audio encoder (depending on the codec provided by \fB\-\-audio\-codec\fR).
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -100,6 +100,7 @@ enum {
     OPT_NO_WINDOW,
     OPT_MOUSE_BIND,
     OPT_NO_MOUSE_HOVER,
+    OPT_AUDIO_DUP,
 };
 
 struct sc_option {
@@ -176,6 +177,13 @@ static const struct sc_option options[] = {
                 "The list of possible codec options is available in the "
                 "Android documentation: "
                 "<https://d.android.com/reference/android/media/MediaFormat>",
+    },
+    {
+        .longopt_id = OPT_AUDIO_DUP,
+        .longopt = "audio-dup",
+        .text = "Duplicate audio (capture and keep playing on the device).\n"
+                "This feature is only available with --audio-source=playback."
+
     },
     {
         .longopt_id = OPT_AUDIO_ENCODER,
@@ -2615,6 +2623,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_NO_WINDOW:
                 opts->window = false;
                 break;
+            case OPT_AUDIO_DUP:
+                opts->audio_dup = true;
+                break;
             default:
                 // getopt prints the error message on stderr
                 return false;
@@ -2888,6 +2899,18 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         } else {
             opts->audio_source = SC_AUDIO_SOURCE_MIC;
             LOGI("Camera video source: microphone audio source selected");
+        }
+    }
+
+    if (opts->audio_dup) {
+        if (!opts->audio) {
+            LOGE("--audio-dup not supported if audio is disabled");
+            return false;
+        }
+
+        if (opts->audio_source != SC_AUDIO_SOURCE_PLAYBACK) {
+            LOGE("--audio-dup is specific to --audio-source=playback");
+            return false;
         }
     }
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -2895,7 +2895,13 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     if (opts->audio && opts->audio_source == SC_AUDIO_SOURCE_AUTO) {
         // Select the audio source according to the video source
         if (opts->video_source == SC_VIDEO_SOURCE_DISPLAY) {
-            opts->audio_source = SC_AUDIO_SOURCE_OUTPUT;
+            if (opts->audio_dup) {
+                LOGI("Audio duplication enabled: audio source switched to "
+                     "\"playback\"");
+                opts->audio_source = SC_AUDIO_SOURCE_PLAYBACK;
+            } else {
+                opts->audio_source = SC_AUDIO_SOURCE_OUTPUT;
+            }
         } else {
             opts->audio_source = SC_AUDIO_SOURCE_MIC;
             LOGI("Camera video source: microphone audio source selected");

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -189,7 +189,13 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_AUDIO_SOURCE,
         .longopt = "audio-source",
         .argdesc = "source",
-        .text = "Select the audio source (output or mic).\n"
+        .text = "Select the audio source (output, mic or playback).\n"
+                "The \"output\" source forwards the whole audio output, and "
+                "disables playback on the device.\n"
+                "The \"playback\" source captures the audio playback (Android "
+                "apps can opt-out, so the whole output is not necessarily "
+                "captured).\n"
+                "The \"mic\" source captures the microphone.\n"
                 "Default is output.",
     },
     {
@@ -1931,7 +1937,13 @@ parse_audio_source(const char *optarg, enum sc_audio_source *source) {
         return true;
     }
 
-    LOGE("Unsupported audio source: %s (expected output or mic)", optarg);
+    if (!strcmp(optarg, "playback")) {
+        *source = SC_AUDIO_SOURCE_PLAYBACK;
+        return true;
+    }
+
+    LOGE("Unsupported audio source: %s (expected output, mic or playback)",
+         optarg);
     return false;
 }
 

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -101,6 +101,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .list = 0,
     .window = true,
     .mouse_hover = true,
+    .audio_dup = false,
 };
 
 enum sc_orientation

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -297,6 +297,7 @@ struct scrcpy_options {
     uint8_t list;
     bool window;
     bool mouse_hover;
+    bool audio_dup;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -59,6 +59,7 @@ enum sc_audio_source {
     SC_AUDIO_SOURCE_AUTO, // OUTPUT for video DISPLAY, MIC for video CAMERA
     SC_AUDIO_SOURCE_OUTPUT,
     SC_AUDIO_SOURCE_MIC,
+    SC_AUDIO_SOURCE_PLAYBACK,
 };
 
 enum sc_camera_facing {

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -394,6 +394,7 @@ scrcpy(struct scrcpy_options *options) {
         .display_id = options->display_id,
         .video = options->video,
         .audio = options->audio,
+        .audio_dup = options->audio_dup,
         .show_touches = options->show_touches,
         .stay_awake = options->stay_awake,
         .video_codec_options = options->video_codec_options,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -292,6 +292,9 @@ execute_server(struct sc_server *server,
         ADD_PARAM("audio_source=%s",
                   sc_server_get_audio_source_name(params->audio_source));
     }
+    if (params->audio_dup) {
+        ADD_PARAM("audio_dup=true");
+    }
     if (params->max_size) {
         ADD_PARAM("max_size=%" PRIu16, params->max_size);
     }

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -203,6 +203,21 @@ sc_server_get_camera_facing_name(enum sc_camera_facing camera_facing) {
     }
 }
 
+static const char *
+sc_server_get_audio_source_name(enum sc_audio_source audio_source) {
+    switch (audio_source) {
+        case SC_AUDIO_SOURCE_OUTPUT:
+            return "output";
+        case SC_AUDIO_SOURCE_MIC:
+            return "mic";
+        case SC_AUDIO_SOURCE_PLAYBACK:
+            return "playback";
+        default:
+            assert(!"unexpected audio source");
+            return NULL;
+    }
+}
+
 static sc_pid
 execute_server(struct sc_server *server,
                const struct sc_server_params *params) {
@@ -273,8 +288,9 @@ execute_server(struct sc_server *server,
         assert(params->video_source == SC_VIDEO_SOURCE_CAMERA);
         ADD_PARAM("video_source=camera");
     }
-    if (params->audio_source == SC_AUDIO_SOURCE_MIC) {
-        ADD_PARAM("audio_source=mic");
+    if (params->audio_source != SC_AUDIO_SOURCE_OUTPUT) {
+        ADD_PARAM("audio_source=%s",
+                  sc_server_get_audio_source_name(params->audio_source));
     }
     if (params->max_size) {
         ADD_PARAM("max_size=%" PRIu16, params->max_size);

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -50,6 +50,7 @@ struct sc_server_params {
     uint32_t display_id;
     bool video;
     bool audio;
+    bool audio_dup;
     bool show_touches;
     bool stay_awake;
     bool force_adb_forward;

--- a/doc/audio.md
+++ b/doc/audio.md
@@ -66,6 +66,30 @@ the computer:
 scrcpy --audio-source=mic --no-video --no-playback --record=file.opus
 ```
 
+### Duplication
+
+An alternative device audio capture method is also available (only for Android
+13 and above):
+
+```
+scrcpy --audio-source=playback
+```
+
+This audio source supports keeping the audio playing on the device while
+mirroring, with `--audio-dup`:
+
+```bash
+scrcpy --audio-source=playback --audio-dup
+# or simply:
+scrcpy --audio-dup  # --audio-source=playback is implied
+```
+
+However, it requires Android 13, and Android apps can opt-out (so they are not
+captured).
+
+
+See [#4380](https://github.com/Genymobile/scrcpy/issues/4380).
+
 
 ## Codec
 

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -26,6 +26,7 @@ public class Options {
     private AudioCodec audioCodec = AudioCodec.OPUS;
     private VideoSource videoSource = VideoSource.DISPLAY;
     private AudioSource audioSource = AudioSource.OUTPUT;
+    private boolean audioDup;
     private int videoBitRate = 8000000;
     private int audioBitRate = 128000;
     private int maxFps;
@@ -98,6 +99,10 @@ public class Options {
 
     public AudioSource getAudioSource() {
         return audioSource;
+    }
+
+    public boolean getAudioDup() {
+        return audioDup;
     }
 
     public int getVideoBitRate() {
@@ -302,6 +307,9 @@ public class Options {
                         throw new IllegalArgumentException("Audio source " + value + " not supported");
                     }
                     options.audioSource = audioSource;
+                    break;
+                case "audio_dup":
+                    options.audioDup = Boolean.parseBoolean(value);
                     break;
                 case "max_size":
                     options.maxSize = Integer.parseInt(value) & ~7; // multiple of 8

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -4,7 +4,9 @@ import com.genymobile.scrcpy.audio.AudioCapture;
 import com.genymobile.scrcpy.audio.AudioCodec;
 import com.genymobile.scrcpy.audio.AudioDirectCapture;
 import com.genymobile.scrcpy.audio.AudioEncoder;
+import com.genymobile.scrcpy.audio.AudioPlaybackCapture;
 import com.genymobile.scrcpy.audio.AudioRawRecorder;
+import com.genymobile.scrcpy.audio.AudioSource;
 import com.genymobile.scrcpy.control.ControlChannel;
 import com.genymobile.scrcpy.control.Controller;
 import com.genymobile.scrcpy.control.DeviceMessage;
@@ -164,7 +166,8 @@ public final class Server {
 
             if (audio) {
                 AudioCodec audioCodec = options.getAudioCodec();
-                AudioCapture audioCapture = new AudioDirectCapture(options.getAudioSource());
+                AudioSource audioSource = options.getAudioSource();
+                AudioCapture audioCapture = audioSource.isDirect() ? new AudioDirectCapture(audioSource) : new AudioPlaybackCapture();
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendCodecMeta(), options.getSendFrameMeta());
                 AsyncProcessor audioRecorder;
                 if (audioCodec == AudioCodec.RAW) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -167,7 +167,13 @@ public final class Server {
             if (audio) {
                 AudioCodec audioCodec = options.getAudioCodec();
                 AudioSource audioSource = options.getAudioSource();
-                AudioCapture audioCapture = audioSource.isDirect() ? new AudioDirectCapture(audioSource) : new AudioPlaybackCapture();
+                AudioCapture audioCapture;
+                if (audioSource.isDirect()) {
+                    audioCapture = new AudioDirectCapture(audioSource);
+                } else {
+                    audioCapture = new AudioPlaybackCapture(options.getAudioDup());
+                }
+
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendCodecMeta(), options.getSendFrameMeta());
                 AsyncProcessor audioRecorder;
                 if (audioCodec == AudioCodec.RAW) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy;
 
 import com.genymobile.scrcpy.audio.AudioCapture;
 import com.genymobile.scrcpy.audio.AudioCodec;
+import com.genymobile.scrcpy.audio.AudioDirectCapture;
 import com.genymobile.scrcpy.audio.AudioEncoder;
 import com.genymobile.scrcpy.audio.AudioRawRecorder;
 import com.genymobile.scrcpy.control.ControlChannel;
@@ -163,7 +164,7 @@ public final class Server {
 
             if (audio) {
                 AudioCodec audioCodec = options.getAudioCodec();
-                AudioCapture audioCapture = new AudioCapture(options.getAudioSource());
+                AudioCapture audioCapture = new AudioDirectCapture(options.getAudioSource());
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendCodecMeta(), options.getSendFrameMeta());
                 AsyncProcessor audioRecorder;
                 if (audioCodec == AudioCodec.RAW) {

--- a/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
@@ -1,5 +1,6 @@
 package com.genymobile.scrcpy;
 
+import com.genymobile.scrcpy.audio.AudioCaptureException;
 import com.genymobile.scrcpy.util.Ln;
 
 import android.annotation.SuppressLint;
@@ -195,7 +196,8 @@ public final class Workarounds {
 
     @TargetApi(Build.VERSION_CODES.R)
     @SuppressLint("WrongConstant,MissingPermission")
-    public static AudioRecord createAudioRecord(int source, int sampleRate, int channelConfig, int channels, int channelMask, int encoding) {
+    public static AudioRecord createAudioRecord(int source, int sampleRate, int channelConfig, int channels, int channelMask, int encoding) throws
+            AudioCaptureException {
         // Vivo (and maybe some other third-party ROMs) modified `AudioRecord`'s constructor, requiring `Context`s from real App environment.
         //
         // This method invokes the `AudioRecord(long nativeRecordInJavaObj)` constructor to create an empty `AudioRecord` instance, then uses
@@ -336,8 +338,8 @@ public final class Workarounds {
 
             return audioRecord;
         } catch (Exception e) {
-            Ln.e("Failed to invoke AudioRecord.<init>.", e);
-            throw new RuntimeException("Cannot create AudioRecord");
+            Ln.e("Cannot create AudioRecord", e);
+            throw new AudioCaptureException();
         }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
@@ -109,7 +109,7 @@ public final class AudioCapture {
         }
     }
 
-    private void startRecording() {
+    private void startRecording() throws AudioCaptureException {
         try {
             recorder = createAudioRecord(audioSource);
         } catch (NullPointerException e) {

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
@@ -121,6 +121,13 @@ public final class AudioCapture {
         recorder.startRecording();
     }
 
+    public void checkCompatibility() throws AudioCaptureException {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            Ln.w("Audio disabled: it is not supported before Android 11");
+            throw new AudioCaptureException();
+        }
+    }
+
     public void start() throws AudioCaptureException {
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
             startWorkaroundAndroid11();

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
@@ -89,7 +89,7 @@ public final class AudioCapture {
         ServiceManager.getActivityManager().forceStopPackage(FakeContext.PACKAGE_NAME);
     }
 
-    private void tryStartRecording(int attempts, int delayMs) throws AudioCaptureForegroundException {
+    private void tryStartRecording(int attempts, int delayMs) throws AudioCaptureException {
         while (attempts-- > 0) {
             // Wait for activity to start
             SystemClock.sleep(delayMs);
@@ -101,7 +101,7 @@ public final class AudioCapture {
                     Ln.e("Failed to start audio capture");
                     Ln.e("On Android 11, audio capture must be started in the foreground, make sure that the device is unlocked when starting "
                             + "scrcpy.");
-                    throw new AudioCaptureForegroundException();
+                    throw new AudioCaptureException();
                 } else {
                     Ln.d("Failed to start audio capture, retrying...");
                 }
@@ -121,7 +121,7 @@ public final class AudioCapture {
         recorder.startRecording();
     }
 
-    public void start() throws AudioCaptureForegroundException {
+    public void start() throws AudioCaptureException {
         if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
             startWorkaroundAndroid11();
             try {

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
@@ -9,7 +9,6 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.ComponentName;
 import android.content.Intent;
-import android.media.AudioFormat;
 import android.media.AudioRecord;
 import android.media.AudioTimestamp;
 import android.media.MediaCodec;
@@ -44,14 +43,6 @@ public final class AudioCapture {
         this.audioSource = audioSource.value();
     }
 
-    private static AudioFormat createAudioFormat() {
-        AudioFormat.Builder builder = new AudioFormat.Builder();
-        builder.setEncoding(ENCODING);
-        builder.setSampleRate(SAMPLE_RATE);
-        builder.setChannelMask(CHANNEL_CONFIG);
-        return builder.build();
-    }
-
     @TargetApi(Build.VERSION_CODES.M)
     @SuppressLint({"WrongConstant", "MissingPermission"})
     private static AudioRecord createAudioRecord(int audioSource) {
@@ -61,7 +52,7 @@ public final class AudioCapture {
             builder.setContext(FakeContext.get());
         }
         builder.setAudioSource(audioSource);
-        builder.setAudioFormat(createAudioFormat());
+        builder.setAudioFormat(AudioConfig.createAudioFormat());
         int minBufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, ENCODING);
         // This buffer size does not impact latency
         builder.setBufferSizeInBytes(8 * minBufferSize);

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
@@ -20,17 +20,14 @@ import java.nio.ByteBuffer;
 
 public final class AudioCapture {
 
-    public static final int SAMPLE_RATE = 48000;
-    public static final int CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_STEREO;
-    public static final int CHANNELS = 2;
-    public static final int CHANNEL_MASK = AudioFormat.CHANNEL_IN_LEFT | AudioFormat.CHANNEL_IN_RIGHT;
-    public static final int ENCODING = AudioFormat.ENCODING_PCM_16BIT;
-    public static final int BYTES_PER_SAMPLE = 2;
+    private static final int SAMPLE_RATE = AudioConfig.SAMPLE_RATE;
+    private static final int CHANNEL_CONFIG = AudioConfig.CHANNEL_CONFIG;
+    private static final int CHANNELS = AudioConfig.CHANNELS;
+    private static final int CHANNEL_MASK = AudioConfig.CHANNEL_MASK;
+    private static final int ENCODING = AudioConfig.ENCODING;
+    private static final int BYTES_PER_SAMPLE = AudioConfig.BYTES_PER_SAMPLE;
 
-    // Never read more than 1024 samples, even if the buffer is bigger (that would increase latency).
-    // A lower value is useless, since the system captures audio samples by blocks of 1024 (so for example if we read by blocks of 256 samples, we
-    // receive 4 successive blocks without waiting, then we wait for the 4 next ones).
-    public static final int MAX_READ_SIZE = 1024 * CHANNELS * BYTES_PER_SAMPLE;
+    private static final int MAX_READ_SIZE = AudioConfig.MAX_READ_SIZE;
 
     private static final long ONE_SAMPLE_US = (1000000 + SAMPLE_RATE - 1) / SAMPLE_RATE; // 1 sample in microseconds (used for fixing PTS)
 

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCapture.java
@@ -1,134 +1,20 @@
 package com.genymobile.scrcpy.audio;
 
-import com.genymobile.scrcpy.FakeContext;
-import com.genymobile.scrcpy.util.Ln;
-import com.genymobile.scrcpy.Workarounds;
-import com.genymobile.scrcpy.wrappers.ServiceManager;
-
-import android.annotation.SuppressLint;
-import android.annotation.TargetApi;
-import android.content.ComponentName;
-import android.content.Intent;
-import android.media.AudioRecord;
 import android.media.MediaCodec;
-import android.os.Build;
-import android.os.SystemClock;
 
 import java.nio.ByteBuffer;
 
-public final class AudioCapture {
+public interface AudioCapture {
+    void checkCompatibility() throws AudioCaptureException;
+    void start() throws AudioCaptureException;
+    void stop();
 
-    private static final int SAMPLE_RATE = AudioConfig.SAMPLE_RATE;
-    private static final int CHANNEL_CONFIG = AudioConfig.CHANNEL_CONFIG;
-    private static final int CHANNELS = AudioConfig.CHANNELS;
-    private static final int CHANNEL_MASK = AudioConfig.CHANNEL_MASK;
-    private static final int ENCODING = AudioConfig.ENCODING;
-
-    private final int audioSource;
-
-    private AudioRecord recorder;
-    private AudioRecordReader reader;
-
-    public AudioCapture(AudioSource audioSource) {
-        this.audioSource = audioSource.value();
-    }
-
-    @TargetApi(Build.VERSION_CODES.M)
-    @SuppressLint({"WrongConstant", "MissingPermission"})
-    private static AudioRecord createAudioRecord(int audioSource) {
-        AudioRecord.Builder builder = new AudioRecord.Builder();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            // On older APIs, Workarounds.fillAppInfo() must be called beforehand
-            builder.setContext(FakeContext.get());
-        }
-        builder.setAudioSource(audioSource);
-        builder.setAudioFormat(AudioConfig.createAudioFormat());
-        int minBufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, ENCODING);
-        // This buffer size does not impact latency
-        builder.setBufferSizeInBytes(8 * minBufferSize);
-        return builder.build();
-    }
-
-    private static void startWorkaroundAndroid11() {
-        // Android 11 requires Apps to be at foreground to record audio.
-        // Normally, each App has its own user ID, so Android checks whether the requesting App has the user ID that's at the foreground.
-        // But scrcpy server is NOT an App, it's a Java application started from Android shell, so it has the same user ID (2000) with Android
-        // shell ("com.android.shell").
-        // If there is an Activity from Android shell running at foreground, then the permission system will believe scrcpy is also in the
-        // foreground.
-        Intent intent = new Intent(Intent.ACTION_MAIN);
-        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.addCategory(Intent.CATEGORY_LAUNCHER);
-        intent.setComponent(new ComponentName(FakeContext.PACKAGE_NAME, "com.android.shell.HeapDumpActivity"));
-        ServiceManager.getActivityManager().startActivity(intent);
-    }
-
-    private static void stopWorkaroundAndroid11() {
-        ServiceManager.getActivityManager().forceStopPackage(FakeContext.PACKAGE_NAME);
-    }
-
-    private void tryStartRecording(int attempts, int delayMs) throws AudioCaptureException {
-        while (attempts-- > 0) {
-            // Wait for activity to start
-            SystemClock.sleep(delayMs);
-            try {
-                startRecording();
-                return; // it worked
-            } catch (UnsupportedOperationException e) {
-                if (attempts == 0) {
-                    Ln.e("Failed to start audio capture");
-                    Ln.e("On Android 11, audio capture must be started in the foreground, make sure that the device is unlocked when starting "
-                            + "scrcpy.");
-                    throw new AudioCaptureException();
-                } else {
-                    Ln.d("Failed to start audio capture, retrying...");
-                }
-            }
-        }
-    }
-
-    private void startRecording() throws AudioCaptureException {
-        try {
-            recorder = createAudioRecord(audioSource);
-        } catch (NullPointerException e) {
-            // Creating an AudioRecord using an AudioRecord.Builder does not work on Vivo phones:
-            // - <https://github.com/Genymobile/scrcpy/issues/3805>
-            // - <https://github.com/Genymobile/scrcpy/pull/3862>
-            recorder = Workarounds.createAudioRecord(audioSource, SAMPLE_RATE, CHANNEL_CONFIG, CHANNELS, CHANNEL_MASK, ENCODING);
-        }
-        recorder.startRecording();
-        reader = new AudioRecordReader(recorder);
-    }
-
-    public void checkCompatibility() throws AudioCaptureException {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-            Ln.w("Audio disabled: it is not supported before Android 11");
-            throw new AudioCaptureException();
-        }
-    }
-
-    public void start() throws AudioCaptureException {
-        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
-            startWorkaroundAndroid11();
-            try {
-                tryStartRecording(5, 100);
-            } finally {
-                stopWorkaroundAndroid11();
-            }
-        } else {
-            startRecording();
-        }
-    }
-
-    public void stop() {
-        if (recorder != null) {
-            // Will call .stop() if necessary, without throwing an IllegalStateException
-            recorder.release();
-        }
-    }
-
-    @TargetApi(Build.VERSION_CODES.N)
-    public int read(ByteBuffer outDirectBuffer, MediaCodec.BufferInfo outBufferInfo) {
-        return reader.read(outDirectBuffer, outBufferInfo);
-    }
+    /**
+     * Read a chunk of {@link AudioConfig#MAX_READ_SIZE} samples.
+     *
+     * @param outDirectBuffer The target buffer
+     * @param outBufferInfo The info to provide to MediaCodec
+     * @return the number of bytes actually read.
+     */
+    int read(ByteBuffer outDirectBuffer, MediaCodec.BufferInfo outBufferInfo);
 }

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCaptureException.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCaptureException.java
@@ -1,0 +1,12 @@
+package com.genymobile.scrcpy.audio;
+
+/**
+ * Exception for any audio capture issue.
+ * <p/>
+ * This includes the case where audio capture failed on Android 11 specifically because the running App (Shell) was not in foreground.
+ * <p/>
+ * Its purpose is to disable audio without errors (that's why the exception is empty, any error message must be printed by the caller before
+ * throwing the exception).
+ */
+public class AudioCaptureException extends Exception {
+}

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioCaptureForegroundException.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioCaptureForegroundException.java
@@ -1,7 +1,0 @@
-package com.genymobile.scrcpy.audio;
-
-/**
- * Exception thrown if audio capture failed on Android 11 specifically because the running App (shell) was not in foreground.
- */
-public class AudioCaptureForegroundException extends Exception {
-}

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioConfig.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioConfig.java
@@ -18,4 +18,12 @@ public final class AudioConfig {
     private AudioConfig() {
         // Not instantiable
     }
+
+    public static AudioFormat createAudioFormat() {
+        AudioFormat.Builder builder = new AudioFormat.Builder();
+        builder.setEncoding(ENCODING);
+        builder.setSampleRate(SAMPLE_RATE);
+        builder.setChannelMask(CHANNEL_CONFIG);
+        return builder.build();
+    }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioConfig.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioConfig.java
@@ -1,0 +1,21 @@
+package com.genymobile.scrcpy.audio;
+
+import android.media.AudioFormat;
+
+public final class AudioConfig {
+    public static final int SAMPLE_RATE = 48000;
+    public static final int CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_STEREO;
+    public static final int CHANNELS = 2;
+    public static final int CHANNEL_MASK = AudioFormat.CHANNEL_IN_LEFT | AudioFormat.CHANNEL_IN_RIGHT;
+    public static final int ENCODING = AudioFormat.ENCODING_PCM_16BIT;
+    public static final int BYTES_PER_SAMPLE = 2;
+
+    // Never read more than 1024 samples, even if the buffer is bigger (that would increase latency).
+    // A lower value is useless, since the system captures audio samples by blocks of 1024 (so for example if we read by blocks of 256 samples, we
+    // receive 4 successive blocks without waiting, then we wait for the 4 next ones).
+    public static final int MAX_READ_SIZE = 1024 * CHANNELS * BYTES_PER_SAMPLE;
+
+    private AudioConfig() {
+        // Not instantiable
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioDirectCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioDirectCapture.java
@@ -11,6 +11,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.media.AudioRecord;
 import android.media.MediaCodec;
+import android.media.MediaRecorder;
 import android.os.Build;
 import android.os.SystemClock;
 
@@ -30,7 +31,18 @@ public class AudioDirectCapture implements AudioCapture {
     private AudioRecordReader reader;
 
     public AudioDirectCapture(AudioSource audioSource) {
-        this.audioSource = audioSource.value();
+        this.audioSource = getAudioSourceValue(audioSource);
+    }
+
+    private static int getAudioSourceValue(AudioSource audioSource) {
+        switch (audioSource) {
+            case OUTPUT:
+                return MediaRecorder.AudioSource.REMOTE_SUBMIX;
+            case MIC:
+                return MediaRecorder.AudioSource.MIC;
+            default:
+                throw new IllegalArgumentException("Unsupported audio source: " + audioSource);
+        }
     }
 
     @TargetApi(Build.VERSION_CODES.M)

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioDirectCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioDirectCapture.java
@@ -1,0 +1,138 @@
+package com.genymobile.scrcpy.audio;
+
+import com.genymobile.scrcpy.FakeContext;
+import com.genymobile.scrcpy.Workarounds;
+import com.genymobile.scrcpy.util.Ln;
+import com.genymobile.scrcpy.wrappers.ServiceManager;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.media.AudioRecord;
+import android.media.MediaCodec;
+import android.os.Build;
+import android.os.SystemClock;
+
+import java.nio.ByteBuffer;
+
+public class AudioDirectCapture implements AudioCapture {
+
+    private static final int SAMPLE_RATE = AudioConfig.SAMPLE_RATE;
+    private static final int CHANNEL_CONFIG = AudioConfig.CHANNEL_CONFIG;
+    private static final int CHANNELS = AudioConfig.CHANNELS;
+    private static final int CHANNEL_MASK = AudioConfig.CHANNEL_MASK;
+    private static final int ENCODING = AudioConfig.ENCODING;
+
+    private final int audioSource;
+
+    private AudioRecord recorder;
+    private AudioRecordReader reader;
+
+    public AudioDirectCapture(AudioSource audioSource) {
+        this.audioSource = audioSource.value();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    @SuppressLint({"WrongConstant", "MissingPermission"})
+    private static AudioRecord createAudioRecord(int audioSource) {
+        AudioRecord.Builder builder = new AudioRecord.Builder();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // On older APIs, Workarounds.fillAppInfo() must be called beforehand
+            builder.setContext(FakeContext.get());
+        }
+        builder.setAudioSource(audioSource);
+        builder.setAudioFormat(AudioConfig.createAudioFormat());
+        int minBufferSize = AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, ENCODING);
+        // This buffer size does not impact latency
+        builder.setBufferSizeInBytes(8 * minBufferSize);
+        return builder.build();
+    }
+
+    private static void startWorkaroundAndroid11() {
+        // Android 11 requires Apps to be at foreground to record audio.
+        // Normally, each App has its own user ID, so Android checks whether the requesting App has the user ID that's at the foreground.
+        // But scrcpy server is NOT an App, it's a Java application started from Android shell, so it has the same user ID (2000) with Android
+        // shell ("com.android.shell").
+        // If there is an Activity from Android shell running at foreground, then the permission system will believe scrcpy is also in the
+        // foreground.
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.addCategory(Intent.CATEGORY_LAUNCHER);
+        intent.setComponent(new ComponentName(FakeContext.PACKAGE_NAME, "com.android.shell.HeapDumpActivity"));
+        ServiceManager.getActivityManager().startActivity(intent);
+    }
+
+    private static void stopWorkaroundAndroid11() {
+        ServiceManager.getActivityManager().forceStopPackage(FakeContext.PACKAGE_NAME);
+    }
+
+    private void tryStartRecording(int attempts, int delayMs) throws AudioCaptureException {
+        while (attempts-- > 0) {
+            // Wait for activity to start
+            SystemClock.sleep(delayMs);
+            try {
+                startRecording();
+                return; // it worked
+            } catch (UnsupportedOperationException e) {
+                if (attempts == 0) {
+                    Ln.e("Failed to start audio capture");
+                    Ln.e("On Android 11, audio capture must be started in the foreground, make sure that the device is unlocked when starting "
+                            + "scrcpy.");
+                    throw new AudioCaptureException();
+                } else {
+                    Ln.d("Failed to start audio capture, retrying...");
+                }
+            }
+        }
+    }
+
+    private void startRecording() throws AudioCaptureException {
+        try {
+            recorder = createAudioRecord(audioSource);
+        } catch (NullPointerException e) {
+            // Creating an AudioRecord using an AudioRecord.Builder does not work on Vivo phones:
+            // - <https://github.com/Genymobile/scrcpy/issues/3805>
+            // - <https://github.com/Genymobile/scrcpy/pull/3862>
+            recorder = Workarounds.createAudioRecord(audioSource, SAMPLE_RATE, CHANNEL_CONFIG, CHANNELS, CHANNEL_MASK, ENCODING);
+        }
+        recorder.startRecording();
+        reader = new AudioRecordReader(recorder);
+    }
+
+    @Override
+    public void checkCompatibility() throws AudioCaptureException {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            Ln.w("Audio disabled: it is not supported before Android 11");
+            throw new AudioCaptureException();
+        }
+    }
+
+    @Override
+    public void start() throws AudioCaptureException {
+        if (Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
+            startWorkaroundAndroid11();
+            try {
+                tryStartRecording(5, 100);
+            } finally {
+                stopWorkaroundAndroid11();
+            }
+        } else {
+            startRecording();
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (recorder != null) {
+            // Will call .stop() if necessary, without throwing an IllegalStateException
+            recorder.release();
+        }
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.N)
+    public int read(ByteBuffer outDirectBuffer, MediaCodec.BufferInfo outBufferInfo) {
+        return reader.read(outDirectBuffer, outBufferInfo);
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
@@ -176,7 +176,7 @@ public final class AudioEncoder implements AsyncProcessor {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    public void encode() throws IOException, ConfigurationException, AudioCaptureForegroundException {
+    private void encode() throws IOException, ConfigurationException, AudioCaptureForegroundException {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             Ln.w("Audio disabled: it is not supported before Android 11");
             streamer.writeDisableStream(false);

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
@@ -44,8 +44,8 @@ public final class AudioEncoder implements AsyncProcessor {
         }
     }
 
-    private static final int SAMPLE_RATE = AudioCapture.SAMPLE_RATE;
-    private static final int CHANNELS = AudioCapture.CHANNELS;
+    private static final int SAMPLE_RATE = AudioConfig.SAMPLE_RATE;
+    private static final int CHANNELS = AudioConfig.CHANNELS;
 
     private final AudioCapture capture;
     private final Streamer streamer;

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
@@ -132,7 +132,7 @@ public final class AudioEncoder implements AsyncProcessor {
             } catch (ConfigurationException e) {
                 // Do not print stack trace, a user-friendly error-message has already been logged
                 fatalError = true;
-            } catch (AudioCaptureForegroundException e) {
+            } catch (AudioCaptureException e) {
                 // Do not print stack trace, a user-friendly error-message has already been logged
             } catch (IOException e) {
                 Ln.e("Audio encoding error", e);
@@ -176,7 +176,7 @@ public final class AudioEncoder implements AsyncProcessor {
     }
 
     @TargetApi(Build.VERSION_CODES.M)
-    private void encode() throws IOException, ConfigurationException, AudioCaptureForegroundException {
+    private void encode() throws IOException, ConfigurationException, AudioCaptureException {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             Ln.w("Audio disabled: it is not supported before Android 11");
             streamer.writeDisableStream(false);

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioEncoder.java
@@ -187,6 +187,8 @@ public final class AudioEncoder implements AsyncProcessor {
 
         boolean mediaCodecStarted = false;
         try {
+            capture.checkCompatibility(); // throws an AudioCaptureException on error
+
             Codec codec = streamer.getCodec();
             mediaCodec = createMediaCodec(codec, encoderName);
 

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
@@ -1,0 +1,130 @@
+package com.genymobile.scrcpy.audio;
+
+import com.genymobile.scrcpy.FakeContext;
+import com.genymobile.scrcpy.util.Ln;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioRecord;
+import android.media.MediaCodec;
+import android.os.Build;
+
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+
+public final class AudioPlaybackCapture implements AudioCapture {
+
+    private AudioRecord recorder;
+    private AudioRecordReader reader;
+
+    @SuppressLint("PrivateApi")
+    private AudioRecord createAudioRecord() throws AudioCaptureException {
+        // See <https://github.com/Genymobile/scrcpy/issues/4380>
+        try {
+            Class<?> audioMixingRuleClass = Class.forName("android.media.audiopolicy.AudioMixingRule");
+            Class<?> audioMixingRuleBuilderClass = Class.forName("android.media.audiopolicy.AudioMixingRule$Builder");
+
+            // AudioMixingRule.Builder audioMixingRuleBuilder = new AudioMixingRule.Builder();
+            Object audioMixingRuleBuilder = audioMixingRuleBuilderClass.getConstructor().newInstance();
+
+            // audioMixingRuleBuilder.setTargetMixRole(AudioMixingRule.MIX_ROLE_PLAYERS);
+            int mixRolePlayersConstant = audioMixingRuleClass.getField("MIX_ROLE_PLAYERS").getInt(null);
+            Method setTargetMixRoleMethod = audioMixingRuleBuilderClass.getMethod("setTargetMixRole", int.class);
+            setTargetMixRoleMethod.invoke(audioMixingRuleBuilder, mixRolePlayersConstant);
+
+            AudioAttributes attributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build();
+
+            // audioMixingRuleBuilder.addMixRule(AudioMixingRule.RULE_MATCH_ATTRIBUTE_USAGE, attributes);
+            int ruleMatchAttributeUsageConstant = audioMixingRuleClass.getField("RULE_MATCH_ATTRIBUTE_USAGE").getInt(null);
+            Method addMixRuleMethod = audioMixingRuleBuilderClass.getMethod("addMixRule", int.class, Object.class);
+            addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant, attributes);
+
+            // AudioMixingRule audioMixingRule = builder.build();
+            Object audioMixingRule = audioMixingRuleBuilderClass.getMethod("build").invoke(audioMixingRuleBuilder);
+
+            // audioMixingRuleBuilder.voiceCommunicationCaptureAllowed(true);
+            Method voiceCommunicationCaptureAllowedMethod = audioMixingRuleBuilderClass.getMethod("voiceCommunicationCaptureAllowed", boolean.class);
+            voiceCommunicationCaptureAllowedMethod.invoke(audioMixingRuleBuilder, true);
+
+            Class<?> audioMixClass = Class.forName("android.media.audiopolicy.AudioMix");
+            Class<?> audioMixBuilderClass = Class.forName("android.media.audiopolicy.AudioMix$Builder");
+
+            // AudioMix.Builder audioMixBuilder = new AudioMix.Builder(audioMixingRule);
+            Object audioMixBuilder = audioMixBuilderClass.getConstructor(audioMixingRuleClass).newInstance(audioMixingRule);
+
+            // audioMixBuilder.setFormat(createAudioFormat());
+            Method setFormat = audioMixBuilder.getClass().getMethod("setFormat", AudioFormat.class);
+            setFormat.invoke(audioMixBuilder, AudioConfig.createAudioFormat());
+
+            int routeFlags = audioMixClass.getField("ROUTE_FLAG_LOOP_BACK").getInt(null);
+
+            // audioMixBuilder.setRouteFlags(routeFlag);
+            Method setRouteFlags = audioMixBuilder.getClass().getMethod("setRouteFlags", int.class);
+            setRouteFlags.invoke(audioMixBuilder, routeFlags);
+
+            // AudioMix audioMix = audioMixBuilder.build();
+            Object audioMix = audioMixBuilderClass.getMethod("build").invoke(audioMixBuilder);
+
+            Class<?> audioPolicyClass = Class.forName("android.media.audiopolicy.AudioPolicy");
+            Class<?> audioPolicyBuilderClass = Class.forName("android.media.audiopolicy.AudioPolicy$Builder");
+
+            // AudioPolicy.Builder audioPolicyBuilder = new AudioPolicy.Builder();
+            Object audioPolicyBuilder = audioPolicyBuilderClass.getConstructor(Context.class).newInstance(FakeContext.get());
+
+            // audioPolicyBuilder.addMix(audioMix);
+            Method addMixMethod = audioPolicyBuilderClass.getMethod("addMix", audioMixClass);
+            addMixMethod.invoke(audioPolicyBuilder, audioMix);
+
+            // AudioPolicy audioPolicy = audioPolicyBuilder.build();
+            Object audioPolicy = audioPolicyBuilderClass.getMethod("build").invoke(audioPolicyBuilder);
+
+            // AudioManager.registerAudioPolicyStatic(audioPolicy);
+            Method registerAudioPolicyStaticMethod = AudioManager.class.getDeclaredMethod("registerAudioPolicyStatic", audioPolicyClass);
+            registerAudioPolicyStaticMethod.setAccessible(true);
+            int result = (int) registerAudioPolicyStaticMethod.invoke(null, audioPolicy);
+            if (result != 0) {
+                throw new RuntimeException("registerAudioPolicy() returned " + result);
+            }
+
+            // audioPolicy.createAudioRecordSink(audioPolicy);
+            Method createAudioRecordSinkClass = audioPolicyClass.getMethod("createAudioRecordSink", audioMixClass);
+            return (AudioRecord) createAudioRecordSinkClass.invoke(audioPolicy, audioMix);
+        } catch (Exception e) {
+            Ln.e("Could not capture audio playback", e);
+            throw new AudioCaptureException();
+        }
+    }
+
+    @Override
+    public void checkCompatibility() throws AudioCaptureException {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            Ln.w("Audio disabled: audio playback capture source not supported before Android 13");
+            throw new AudioCaptureException();
+        }
+    }
+
+    @Override
+    public void start() throws AudioCaptureException {
+        recorder = createAudioRecord();
+        recorder.startRecording();
+        reader = new AudioRecordReader(recorder);
+    }
+
+    @Override
+    public void stop() {
+        if (recorder != null) {
+            // Will call .stop() if necessary, without throwing an IllegalStateException
+            recorder.release();
+        }
+    }
+
+    @Override
+    @TargetApi(Build.VERSION_CODES.N)
+    public int read(ByteBuffer outDirectBuffer, MediaCodec.BufferInfo outBufferInfo) {
+        return reader.read(outDirectBuffer, outBufferInfo);
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
@@ -18,8 +18,14 @@ import java.nio.ByteBuffer;
 
 public final class AudioPlaybackCapture implements AudioCapture {
 
+    private final boolean keepPlayingOnDevice;
+
     private AudioRecord recorder;
     private AudioRecordReader reader;
+
+    public AudioPlaybackCapture(boolean keepPlayingOnDevice) {
+        this.keepPlayingOnDevice = keepPlayingOnDevice;
+    }
 
     @SuppressLint("PrivateApi")
     private AudioRecord createAudioRecord() throws AudioCaptureException {
@@ -60,7 +66,8 @@ public final class AudioPlaybackCapture implements AudioCapture {
             Method setFormat = audioMixBuilder.getClass().getMethod("setFormat", AudioFormat.class);
             setFormat.invoke(audioMixBuilder, AudioConfig.createAudioFormat());
 
-            int routeFlags = audioMixClass.getField("ROUTE_FLAG_LOOP_BACK").getInt(null);
+            String routeFlagName = keepPlayingOnDevice ? "ROUTE_FLAG_LOOP_BACK_RENDER" : "ROUTE_FLAG_LOOP_BACK";
+            int routeFlags = audioMixClass.getField(routeFlagName).getInt(null);
 
             // audioMixBuilder.setRouteFlags(routeFlag);
             Method setRouteFlags = audioMixBuilder.getClass().getMethod("setRouteFlags", int.class);

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioRawRecorder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioRawRecorder.java
@@ -30,7 +30,7 @@ public final class AudioRawRecorder implements AsyncProcessor {
             return;
         }
 
-        final ByteBuffer buffer = ByteBuffer.allocateDirect(AudioCapture.MAX_READ_SIZE);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(AudioConfig.MAX_READ_SIZE);
         final MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
 
         try {

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioRawRecorder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioRawRecorder.java
@@ -23,7 +23,7 @@ public final class AudioRawRecorder implements AsyncProcessor {
         this.streamer = streamer;
     }
 
-    private void record() throws IOException, AudioCaptureForegroundException {
+    private void record() throws IOException, AudioCaptureException {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             Ln.w("Audio disabled: it is not supported before Android 11");
             streamer.writeDisableStream(false);
@@ -69,7 +69,7 @@ public final class AudioRawRecorder implements AsyncProcessor {
             boolean fatalError = false;
             try {
                 record();
-            } catch (AudioCaptureForegroundException e) {
+            } catch (AudioCaptureException e) {
                 // Do not print stack trace, a user-friendly error-message has already been logged
             } catch (Throwable t) {
                 Ln.e("Audio recording error", t);

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioRecordReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioRecordReader.java
@@ -1,0 +1,67 @@
+package com.genymobile.scrcpy.audio;
+
+import com.genymobile.scrcpy.util.Ln;
+
+import android.annotation.TargetApi;
+import android.media.AudioRecord;
+import android.media.AudioTimestamp;
+import android.media.MediaCodec;
+import android.os.Build;
+
+import java.nio.ByteBuffer;
+
+public class AudioRecordReader {
+
+    private static final long ONE_SAMPLE_US =
+            (1000000 + AudioConfig.SAMPLE_RATE - 1) / AudioConfig.SAMPLE_RATE; // 1 sample in microseconds (used for fixing PTS)
+
+    private final AudioRecord recorder;
+
+    private final AudioTimestamp timestamp = new AudioTimestamp();
+    private long previousRecorderTimestamp = -1;
+    private long previousPts = 0;
+    private long nextPts = 0;
+
+    public AudioRecordReader(AudioRecord recorder) {
+        this.recorder = recorder;
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    public int read(ByteBuffer outDirectBuffer, MediaCodec.BufferInfo outBufferInfo) {
+        int r = recorder.read(outDirectBuffer, AudioConfig.MAX_READ_SIZE);
+        if (r <= 0) {
+            return r;
+        }
+
+        long pts;
+
+        int ret = recorder.getTimestamp(timestamp, AudioTimestamp.TIMEBASE_MONOTONIC);
+        if (ret == AudioRecord.SUCCESS && timestamp.nanoTime != previousRecorderTimestamp) {
+            pts = timestamp.nanoTime / 1000;
+            previousRecorderTimestamp = timestamp.nanoTime;
+        } else {
+            if (nextPts == 0) {
+                Ln.w("Could not get initial audio timestamp");
+                nextPts = System.nanoTime() / 1000;
+            }
+            // compute from previous timestamp and packet size
+            pts = nextPts;
+        }
+
+        long durationUs = r * 1000000L / (AudioConfig.CHANNELS * AudioConfig.BYTES_PER_SAMPLE * AudioConfig.SAMPLE_RATE);
+        nextPts = pts + durationUs;
+
+        if (previousPts != 0 && pts < previousPts + ONE_SAMPLE_US) {
+            // Audio PTS may come from two sources:
+            //  - recorder.getTimestamp() if the call works;
+            //  - an estimation from the previous PTS and the packet size as a fallback.
+            //
+            // Therefore, the property that PTS are monotonically increasing is no guaranteed in corner cases, so enforce it.
+            pts = previousPts + ONE_SAMPLE_US;
+        }
+        previousPts = pts;
+
+        outBufferInfo.set(0, r, pts, 0);
+        return r;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioSource.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioSource.java
@@ -2,12 +2,17 @@ package com.genymobile.scrcpy.audio;
 
 public enum AudioSource {
     OUTPUT("output"),
-    MIC("mic");
+    MIC("mic"),
+    PLAYBACK("playback");
 
     private final String name;
 
     AudioSource(String name) {
         this.name = name;
+    }
+
+    public boolean isDirect() {
+        return this != PLAYBACK;
     }
 
     public static AudioSource findByName(String name) {

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioSource.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioSource.java
@@ -1,21 +1,13 @@
 package com.genymobile.scrcpy.audio;
 
-import android.media.MediaRecorder;
-
 public enum AudioSource {
-    OUTPUT("output", MediaRecorder.AudioSource.REMOTE_SUBMIX),
-    MIC("mic", MediaRecorder.AudioSource.MIC);
+    OUTPUT("output"),
+    MIC("mic");
 
     private final String name;
-    private final int value;
 
-    AudioSource(String name, int value) {
+    AudioSource(String name) {
         this.name = name;
-        this.value = value;
-    }
-
-    int value() {
-        return value;
     }
 
     public static AudioSource findByName(String name) {


### PR DESCRIPTION
Add a new method to capture audio on the device, provided by @yume-chan  in #4380. It is exposed as a separate audio source (in addition to `output` and `mic`):

```
scrcpy --audio-source=playback
```

There are pros and cons, as noted by @yume-chan:

> Pros:
>
> - Can choose to continue playing audio on device
> - Not affected by connected headsets
> - Not affected by system volume
> - […]
>
> Cons:
>
> - Requires Android 13, in which the Shell app has MODIFY_AUDIO_ROUTING permission added
> - Apps can opt out from being captured. […]

With this audio source, it is possible to request to keep playing on the device while mirroring:

```
scrcpy --audio-source=playback --audio-dup
```

If the audio source is not specified and `--audio-dup` is set, then it is implicitly set to `--audio-source=playback`:

```bash
scrcpy --audio-dup   # equivalent
```

Fixes #3875

---

Here is a binary for Windows:

- [`scrcpy-win64-audiodup.zip`](https://tmp.rom1v.com/scrcpy/5102/1/scrcpy-win64-audiodup.zip) <sub>`SHA-256: 334e2579ed0f2a684c7e6a88082ac65259379d5de57989c4ab2ba1a9364cf28`</sub>

Feedback welcome :wink: 