### PR TITLE
Adding Rocky Linux dependencies to build.md

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -84,6 +84,27 @@ sudo dnf install java-devel
 ```
 
 
+#### Rocky Linux
+
+```bash
+# enable RPM fusion release, 8 for Rocky 8.x and 9 for Rocky 9.x
+sudo dnf install https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
+
+# enable extra packages with epel-release
+sudo dnf install epel-release
+
+# add repo for epel-multimedia
+sudo dnf config-manager --add-repo=https://negativo17.org/repos/epel-multimedia.repo
+
+# enable powertools
+sudo dnf config-manager --set-enabled powertools
+
+# install dependencies
+sudo dnf install ffmpeg adb android-tools wget gcc git pkg-config meson ninja-build \
+                 SDL2 SDL2-devel libavcodec-devel libavdevice-devel libavformat-devel \
+                 libavutil-devel libusb-devel libswresample-devel libusb-devel
+```
+
 
 ### Windows
 


### PR DESCRIPTION
I had to use scrscy on Rocky Linux 8.x: https://rockylinux.org/ (which is supposed to be the principal sucessor of Cent OS).
The Rocky repos doesn't have scrcpy available, so needed to compile it my self.

So to help others I have collected the dependencies of scrcpy for Rocky Linux.
I have tested and used this on Rocky 8.10, but it should work on other versions too.