### PR TITLE
Fix Honor Android 14 devices --turn-screen-off failed

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -323,7 +323,19 @@ public final class Device {
      * @param mode one of the {@code POWER_MODE_*} constants
      */
     public static boolean setScreenPowerMode(int mode) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        boolean applyToMultiPhysicalDisplays = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
+
+        if (applyToMultiPhysicalDisplays
+                && Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+                && Build.BRAND.equalsIgnoreCase("honor")
+                && SurfaceControl.hasGetBuildInDisplayMethod()) {
+            // Workaround for Honor devices with Android 14:
+            //  - <https://github.com/Genymobile/scrcpy/issues/4823>
+            //  - <https://github.com/Genymobile/scrcpy/issues/4943>
+            applyToMultiPhysicalDisplays = false;
+        }
+
+        if (applyToMultiPhysicalDisplays) {
             // On Android 14, these internal methods have been moved to DisplayControl
             boolean useDisplayControl =
                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE && !SurfaceControl.hasPhysicalDisplayIdsMethod();

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/SurfaceControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/SurfaceControl.java
@@ -94,6 +94,15 @@ public final class SurfaceControl {
         return getBuiltInDisplayMethod;
     }
 
+    public static boolean hasGetBuildInDisplayMethod() {
+        try {
+            getGetBuiltInDisplayMethod();
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
     public static IBinder getBuiltInDisplay() {
         try {
             Method method = getGetBuiltInDisplayMethod();


### PR DESCRIPTION
Only fix Honor devices running Android 14. #4823 
Android 14 framework.jar: https://github.com/Genymobile/scrcpy/pull/4822#issuecomment-2041359942

---

Honor devices running Android 13 and below still have SurfaceControl.getPhysicalDisplayIds().
Android 13 framework.jar: https://github.com/Genymobile/scrcpy/issues/3885#issuecomment-1492890154