### PR TITLE
Fix window access typo for macOS

### DIFF
--- a/app/src/mouse_capture.c
+++ b/app/src/mouse_capture.c
@@ -92,8 +92,8 @@ sc_mouse_capture_set_active(struct sc_mouse_capture *mc, bool capture) {
         SDL_GetGlobalMouseState(&mouse_x, &mouse_y);
 
         int x, y, w, h;
-        SDL_GetWindowPosition(window, &x, &y);
-        SDL_GetWindowSize(window, &w, &h);
+        SDL_GetWindowPosition(mc->window, &x, &y);
+        SDL_GetWindowSize(mc->window, &w, &h);
 
         bool outside_window = mouse_x < x || mouse_x >= x + w
                            || mouse_y < y || mouse_y >= y + h;


### PR DESCRIPTION
Got this error when building `dev` branch:
```
ninja: Entering directory `x'
[29/129] Compiling C object app/scrcpy.p/src_mouse_capture.c.o
FAILED: app/scrcpy.p/src_mouse_capture.c.o
cc -Iapp/scrcpy.p -Iapp -I../app -I../app/src -I/usr/local/include -I/usr/local/include/SDL2 -I/usr/local/Cellar/libusb/1.0.27/include/libusb-1.0 -fdiagnostics-color=always -Wall -Winvalid-pch -Wextra -std=c11 -O0 -g -Wmissing-prototypes -D_THREAD_SAFE -MD -MQ app/scrcpy.p/
src_mouse_capture.c.o -MF app/scrcpy.p/src_mouse_capture.c.o.d -o app/scrcpy.p/src_mouse_capture.c.o -c ../app/src/mouse_capture.c
../app/src/mouse_capture.c:95:31: error: use of undeclared identifier 'window'
   95 |         SDL_GetWindowPosition(window, &x, &y);
      |                               ^
../app/src/mouse_capture.c:96:27: error: use of undeclared identifier 'window'
   96 |         SDL_GetWindowSize(window, &w, &h);
      |                           ^
2 errors generated.
```