### PR TITLE
Add ability to setup server by config file

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -19,6 +19,7 @@
 
 enum {
     OPT_BIT_RATE = 1000,
+    OPT_SERVER_CONFIG,
     OPT_WINDOW_TITLE,
     OPT_PUSH_TARGET,
     OPT_ALWAYS_ON_TOP,
@@ -284,6 +285,17 @@ static const struct sc_option options[] = {
                 "The values are expressed in the device natural orientation "
                 "(typically, portrait for a phone, landscape for a tablet). "
                 "Any --max-size value is computed on the cropped size.",
+    },
+    {
+        .longopt_id = OPT_SERVER_CONFIG,
+        .longopt = "server-config",
+        .argdesc = "/path/to/config",
+        .text = "Server configuration file path.\n"
+                "The file must be in Properties format.\n"
+                "Exmaple:\n"
+                "# scrcpy server configuration\n"
+                "power_off_on_close=true\n"
+                "cleanup=true\n",
     },
     {
         .shortopt = 'd',
@@ -2144,6 +2156,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_CROP:
                 opts->crop = optarg;
+                break;
+            case OPT_SERVER_CONFIG:
+                opts->server_config = optarg;
                 break;
             case OPT_DISPLAY:
                 LOGW("--display is deprecated, use --display-id instead.");

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -2,6 +2,7 @@
 
 const struct scrcpy_options scrcpy_options_default = {
     .serial = NULL,
+    .server_config = NULL,
     .crop = NULL,
     .record_filename = NULL,
     .window_title = NULL,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -204,6 +204,7 @@ struct sc_port_range {
 
 struct scrcpy_options {
     const char *serial;
+    const char *server_config;
     const char *crop;
     const char *record_filename;
     const char *window_title;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -377,6 +377,7 @@ scrcpy(struct scrcpy_options *options) {
         .audio_source = options->audio_source,
         .camera_facing = options->camera_facing,
         .crop = options->crop,
+        .config = options->server_config,
         .port_range = options->port_range,
         .tunnel_host = options->tunnel_host,
         .tunnel_port = options->tunnel_port,
@@ -417,7 +418,8 @@ scrcpy(struct scrcpy_options *options) {
         .on_connected = sc_server_on_connected,
         .on_disconnected = sc_server_on_disconnected,
     };
-    if (!sc_server_init(&s->server, &params, &cbs, NULL)) {
+
+    if (!sc_server_init(&s->server, options->server_config, &params, &cbs, NULL)) {
         return SCRCPY_EXIT_FAILURE;
     }
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -19,6 +19,7 @@
 
 #define SC_SERVER_PATH_DEFAULT PREFIX "/share/scrcpy/" SC_SERVER_FILENAME
 #define SC_DEVICE_SERVER_PATH "/data/local/tmp/scrcpy-server.jar"
+#define SC_DEVICE_SERVER_CONFIG_PATH "/data/local/tmp/scrcpy-server.properties"
 
 #define SC_ADB_PORT_DEFAULT 5555
 #define SC_SOCKET_NAME_PREFIX "scrcpy_"
@@ -71,6 +72,7 @@ sc_server_params_destroy(struct sc_server_params *params) {
     // The server stores a copy of the params provided by the user
     free((char *) params->req_serial);
     free((char *) params->crop);
+    free((char *) params->config);
     free((char *) params->video_codec_options);
     free((char *) params->audio_codec_options);
     free((char *) params->video_encoder);
@@ -100,6 +102,7 @@ sc_server_params_copy(struct sc_server_params *dst,
 
     COPY(req_serial);
     COPY(crop);
+    COPY(config);
     COPY(video_codec_options);
     COPY(audio_codec_options);
     COPY(video_encoder);
@@ -114,6 +117,18 @@ sc_server_params_copy(struct sc_server_params *dst,
 error:
     sc_server_params_destroy(dst);
     return false;
+}
+
+static bool
+push_server_config(struct sc_intr *intr,
+                   const char *serial,
+                   const char *config) {
+    if (!sc_file_is_regular(config)) {
+        LOGE("'%s' does not exist or is not a regular file\n", config);
+        return false;
+    }
+
+    return sc_adb_push(intr, serial, config, SC_DEVICE_SERVER_CONFIG_PATH, 0);
 }
 
 static bool
@@ -290,6 +305,9 @@ execute_server(struct sc_server *server,
     if (params->crop) {
         ADD_PARAM("crop=%s", params->crop);
     }
+    if (params->config) {
+        ADD_PARAM("config=%s", SC_DEVICE_SERVER_CONFIG_PATH);
+    }
     if (!params->control) {
         // By default, control is true
         ADD_PARAM("control=false");
@@ -381,6 +399,8 @@ execute_server(struct sc_server *server,
     //     Port: 5005
     // Then click on "Debug"
 #endif
+    LOGI("Server command: %s %s %s", cmd[9], cmd[10], cmd[11]);
+
     // Inherit both stdout and stderr (all server logs are printed to stdout)
     pid = sc_adb_execute(cmd, 0);
 
@@ -445,8 +465,11 @@ connect_to_server(struct sc_server *server, unsigned attempts, sc_tick delay,
 }
 
 bool
-sc_server_init(struct sc_server *server, const struct sc_server_params *params,
-              const struct sc_server_callbacks *cbs, void *cbs_userdata) {
+sc_server_init(struct sc_server *server,
+               const char *config_path,
+               const struct sc_server_params *params,
+               const struct sc_server_callbacks *cbs, 
+               void *cbs_userdata) {
     bool ok = sc_server_params_copy(&server->params, params);
     if (!ok) {
         LOG_OOM();
@@ -475,6 +498,7 @@ sc_server_init(struct sc_server *server, const struct sc_server_params *params,
     }
 
     server->serial = NULL;
+    server->config = config_path != NULL ? strdup(config_path) : NULL;
     server->device_socket_name = NULL;
     server->stopped = false;
 
@@ -937,6 +961,13 @@ run_server(void *data) {
     assert(serial);
     LOGD("Device serial: %s", serial);
 
+    if (server->config) {
+        ok = push_server_config(&server->intr, serial, server->config);
+        if (!ok) {
+            goto error_connection_failed;
+        }
+    }
+
     ok = push_server(&server->intr, serial);
     if (!ok) {
         goto error_connection_failed;
@@ -1100,6 +1131,7 @@ sc_server_destroy(struct sc_server *server) {
     }
 
     free(server->serial);
+    free(server->config);
     free(server->device_socket_name);
     sc_server_params_destroy(&server->params);
     sc_intr_destroy(&server->intr);

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -30,6 +30,7 @@ struct sc_server_params {
     enum sc_audio_source audio_source;
     enum sc_camera_facing camera_facing;
     const char *crop;
+    const char *config;
     const char *video_codec_options;
     const char *audio_codec_options;
     const char *video_encoder;
@@ -70,6 +71,7 @@ struct sc_server_params {
 struct sc_server {
     // The internal allocated strings are copies owned by the server
     struct sc_server_params params;
+    char *config;
     char *serial;
     char *device_socket_name;
 
@@ -113,7 +115,7 @@ struct sc_server_callbacks {
 
 // init the server with the given params
 bool
-sc_server_init(struct sc_server *server, const struct sc_server_params *params,
+sc_server_init(struct sc_server *server, const char *config_path, const struct sc_server_params *params,
                const struct sc_server_callbacks *cbs, void *cbs_userdata);
 
 // start the server asynchronously

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -25,8 +25,8 @@ public final class CleanUp {
         this.out = out;
     }
 
-    public static CleanUp configure(int displayId) throws IOException {
-        String[] cmd = {"app_process", "/", CleanUp.class.getName(), String.valueOf(displayId)};
+    public static CleanUp configure(int displayId, String configPath) throws IOException {
+        String[] cmd = {"app_process", "/", CleanUp.class.getName(), String.valueOf(displayId), configPath};
 
         ProcessBuilder builder = new ProcessBuilder(cmd);
         builder.environment().put("CLASSPATH", Server.SERVER_PATH);
@@ -78,6 +78,7 @@ public final class CleanUp {
         unlinkSelf();
 
         int displayId = Integer.parseInt(args[0]);
+        String configPath = args.length > 1 ? args[1] : null;
 
         int restoreStayOn = -1;
         boolean disableShowTouches = false;
@@ -113,6 +114,14 @@ public final class CleanUp {
         }
 
         Ln.i("Cleaning up");
+
+        if (configPath != null && !configPath.isBlank()) {
+            try {
+                new File(configPath).delete();
+            } catch (Exception e) {
+                Ln.e("Could not unlink server config", e);
+            }
+        }
 
         if (disableShowTouches) {
             Ln.i("Disabling \"show touches\"");

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -2,10 +2,18 @@ package com.genymobile.scrcpy;
 
 import android.graphics.Rect;
 
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
 
 public class Options {
+
+    private String configPath;
 
     private Ln.Level logLevel = Ln.Level.DEBUG;
     private int scid = -1; // 31-bit non-negative value, or -1
@@ -53,6 +61,10 @@ public class Options {
     private boolean sendFrameMeta = true; // send PTS so that the client may record properly
     private boolean sendDummyByte = true; // write a byte on start to detect connection issues
     private boolean sendCodecMeta = true; // write the codec metadata before the stream
+
+    public String getConfigPath() {
+        return configPath;
+    }
 
     public Ln.Level getLogLevel() {
         return logLevel;
@@ -238,17 +250,34 @@ public class Options {
                     "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "(" + clientVersion + ")");
         }
 
+        Properties params = new Properties();
+
+        try {
+            String[] arguments = Arrays.copyOfRange(args, 1, args.length);
+            StringReader reader = new StringReader(String.join("\n", arguments));
+
+            params.load(reader);
+            reader.close();
+
+            if (params.containsKey("config")) {
+                String configFilename = params.getProperty("config");
+                Properties configParams = Options.loadFromConfig(configFilename);
+                params.putAll(configParams);
+
+                Ln.i("Add options from \"" + configFilename + "\"");
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+
         Options options = new Options();
 
-        for (int i = 1; i < args.length; ++i) {
-            String arg = args[i];
-            int equalIndex = arg.indexOf('=');
-            if (equalIndex == -1) {
-                throw new IllegalArgumentException("Invalid key=value pair: \"" + arg + "\"");
-            }
-            String key = arg.substring(0, equalIndex);
-            String value = arg.substring(equalIndex + 1);
+        for (String key : params.stringPropertyNames()) {
+            String value = params.getProperty(key, "");
             switch (key) {
+                case "config":
+                    options.configPath = value;
+                    break;
                 case "scid":
                     int scid = Integer.parseInt(value, 0x10);
                     if (scid < -1) {
@@ -468,5 +497,19 @@ public class Options {
 
         float floatAr = Float.parseFloat(tokens[0]);
         return CameraAspectRatio.fromFloat(floatAr);
+    }
+
+    private static Properties loadFromConfig(String filename) {
+        try {
+            Properties props = new Properties();
+            FileReader reader = new FileReader(filename);
+
+            props.load(reader);
+            reader.close();
+
+            return props;
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -106,7 +106,7 @@ public final class Server {
         Thread initThread = null;
 
         if (options.getCleanup()) {
-            cleanUp = CleanUp.configure(options.getDisplayId());
+            cleanUp = CleanUp.configure(options.getDisplayId(), options.getConfigPath());
             initThread = startInitThread(options, cleanUp);
         }
 


### PR DESCRIPTION
Greetings!

My colleagues and I are working on a "Mobile Farm" project.
While working, I came across a problem with Samsung devices described in #2841. If a certain number of characters was exceeded during an attempt to start the scrcpy-server, the process crashed with an error. And to solve this problem, I decided to make it possible to transfer the list of required options through a server configuration file.

Along the way, I reworked the parsing of options, using `FileReader`/`StringReader` + `Properties` classes.

Closes #2841