### PR TITLE
Add workaround for TCL Android 12 Smart TVs.

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
@@ -72,6 +72,11 @@ public final class Workarounds {
             //  - <https://github.com/Genymobile/scrcpy/issues/3805#issuecomment-1596148031>
             mustFillAppInfo = true;
             mustFillAppContext = true;
+        } else if (Build.BRAND.equalsIgnoreCase("tcl") && Build.VERSION.SDK_INT == Build.VERSION_CODES.S) {
+            // Workarounds must be applied for certain TCL devices:
+            //  - <https://github.com/Genymobile/scrcpy/issues/5140>
+            mustFillAppInfo = true;
+            mustFillAppContext = true;
         }
 
         if (audio && Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {


### PR DESCRIPTION
Fixes genymobile/scrcpy#5140

A fix for a bug which caused scrcpy to crash generating a video stream on certain TCL Android TVs.

Manufacturer's custom code expects to have access information about the activity. 
Fix follows similar pattern to workarounds for other manufacturers, providing them the fake context.

Scoped only to android 12. 