### PR TITLE
Add GitHub Actions workflow for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,147 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Version name (default is ref name)'
+
+jobs:
+  build-scrcpy-server:
+    runs-on: ubuntu-latest
+    env:
+      GRADLE: gradle  # use native gradle instead of ./gradlew in release.mk
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+
+      - name: Test scrcpy-server
+        run: make -f release.mk test-server
+
+      - name: Build scrcpy-server
+        run: make -f release.mk build-server
+
+      - name: Upload scrcpy-server artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrcpy-server
+          path: build-server/server/scrcpy-server
+
+  test-client:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y meson ninja-build nasm ffmpeg libsdl2-2.0-0 \
+             libsdl2-dev libavcodec-dev libavdevice-dev libavformat-dev \
+             libavutil-dev libswresample-dev libusb-1.0-0 libusb-1.0-0-dev
+
+      - name: Build
+        run: |
+          meson setup d -Db_sanitize=address,undefined
+
+      - name: Test
+        run: |
+          meson test -Cd
+
+  build-win32:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y meson ninja-build nasm ffmpeg libsdl2-2.0-0 \
+             libsdl2-dev libavcodec-dev libavdevice-dev libavformat-dev \
+             libavutil-dev libswresample-dev libusb-1.0-0 libusb-1.0-0-dev \
+             mingw-w64 mingw-w64-tools libz-mingw-w64-dev
+
+      - name: Workaround for old meson version run by Github Actions
+        run: sed -i 's/^pkg-config/pkgconfig/' cross_win32.txt
+
+      - name: Build scrcpy win32
+        run: make -f release.mk build-win32
+
+      - name: Upload build-win32 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-win32-intermediate
+          path: build-win32/dist/
+
+  build-win64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y meson ninja-build nasm ffmpeg libsdl2-2.0-0 \
+             libsdl2-dev libavcodec-dev libavdevice-dev libavformat-dev \
+             libavutil-dev libswresample-dev libusb-1.0-0 libusb-1.0-0-dev \
+             mingw-w64 mingw-w64-tools libz-mingw-w64-dev
+
+      - name: Workaround for old meson version run by Github Actions
+        run: sed -i 's/^pkg-config/pkgconfig/' cross_win64.txt
+
+      - name: Build scrcpy win64
+        run: make -f release.mk build-win64
+
+      - name: Upload build-win64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-win64-intermediate
+          path: build-win64/dist/
+
+  package:
+    needs:
+      - build-scrcpy-server
+      - build-win32
+      - build-win64
+    runs-on: ubuntu-latest
+    env:
+      # $VERSION is used by release.mk
+      VERSION: ${{ github.event.inputs.name || github.ref_name }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download scrcpy-server
+        uses: actions/download-artifact@v4
+        with:
+          name: scrcpy-server
+          path: build-server/server/
+
+      - name: Download build-win32
+        uses: actions/download-artifact@v4
+        with:
+          name: build-win32-intermediate
+          path: build-win32/dist/
+
+      - name: Download build-win64
+        uses: actions/download-artifact@v4
+        with:
+          name: build-win64-intermediate
+          path: build-win64/dist/
+
+      - name: Package
+        run: make -f release.mk package
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scrcpy-release-${{ env.VERSION }}
+          path: release-${{ env.VERSION }}

--- a/release.mk
+++ b/release.mk
@@ -9,7 +9,7 @@
 # the server to the device.
 
 .PHONY: default clean \
-	test \
+	test test-client test-server \
 	build-server \
 	prepare-deps-win32 prepare-deps-win64 \
 	build-win32 build-win64 \
@@ -51,11 +51,15 @@ clean:
 	rm -rf "$(DIST)" "$(TEST_BUILD_DIR)" "$(SERVER_BUILD_DIR)" \
 		"$(WIN32_BUILD_DIR)" "$(WIN64_BUILD_DIR)"
 
-test:
+test-client:
 	[ -d "$(TEST_BUILD_DIR)" ] || ( mkdir "$(TEST_BUILD_DIR)" && \
 		meson setup "$(TEST_BUILD_DIR)" -Db_sanitize=address )
 	ninja -C "$(TEST_BUILD_DIR)"
+
+test-server:
 	$(GRADLE) -p server check
+
+test: test-client test-server
 
 build-server:
 	[ -d "$(SERVER_BUILD_DIR)" ] || ( mkdir "$(SERVER_BUILD_DIR)" && \

--- a/release.mk
+++ b/release.mk
@@ -62,9 +62,10 @@ test-server:
 test: test-client test-server
 
 build-server:
-	[ -d "$(SERVER_BUILD_DIR)" ] || ( mkdir "$(SERVER_BUILD_DIR)" && \
-		meson setup "$(SERVER_BUILD_DIR)" --buildtype release -Dcompile_app=false )
-	ninja -C "$(SERVER_BUILD_DIR)"
+	$(GRADLE) -p server assembleRelease
+	mkdir -p "$(SERVER_BUILD_DIR)/server"
+	cp server/build/outputs/apk/release/server-release-unsigned.apk \
+		"$(SERVER_BUILD_DIR)/server/scrcpy-server"
 
 prepare-deps-win32:
 	@app/deps/adb.sh win32

--- a/release.mk
+++ b/release.mk
@@ -11,7 +11,7 @@
 .PHONY: default clean \
 	test \
 	build-server \
-	prepare-deps \
+	prepare-deps-win32 prepare-deps-win64 \
 	build-win32 build-win64 \
 	dist-win32 dist-win64 \
 	zip-win32 zip-win64 \

--- a/release.mk
+++ b/release.mk
@@ -13,9 +13,8 @@
 	build-server \
 	prepare-deps-win32 prepare-deps-win64 \
 	build-win32 build-win64 \
-	dist-win32 dist-win64 \
 	zip-win32 zip-win64 \
-	release
+	package release
 
 GRADLE ?= ./gradlew
 
@@ -26,7 +25,7 @@ WIN64_BUILD_DIR := build-win64
 
 VERSION ?= $(shell git describe --tags --exclude='*install-release' --always)
 
-DIST := dist
+ZIP := zip
 WIN32_TARGET_DIR := scrcpy-win32-$(VERSION)
 WIN64_TARGET_DIR := scrcpy-win64-$(VERSION)
 WIN32_TARGET := $(WIN32_TARGET_DIR).zip
@@ -34,21 +33,11 @@ WIN64_TARGET := $(WIN64_TARGET_DIR).zip
 
 RELEASE_DIR := release-$(VERSION)
 
-release: clean test build-server zip-win32 zip-win64
-	mkdir -p "$(RELEASE_DIR)"
-	cp "$(SERVER_BUILD_DIR)/server/scrcpy-server" \
-		"$(RELEASE_DIR)/scrcpy-server-$(VERSION)"
-	cp "$(DIST)/$(WIN32_TARGET)" "$(RELEASE_DIR)"
-	cp "$(DIST)/$(WIN64_TARGET)" "$(RELEASE_DIR)"
-	cd "$(RELEASE_DIR)" && \
-		sha256sum "scrcpy-server-$(VERSION)" \
-			"scrcpy-win32-$(VERSION).zip" \
-			"scrcpy-win64-$(VERSION).zip" > SHA256SUMS.txt
-	@echo "Release generated in $(RELEASE_DIR)/"
+release: clean test build-server build-win32 build-win64 package
 
 clean:
 	$(GRADLE) clean
-	rm -rf "$(DIST)" "$(TEST_BUILD_DIR)" "$(SERVER_BUILD_DIR)" \
+	rm -rf "$(ZIP)" "$(TEST_BUILD_DIR)" "$(SERVER_BUILD_DIR)" \
 		"$(WIN32_BUILD_DIR)" "$(WIN64_BUILD_DIR)"
 
 test-client:
@@ -91,6 +80,15 @@ build-win32: prepare-deps-win32
 		-Dcompile_server=false \
 		-Dportable=true
 	ninja -C "$(WIN32_BUILD_DIR)"
+	# Group intermediate outputs into a 'dist' directory
+	mkdir -p "$(WIN32_BUILD_DIR)/dist"
+	cp "$(WIN32_BUILD_DIR)"/app/scrcpy.exe "$(WIN32_BUILD_DIR)/dist/"
+	cp app/data/scrcpy-console.bat "$(WIN32_BUILD_DIR)/dist/"
+	cp app/data/scrcpy-noconsole.vbs "$(WIN32_BUILD_DIR)/dist/"
+	cp app/data/icon.png "$(WIN32_BUILD_DIR)/dist/"
+	cp app/data/open_a_terminal_here.bat "$(WIN32_BUILD_DIR)/dist/"
+	cp app/deps/work/install/win32/bin/*.dll "$(WIN32_BUILD_DIR)/dist/"
+	cp app/deps/work/install/win32/bin/adb.exe "$(WIN32_BUILD_DIR)/dist/"
 
 build-win64: prepare-deps-win64
 	rm -rf "$(WIN64_BUILD_DIR)"
@@ -104,33 +102,40 @@ build-win64: prepare-deps-win64
 		-Dcompile_server=false \
 		-Dportable=true
 	ninja -C "$(WIN64_BUILD_DIR)"
+	# Group intermediate outputs into a 'dist' directory
+	mkdir -p "$(WIN64_BUILD_DIR)/dist"
+	cp "$(WIN64_BUILD_DIR)"/app/scrcpy.exe "$(WIN64_BUILD_DIR)/dist/"
+	cp app/data/scrcpy-console.bat "$(WIN64_BUILD_DIR)/dist/"
+	cp app/data/scrcpy-noconsole.vbs "$(WIN64_BUILD_DIR)/dist/"
+	cp app/data/icon.png "$(WIN64_BUILD_DIR)/dist/"
+	cp app/data/open_a_terminal_here.bat "$(WIN64_BUILD_DIR)/dist/"
+	cp app/deps/work/install/win64/bin/*.dll "$(WIN64_BUILD_DIR)/dist/"
+	cp app/deps/work/install/win64/bin/adb.exe "$(WIN64_BUILD_DIR)/dist/"
 
-dist-win32: build-server build-win32
-	mkdir -p "$(DIST)/$(WIN32_TARGET_DIR)"
-	cp "$(SERVER_BUILD_DIR)"/server/scrcpy-server "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp "$(WIN32_BUILD_DIR)"/app/scrcpy.exe "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp app/data/scrcpy-console.bat "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp app/data/scrcpy-noconsole.vbs "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp app/data/icon.png "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp app/data/open_a_terminal_here.bat "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp app/deps/work/install/win32/bin/*.dll "$(DIST)/$(WIN32_TARGET_DIR)/"
-	cp app/deps/work/install/win32/bin/adb.exe "$(DIST)/$(WIN32_TARGET_DIR)/"
-
-dist-win64: build-server build-win64
-	mkdir -p "$(DIST)/$(WIN64_TARGET_DIR)"
-	cp "$(SERVER_BUILD_DIR)"/server/scrcpy-server "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp "$(WIN64_BUILD_DIR)"/app/scrcpy.exe "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp app/data/scrcpy-console.bat "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp app/data/scrcpy-noconsole.vbs "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp app/data/icon.png "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp app/data/open_a_terminal_here.bat "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp app/deps/work/install/win64/bin/*.dll "$(DIST)/$(WIN64_TARGET_DIR)/"
-	cp app/deps/work/install/win64/bin/adb.exe "$(DIST)/$(WIN64_TARGET_DIR)/"
-
-zip-win32: dist-win32
-	cd "$(DIST)"; \
+zip-win32:
+	mkdir -p "$(ZIP)/$(WIN32_TARGET_DIR)"
+	cp -r "$(WIN32_BUILD_DIR)/dist/." "$(ZIP)/$(WIN32_TARGET_DIR)/"
+	cp "$(SERVER_BUILD_DIR)"/server/scrcpy-server "$(ZIP)/$(WIN32_TARGET_DIR)/"
+	cd "$(ZIP)"; \
 		zip -r "$(WIN32_TARGET)" "$(WIN32_TARGET_DIR)"
+	rm -rf "$(ZIP)/$(WIN32_TARGET_DIR)"
 
-zip-win64: dist-win64
-	cd "$(DIST)"; \
+zip-win64:
+	mkdir -p "$(ZIP)/$(WIN64_TARGET_DIR)"
+	cp -r "$(WIN64_BUILD_DIR)/dist/." "$(ZIP)/$(WIN64_TARGET_DIR)/"
+	cp "$(SERVER_BUILD_DIR)"/server/scrcpy-server "$(ZIP)/$(WIN64_TARGET_DIR)/"
+	cd "$(ZIP)"; \
 		zip -r "$(WIN64_TARGET)" "$(WIN64_TARGET_DIR)"
+	rm -rf "$(ZIP)/$(WIN64_TARGET_DIR)"
+
+package: zip-win32 zip-win64
+	mkdir -p "$(RELEASE_DIR)"
+	cp "$(SERVER_BUILD_DIR)/server/scrcpy-server" \
+		"$(RELEASE_DIR)/scrcpy-server-$(VERSION)"
+	cp "$(ZIP)/$(WIN32_TARGET)" "$(RELEASE_DIR)"
+	cp "$(ZIP)/$(WIN64_TARGET)" "$(RELEASE_DIR)"
+	cd "$(RELEASE_DIR)" && \
+		sha256sum "scrcpy-server-$(VERSION)" \
+			"scrcpy-win32-$(VERSION).zip" \
+			"scrcpy-win64-$(VERSION).zip" > SHA256SUMS.txt
+	@echo "Release generated in $(RELEASE_DIR)/"


### PR DESCRIPTION
Better late than never (#4490), I finally worked on a GitHub Actions workflow to build scrcpy releases.

I had to refactor the `release.mk` makefile to parallelize server and client build jobs. It is only run manually to build a release (not on push or pull request, I don't need it for now).

![ga](https://github.com/user-attachments/assets/6620531e-a4e9-48eb-abce-ec245ee9c927)

In the end, it produces a zip artifact containing:
 - `scrcpy-server-XXX`
 - `scrcpy-win32-XXX.zip`
 - `scrcpy-win64-XXX.zip`
 - `SHA256SUMS.txt`

where `XXX` is the input name you give when you manually start the workflow (if empty, it uses the ref name, for example the branch or tag name).

To test it:
 - fork the repo to your own account
 - checkout the branch from this PR, and push it to your `master` branch
 - enable GitHub Actions in your repo settings
 - go to the Actions tab
 - select "Build"
 - select "Run workflow"
 - keep `master` branch, choose a version name (for example `v42`)
 - click on Run workflow

![workflow](https://github.com/user-attachments/assets/29aa1f05-c282-404a-a91c-c40789168f6b)

---

For now, it generates the same targets as `./release.sh` did locally (scrcpy-server, release win32, release win64).

The goal now is to add more jobs, especially:
 - macOS releases
 - .deb packages for Ubuntu and Debian recent versions (#4427)

Your help is welcome! :heart:

Now that scrcpy-server is generated separately once and for all, it will be easier to write the jobs for building the scrcpy client for different targets (Android SDK is not needed).

As an important constraint, the jobs MUST only reference "official" github actions (or dockers images), not actions/images from random users. Keep it as simple as possible.

---

Fixes #4490
Refs https://github.com/Genymobile/scrcpy/issues/2256#issuecomment-1218375121 and next comments (cc @dur-randir @LeeBinder @Coool)
Refs #1709 (cc @dylanmtaylor)
Refs #3721 (cc @qmfrederik)
Refs #4427 (cc @hacksysteam)
Refs #4489 (cc @Gary-Cod)