### PR TITLE
Enable workarounds by default

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -144,7 +144,7 @@ public final class Server {
 
         final Device device = camera ? null : new Device(options);
 
-        Workarounds.apply(audio, camera);
+        Workarounds.apply();
 
         List<AsyncProcessor> asyncProcessors = new ArrayList<>();
 
@@ -279,7 +279,7 @@ public final class Server {
                 Ln.i(LogUtils.buildDisplayListMessage());
             }
             if (options.getListCameras() || options.getListCameraSizes()) {
-                Workarounds.apply(false, true);
+                Workarounds.apply();
                 Ln.i(LogUtils.buildCameraListMessage(options.getListCameraSizes()));
             }
             // Just print the requested data, do not mirror

--- a/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Workarounds.java
@@ -51,66 +51,18 @@ public final class Workarounds {
         // not instantiable
     }
 
-    public static void apply(boolean audio, boolean camera) {
-        boolean mustFillConfigurationController = false;
-        boolean mustFillAppInfo = false;
-        boolean mustFillAppContext = false;
-
-        if (Build.BRAND.equalsIgnoreCase("meizu")) {
-            // Workarounds must be applied for Meizu phones:
-            //  - <https://github.com/Genymobile/scrcpy/issues/240>
-            //  - <https://github.com/Genymobile/scrcpy/issues/365>
-            //  - <https://github.com/Genymobile/scrcpy/issues/2656>
-            //
-            // But only apply when strictly necessary, since workarounds can cause other issues:
-            //  - <https://github.com/Genymobile/scrcpy/issues/940>
-            //  - <https://github.com/Genymobile/scrcpy/issues/994>
-            mustFillAppInfo = true;
-        } else if (Build.BRAND.equalsIgnoreCase("honor") || Build.MANUFACTURER.equalsIgnoreCase("skyworth") || Build.BRAND.equalsIgnoreCase("tcl")) {
-            // More workarounds must be applied for Honor devices:
-            //  - <https://github.com/Genymobile/scrcpy/issues/4015>
-            // for Skyworth devices:
-            //  - <https://github.com/Genymobile/scrcpy/issues/4922>
-            // and for TCL devices:
-            //  - <https://github.com/Genymobile/scrcpy/issues/5140>
-            //
-            // The system context must not be set for all devices, because it would cause other problems:
-            //  - <https://github.com/Genymobile/scrcpy/issues/4015#issuecomment-1595382142>
-            //  - <https://github.com/Genymobile/scrcpy/issues/3805#issuecomment-1596148031>
-            mustFillAppInfo = true;
-            mustFillAppContext = true;
-        }
-
-        if (audio && Build.VERSION.SDK_INT == Build.VERSION_CODES.R) {
-            // Before Android 11, audio is not supported.
-            // Since Android 12, we can properly set a context on the AudioRecord.
-            // Only on Android 11 we must fill the application context for the AudioRecord to work.
-            mustFillAppContext = true;
-        }
-
-        if (camera) {
-            mustFillAppInfo = true;
-            mustFillAppContext = true;
-        }
-
+    public static void apply() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
             // On some Samsung devices, DisplayManagerGlobal.getDisplayInfoLocked() calls ActivityThread.currentActivityThread().getConfiguration(),
             // which requires a non-null ConfigurationController.
             // ConfigurationController was introduced in Android 12, so do not attempt to set it on lower versions.
             // <https://github.com/Genymobile/scrcpy/issues/4467>
-            mustFillConfigurationController = true;
-        }
-
-        if (mustFillConfigurationController) {
-            // Must be call before fillAppContext() because it is necessary to get a valid system context
+            // Must be called before fillAppContext() because it is necessary to get a valid system context.
             fillConfigurationController();
         }
-        if (mustFillAppInfo) {
-            fillAppInfo();
-        }
-        if (mustFillAppContext) {
-            fillAppContext();
-        }
+
+        fillAppInfo();
+        fillAppContext();
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Workarounds were disabled by default, and enabled only on some device or in specific conditions.

But it seems they are needed for more and more devices, so enable them by default. They could be disabled for specific devices if necessary in the future.

In the past, these workarounds caused a (harmless) exception to be printed on some Xiaomi devices(https://github.com/Genymobile/scrcpy/issues/4015#issuecomment-1595382142). But this is not a problem anymore since commit b8c5853aa6ac9cfbe3fb4e46bf10978b3fa212e3.
    
They also caused problems for audio on Vivo devices (https://github.com/Genymobile/scrcpy/issues/3805#issuecomment-1596148031), but it seems this is not the case anymore (https://github.com/Genymobile/scrcpy/issues/3805#issuecomment-2260205882).
    
They might also impact an old Nvidia Shield (https://github.com/Genymobile/scrcpy/issues/940), but hopefully this is fixed now.

Refs #5148.

---

- [`scrcpy-win64-pr5154.zip`](https://tmp.rom1v.com/scrcpy/5154/1/scrcpy-win64-pr5154.zip) <sub>`SHA-256: 4a0a0941086fbefff4185202519a31b39e159001d494b12b16745f03a024e84`</sub>