### PR TITLE
Forward Alt and Super

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -23,6 +23,7 @@ src = [
     'src/frame_buffer.c',
     'src/input_manager.c',
     'src/keyboard_sdk.c',
+    'src/mouse_capture.c',
     'src/mouse_sdk.c',
     'src/opengl.c',
     'src/options.c',

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -33,10 +33,10 @@ to_sdl_mod(uint8_t shortcut_mod) {
     return sdl_mod;
 }
 
-static bool
+static inline bool
 is_shortcut_mod(struct sc_input_manager *im, uint16_t sdl_mod) {
-    // keep only the relevant modifier keys
-    sdl_mod &= SC_SDL_SHORTCUT_MODS_MASK;
+    // im->sdl_shortcut_mods is within the mask
+    assert(!(im->sdl_shortcut_mods & ~SC_SDL_SHORTCUT_MODS_MASK));
 
     // at least one shortcut mod pressed?
     return sdl_mod & im->sdl_shortcut_mods;

--- a/app/src/keyboard_sdk.c
+++ b/app/src/keyboard_sdk.c
@@ -45,6 +45,10 @@ convert_keycode(enum sc_keycode from, enum android_keycode *to, uint16_t mod,
         {SC_KEYCODE_RCTRL,     AKEYCODE_CTRL_RIGHT},
         {SC_KEYCODE_LSHIFT,    AKEYCODE_SHIFT_LEFT},
         {SC_KEYCODE_RSHIFT,    AKEYCODE_SHIFT_RIGHT},
+        {SC_KEYCODE_LALT,      AKEYCODE_ALT_LEFT},
+        {SC_KEYCODE_RALT,      AKEYCODE_ALT_RIGHT},
+        {SC_KEYCODE_LGUI,      AKEYCODE_META_LEFT},
+        {SC_KEYCODE_RGUI,      AKEYCODE_META_RIGHT},
     };
 
     // Numpad navigation keys.
@@ -166,11 +170,7 @@ convert_keycode(enum sc_keycode from, enum android_keycode *to, uint16_t mod,
         return false;
     }
 
-    if (mod & (SC_MOD_LALT | SC_MOD_RALT | SC_MOD_LGUI | SC_MOD_RGUI)) {
-        return false;
-    }
-
-    // if ALT and META are not pressed, also handle letters and space
+    // Handle letters and space
     entry = SC_INTMAP_FIND_ENTRY(alphaspace_keys, from);
     if (entry) {
         *to = entry->value;

--- a/app/src/mouse_capture.c
+++ b/app/src/mouse_capture.c
@@ -1,16 +1,19 @@
 #include "mouse_capture.h"
 
+#include "shortcut_mod.h"
 #include "util/log.h"
 
 void
-sc_mouse_capture_init(struct sc_mouse_capture *mc, SDL_Window *window) {
+sc_mouse_capture_init(struct sc_mouse_capture *mc, SDL_Window *window,
+                      uint8_t shortcut_mods) {
     mc->window = window;
+    mc->sdl_mouse_capture_keys = sc_shortcut_mods_to_sdl(shortcut_mods);
     mc->mouse_capture_key_pressed = SDLK_UNKNOWN;
 }
 
 static inline bool
-sc_mouse_capture_is_capture_key(SDL_Keycode key) {
-    return key == SDLK_LALT || key == SDLK_LGUI || key == SDLK_RGUI;
+sc_mouse_capture_is_capture_key(struct sc_mouse_capture *mc, SDL_Keycode key) {
+    return sc_shortcut_mods_is_shortcut_key(mc->sdl_mouse_capture_keys, key);
 }
 
 bool
@@ -25,7 +28,7 @@ sc_mouse_capture_handle_event(struct sc_mouse_capture *mc,
             break;
         case SDL_KEYDOWN: {
             SDL_Keycode key = event->key.keysym.sym;
-            if (sc_mouse_capture_is_capture_key(key)) {
+            if (sc_mouse_capture_is_capture_key(mc, key)) {
                 if (!mc->mouse_capture_key_pressed) {
                     mc->mouse_capture_key_pressed = key;
                 } else {
@@ -42,7 +45,7 @@ sc_mouse_capture_handle_event(struct sc_mouse_capture *mc,
             SDL_Keycode key = event->key.keysym.sym;
             SDL_Keycode cap = mc->mouse_capture_key_pressed;
             mc->mouse_capture_key_pressed = 0;
-            if (sc_mouse_capture_is_capture_key(key)) {
+            if (sc_mouse_capture_is_capture_key(mc, key)) {
                 if (key == cap) {
                     // A mouse capture key has been pressed then released:
                     // toggle the capture mouse mode

--- a/app/src/mouse_capture.c
+++ b/app/src/mouse_capture.c
@@ -1,0 +1,120 @@
+#include "mouse_capture.h"
+
+#include "util/log.h"
+
+void
+sc_mouse_capture_init(struct sc_mouse_capture *mc, SDL_Window *window) {
+    mc->window = window;
+    mc->mouse_capture_key_pressed = SDLK_UNKNOWN;
+}
+
+static inline bool
+sc_mouse_capture_is_capture_key(SDL_Keycode key) {
+    return key == SDLK_LALT || key == SDLK_LGUI || key == SDLK_RGUI;
+}
+
+bool
+sc_mouse_capture_handle_event(struct sc_mouse_capture *mc,
+                              const SDL_Event *event) {
+    switch (event->type) {
+        case SDL_WINDOWEVENT:
+            if (event->window.event == SDL_WINDOWEVENT_FOCUS_LOST) {
+                sc_mouse_capture_set_active(mc, false);
+                return true;
+            }
+            break;
+        case SDL_KEYDOWN: {
+            SDL_Keycode key = event->key.keysym.sym;
+            if (sc_mouse_capture_is_capture_key(key)) {
+                if (!mc->mouse_capture_key_pressed) {
+                    mc->mouse_capture_key_pressed = key;
+                } else {
+                    // Another mouse capture key has been pressed, cancel
+                    // mouse (un)capture
+                    mc->mouse_capture_key_pressed = 0;
+                }
+                // Mouse capture keys are never forwarded to the device
+                return true;
+            }
+            break;
+        }
+        case SDL_KEYUP: {
+            SDL_Keycode key = event->key.keysym.sym;
+            SDL_Keycode cap = mc->mouse_capture_key_pressed;
+            mc->mouse_capture_key_pressed = 0;
+            if (sc_mouse_capture_is_capture_key(key)) {
+                if (key == cap) {
+                    // A mouse capture key has been pressed then released:
+                    // toggle the capture mouse mode
+                    sc_mouse_capture_toggle(mc);
+                }
+                // Mouse capture keys are never forwarded to the device
+                return true;
+            }
+            break;
+        }
+        case SDL_MOUSEWHEEL:
+        case SDL_MOUSEMOTION:
+        case SDL_MOUSEBUTTONDOWN:
+            if (!sc_mouse_capture_is_active(mc)) {
+                // The mouse will be captured on SDL_MOUSEBUTTONUP, so consume
+                // the event
+                return true;
+            }
+            break;
+        case SDL_MOUSEBUTTONUP:
+            if (!sc_mouse_capture_is_active(mc)) {
+                sc_mouse_capture_set_active(mc, true);
+                return true;
+            }
+            break;
+        case SDL_FINGERMOTION:
+        case SDL_FINGERDOWN:
+        case SDL_FINGERUP:
+            // Touch events are not compatible with relative mode
+            // (coordinates are not relative), so consume the event
+            return true;
+    }
+
+    return false;
+}
+
+void
+sc_mouse_capture_set_active(struct sc_mouse_capture *mc, bool capture) {
+#ifdef __APPLE__
+    // Workaround for SDL bug on macOS:
+    // <https://github.com/libsdl-org/SDL/issues/5340>
+    if (capture) {
+        int mouse_x, mouse_y;
+        SDL_GetGlobalMouseState(&mouse_x, &mouse_y);
+
+        int x, y, w, h;
+        SDL_GetWindowPosition(window, &x, &y);
+        SDL_GetWindowSize(window, &w, &h);
+
+        bool outside_window = mouse_x < x || mouse_x >= x + w
+                           || mouse_y < y || mouse_y >= y + h;
+        if (outside_window) {
+            SDL_WarpMouseInWindow(mc->window, w / 2, h / 2);
+        }
+    }
+#else
+    (void) mc;
+#endif
+    if (SDL_SetRelativeMouseMode(capture)) {
+        LOGE("Could not set relative mouse mode to %s: %s",
+             capture ? "true" : "false", SDL_GetError());
+    }
+}
+
+bool
+sc_mouse_capture_is_active(struct sc_mouse_capture *mc) {
+    (void) mc;
+    return SDL_GetRelativeMouseMode();
+}
+
+void
+sc_mouse_capture_toggle(struct sc_mouse_capture *mc) {
+    bool new_value = !sc_mouse_capture_is_active(mc);
+    sc_mouse_capture_set_active(mc, new_value);
+}

--- a/app/src/mouse_capture.h
+++ b/app/src/mouse_capture.h
@@ -9,14 +9,17 @@
 
 struct sc_mouse_capture {
     SDL_Window *window;
+    uint16_t sdl_mouse_capture_keys;
 
     // To enable/disable mouse capture, a mouse capture key (LALT, LGUI or
     // RGUI) must be pressed. This variable tracks the pressed capture key.
     SDL_Keycode mouse_capture_key_pressed;
+
 };
 
 void
-sc_mouse_capture_init(struct sc_mouse_capture *mc, SDL_Window *window);
+sc_mouse_capture_init(struct sc_mouse_capture *mc, SDL_Window *window,
+                      uint8_t shortcut_mods);
 
 void
 sc_mouse_capture_set_active(struct sc_mouse_capture *mc, bool capture);

--- a/app/src/mouse_capture.h
+++ b/app/src/mouse_capture.h
@@ -1,0 +1,35 @@
+#ifndef SC_MOUSE_CAPTURE_H
+#define SC_MOUSE_CAPTURE_H
+
+#include "common.h"
+
+#include <stdbool.h>
+
+#include <SDL2/SDL.h>
+
+struct sc_mouse_capture {
+    SDL_Window *window;
+
+    // To enable/disable mouse capture, a mouse capture key (LALT, LGUI or
+    // RGUI) must be pressed. This variable tracks the pressed capture key.
+    SDL_Keycode mouse_capture_key_pressed;
+};
+
+void
+sc_mouse_capture_init(struct sc_mouse_capture *mc, SDL_Window *window);
+
+void
+sc_mouse_capture_set_active(struct sc_mouse_capture *mc, bool capture);
+
+bool
+sc_mouse_capture_is_active(struct sc_mouse_capture *mc);
+
+void
+sc_mouse_capture_toggle(struct sc_mouse_capture *mc);
+
+// Return true if it consumed the event
+bool
+sc_mouse_capture_handle_event(struct sc_mouse_capture *mc,
+                              const SDL_Event *event);
+
+#endif

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -445,7 +445,7 @@ sc_screen_init(struct sc_screen *screen,
     sc_input_manager_init(&screen->im, &im_params);
 
     // Initialize even if not used for simplicity
-    sc_mouse_capture_init(&screen->mc, screen->window);
+    sc_mouse_capture_init(&screen->mc, screen->window, params->shortcut_mods);
 
 #ifdef CONTINUOUS_RESIZING_WORKAROUND
     if (screen->video) {

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -13,6 +13,7 @@
 #include "fps_counter.h"
 #include "frame_buffer.h"
 #include "input_manager.h"
+#include "mouse_capture.h"
 #include "opengl.h"
 #include "options.h"
 #include "trait/key_processor.h"
@@ -30,6 +31,7 @@ struct sc_screen {
 
     struct sc_display display;
     struct sc_input_manager im;
+    struct sc_mouse_capture mc; // only used in mouse relative mode
     struct sc_frame_buffer fb;
     struct sc_fps_counter fps_counter;
 
@@ -60,10 +62,6 @@ struct sc_screen {
     bool fullscreen;
     bool maximized;
     bool minimized;
-
-    // To enable/disable mouse capture, a mouse capture key (LALT, LGUI or
-    // RGUI) must be pressed. This variable tracks the pressed capture key.
-    SDL_Keycode mouse_capture_key_pressed;
 
     AVFrame *frame;
 

--- a/app/src/shortcut_mod.h
+++ b/app/src/shortcut_mod.h
@@ -1,0 +1,60 @@
+#ifndef SC_SHORTCUT_MOD_H
+#define SC_SHORTCUT_MOD_H
+
+#include "common.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <SDL2/SDL_keycode.h>
+
+#include "options.h"
+
+#define SC_SDL_SHORTCUT_MODS_MASK (KMOD_CTRL | KMOD_ALT | KMOD_GUI)
+
+// input: OR of enum sc_shortcut_mod
+// output: OR of SDL_Keymod
+static inline uint16_t
+sc_shortcut_mods_to_sdl(uint8_t shortcut_mods) {
+    uint16_t sdl_mod = 0;
+    if (shortcut_mods & SC_SHORTCUT_MOD_LCTRL) {
+        sdl_mod |= KMOD_LCTRL;
+    }
+    if (shortcut_mods & SC_SHORTCUT_MOD_RCTRL) {
+        sdl_mod |= KMOD_RCTRL;
+    }
+    if (shortcut_mods & SC_SHORTCUT_MOD_LALT) {
+        sdl_mod |= KMOD_LALT;
+    }
+    if (shortcut_mods & SC_SHORTCUT_MOD_RALT) {
+        sdl_mod |= KMOD_RALT;
+    }
+    if (shortcut_mods & SC_SHORTCUT_MOD_LSUPER) {
+        sdl_mod |= KMOD_LGUI;
+    }
+    if (shortcut_mods & SC_SHORTCUT_MOD_RSUPER) {
+        sdl_mod |= KMOD_RGUI;
+    }
+    return sdl_mod;
+}
+
+static inline bool
+sc_shortcut_mods_is_shortcut_mod(uint16_t sdl_shortcut_mods, uint16_t sdl_mod) {
+    // sdl_shortcut_mods must be within the mask
+    assert(!(sdl_shortcut_mods & ~SC_SDL_SHORTCUT_MODS_MASK));
+
+    // at least one shortcut mod pressed?
+    return sdl_mod & sdl_shortcut_mods;
+}
+
+static inline bool
+sc_shortcut_mods_is_shortcut_key(uint16_t sdl_shortcut_mods,
+                                 SDL_Keycode keycode) {
+    return (sdl_shortcut_mods & KMOD_LCTRL && keycode == SDLK_LCTRL)
+        || (sdl_shortcut_mods & KMOD_RCTRL && keycode == SDLK_RCTRL)
+        || (sdl_shortcut_mods & KMOD_LALT  && keycode == SDLK_LALT)
+        || (sdl_shortcut_mods & KMOD_RALT  && keycode == SDLK_RALT)
+        || (sdl_shortcut_mods & KMOD_LGUI  && keycode == SDLK_LGUI)
+        || (sdl_shortcut_mods & KMOD_RGUI  && keycode == SDLK_RGUI);
+}
+
+#endif

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -185,6 +185,7 @@ scrcpy_otg(struct scrcpy_options *options) {
         .window_width = options->window_width,
         .window_height = options->window_height,
         .window_borderless = options->window_borderless,
+        .shortcut_mods = options->shortcut_mods,
     };
 
     ok = sc_screen_otg_init(&s->screen_otg, &params);

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -70,7 +70,7 @@ sc_screen_otg_init(struct sc_screen_otg *screen,
         LOGW("Could not load icon");
     }
 
-    sc_mouse_capture_init(&screen->mc, screen->window);
+    sc_mouse_capture_init(&screen->mc, screen->window, params->shortcut_mods);
 
     if (screen->mouse) {
         // Capture mouse on start

--- a/app/src/usb/screen_otg.h
+++ b/app/src/usb/screen_otg.h
@@ -8,6 +8,7 @@
 
 #include "keyboard_aoa.h"
 #include "mouse_aoa.h"
+#include "mouse_capture.h"
 #include "gamepad_aoa.h"
 
 struct sc_screen_otg {
@@ -19,8 +20,7 @@ struct sc_screen_otg {
     SDL_Renderer *renderer;
     SDL_Texture *texture;
 
-    // See equivalent mechanism in screen.h
-    SDL_Keycode mouse_capture_key_pressed;
+    struct sc_mouse_capture mc;
 };
 
 struct sc_screen_otg_params {

--- a/app/src/usb/screen_otg.h
+++ b/app/src/usb/screen_otg.h
@@ -35,6 +35,7 @@ struct sc_screen_otg_params {
     uint16_t window_width;
     uint16_t window_height;
     bool window_borderless;
+    uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
 };
 
 bool


### PR DESCRIPTION
<kbd>Alt</kbd> and <kbd>Super</kbd> (also named Meta) modifier keys are captured for shortcuts by default (cf `--shortcut-mod`).

However, when shortcut modifiers are changed, <kbd>Alt</kbd> and <kbd>Super</kbd> should be forwarded to the device. This is the case for AOA and UHID keyboards, but it was not the case for SDK keyboard.

This PR fixes this.

---

In addition, mouse capture key for relative mouse mode (when `--mouse=aoa` or `--mouse=uhid`) used hardcoded keys (<kbd>Alt</kbd> or <kbd>Meta</kbd>), regardless of the configured shortcut modifier.

Replace these hardcoded keys by the modifiers keys (configured by `--shortcut-mod`).

---

As a result, if you use for example `scrcpy --shortcut-mod=rctrl`, then <kbd>Alt</kbd> and <kbd>Super</kbd> are forwarded to the device (in all modes).

Fixes #5318

Here is a binary to test:
- [`scrcpy-win64-pr5322.zip`](https://tmp.rom1v.com/scrcpy/5322/1/scrcpy-win64-pr5322.zip) <sub>`SHA-256: aa839e5e3ac34e1034287ff4dfbbcb342612fe0dcd32081d81d6cc50c496eb8`</sub>