### PR TITLE
handle SDL_WINDOWEVENT_SHOWN like SDL_WINDOWEVENT_EXPOSED

### DIFF
--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -869,7 +869,8 @@ sc_screen_handle_event(struct sc_screen *screen, const SDL_Event *event) {
         }
         case SDL_WINDOWEVENT:
             if (!screen->video
-                    && event->window.event == SDL_WINDOWEVENT_EXPOSED) {
+                    && (event->window.event == SDL_WINDOWEVENT_EXPOSED
+                        || event->window.event == SDL_WINDOWEVENT_SHOWN)) {
                 sc_screen_render_novideo(screen);
             }
 
@@ -881,6 +882,7 @@ sc_screen_handle_event(struct sc_screen *screen, const SDL_Event *event) {
             }
             switch (event->window.event) {
                 case SDL_WINDOWEVENT_EXPOSED:
+                case SDL_WINDOWEVENT_SHOWN:
                     sc_screen_render(screen, true);
                     break;
                 case SDL_WINDOWEVENT_SIZE_CHANGED:

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -220,6 +220,7 @@ sc_screen_otg_handle_event(struct sc_screen_otg *screen, SDL_Event *event) {
         case SDL_WINDOWEVENT:
             switch (event->window.event) {
                 case SDL_WINDOWEVENT_EXPOSED:
+                case SDL_WINDOWEVENT_SHOWN:
                     sc_screen_otg_render(screen);
                     break;
                 case SDL_WINDOWEVENT_FOCUS_LOST:


### PR DESCRIPTION
on sway, the window didn't show for me at all without this in `--otg` mode (can't test non-otg mode)