### PR TITLE
Add virtual display feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It focuses on:
 Its features include:
  - [audio forwarding](doc/audio.md) (Android 11+)
  - [recording](doc/recording.md)
+ - [virtual display](doc/virtual_display.md)
  - mirroring with [Android device screen off](doc/device.md#turn-screen-off)
  - [copy-paste](doc/control.md#copy-paste) in both directions
  - [configurable quality](doc/video.md)
@@ -91,6 +92,12 @@ Here are just some common examples.
     scrcpy --video-codec=h265 -m1920 --max-fps=60 --no-audio -K  # short version
     ```
 
+ - Start VLC in a new virtual display (separate from the device display):
+
+    ```bash
+    scrcpy --new-display=1920x1080 --start-app=org.videolan.vlc
+    ```
+
  - Record the device camera in H.265 at 1920x1080 (and microphone) to an MP4
    file:
 
@@ -134,6 +141,7 @@ documented in the following pages:
  - [Device](doc/device.md)
  - [Window](doc/window.md)
  - [Recording](doc/recording.md)
+ - [Virtual display](doc/virtual_displays.md)
  - [Tunnels](doc/tunnels.md)
  - [OTG](doc/otg.md)
  - [Camera](doc/camera.md)

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -79,6 +79,7 @@ _scrcpy() {
         -s --serial=
         -S --turn-screen-off
         --shortcut-mod=
+        --start-app=
         -t --show-touches
         --tcpip
         --tcpip=

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -33,6 +33,7 @@ _scrcpy() {
         --keyboard=
         --kill-adb-on-close
         --legacy-paste
+        --list-apps
         --list-camera-sizes
         --list-cameras
         --list-displays

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -46,6 +46,8 @@ _scrcpy() {
         --mouse-bind=
         -n --no-control
         -N --no-playback
+        --new-display
+        --new-display=
         --no-audio
         --no-audio-playback
         --no-cleanup

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -52,6 +52,7 @@ arguments=(
     '--mouse-bind=[Configure bindings of secondary clicks]'
     {-n,--no-control}'[Disable device control \(mirror the device in read only\)]'
     {-N,--no-playback}'[Disable video and audio playback]'
+    '--new-display=[Create a new display]'
     '--no-audio[Disable audio forwarding]'
     '--no-audio-playback[Disable audio playback]'
     '--no-cleanup[Disable device cleanup actions on exit]'

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -82,6 +82,7 @@ arguments=(
     {-s,--serial=}'[The device serial number \(mandatory for multiple devices only\)]:serial:($("${ADB-adb}" devices | awk '\''$2 == "device" {print $1}'\''))'
     {-S,--turn-screen-off}'[Turn the device screen off immediately]'
     '--shortcut-mod=[\[key1,key2+key3,...\] Specify the modifiers to use for scrcpy shortcuts]:shortcut mod:(lctrl rctrl lalt ralt lsuper rsuper)'
+    '--start-app=[Start an Android app]'
     {-t,--show-touches}'[Show physical touches]'
     '--tcpip[\(optional \[ip\:port\]\) Configure and connect the device over TCP/IP]'
     '--time-limit=[Set the maximum mirroring time, in seconds]'

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -40,6 +40,7 @@ arguments=(
     '--keyboard=[Set the keyboard input mode]:mode:(disabled sdk uhid aoa)'
     '--kill-adb-on-close[Kill adb when scrcpy terminates]'
     '--legacy-paste[Inject computer clipboard text as a sequence of key events on Ctrl+v]'
+    '--list-apps[List Android apps installed on the device]'
     '--list-camera-sizes[List the valid camera capture sizes]'
     '--list-cameras[List cameras available on the device]'
     '--list-displays[List displays available on the device]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -228,6 +228,10 @@ Inject computer clipboard text as a sequence of key events on Ctrl+v (like MOD+S
 This is a workaround for some devices not behaving as expected when setting the device clipboard programmatically.
 
 .TP
+.B \-\-list\-apps
+List Android apps installed on the device.
+
+.TP
 .B \-\-list\-camera\-sizes
 List the valid camera capture sizes.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -498,6 +498,10 @@ Default is "lalt,lsuper" (left-Alt or left-Super).
 .BI "\-\-start\-app " name
 Start an Android app, by its exact package name.
 
+Add a '+' prefix to force-stop before starting the app:
+
+    scrcpy --new-display --start-app=+org.mozilla.firefox
+
 .TP
 .B \-t, \-\-show\-touches
 Enable "show touches" on start, restore the initial value on exit.

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -495,6 +495,10 @@ For example, to use either LCtrl or LSuper for scrcpy shortcuts, pass "lctrl,lsu
 Default is "lalt,lsuper" (left-Alt or left-Super).
 
 .TP
+.BI "\-\-start\-app " name
+Start an Android app, by its exact package name.
+
+.TP
 .B \-t, \-\-show\-touches
 Enable "show touches" on start, restore the initial value on exit.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -498,9 +498,17 @@ Default is "lalt,lsuper" (left-Alt or left-Super).
 .BI "\-\-start\-app " name
 Start an Android app, by its exact package name.
 
+Add a '?' prefix to select an app whose name starts with the given name, case-insensitive (retrieving app names on the device may take some time):
+
+    scrcpy --start-app=?firefox
+
 Add a '+' prefix to force-stop before starting the app:
 
     scrcpy --new-display --start-app=+org.mozilla.firefox
+
+Both prefixes can be used, in that order:
+
+    scrcpy --start-app=+?firefox
 
 .TP
 .B \-t, \-\-show\-touches

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -315,6 +315,18 @@ Disable device control (mirror the device in read\-only).
 Disable video and audio playback on the computer (equivalent to \fB\-\-no\-video\-playback \-\-no\-audio\-playback\fR).
 
 .TP
+\fB\-\-new\-display\fR[=[\fIwidth\fRx\fIheight\fR][/\fIdpi\fR]]
+Create a new display with the specified resolution and density. If not provided, they default to the main display dimensions and DPI, and \fB\-\-max\-size\fR is considered.
+
+Examples:
+
+    \-\-new\-display=1920x1080
+    \-\-new\-display=1920x1080/420
+    \-\-new\-display         # main display size and density
+    \-\-new\-display -m1920  # scaled to fit a max size of 1920
+    \-\-new\-display=/240    # main display size and 240 dpi
+
+.TP
 .B \-\-no\-audio
 Disable audio forwarding.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -811,7 +811,9 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_START_APP,
         .longopt = "start-app",
         .argdesc = "name",
-        .text = "Start an Android app, by its exact package name.",
+        .text = "Start an Android app, by its exact package name.\n"
+                "Add a '+' prefix to force-stop before starting the app:\n"
+                "    scrcpy --new-display --start-app=+org.mozilla.firefox",
     },
     {
         .shortopt = 't',

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -812,8 +812,14 @@ static const struct sc_option options[] = {
         .longopt = "start-app",
         .argdesc = "name",
         .text = "Start an Android app, by its exact package name.\n"
+                "Add a '?' prefix to select an app whose name starts with the "
+                "given name, case-insensitive (retrieving app names on the "
+                "device may take some time):\n"
+                "    scrcpy --start-app=?firefox\n"
                 "Add a '+' prefix to force-stop before starting the app:\n"
-                "    scrcpy --new-display --start-app=+org.mozilla.firefox",
+                "    scrcpy --new-display --start-app=+org.mozilla.firefox\n"
+                "Both prefixes can be used, in that order:\n"
+                "    scrcpy --start-app=+?firefox",
     },
     {
         .shortopt = 't',

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -103,6 +103,7 @@ enum {
     OPT_AUDIO_DUP,
     OPT_GAMEPAD,
     OPT_NEW_DISPLAY,
+    OPT_LIST_APPS,
 };
 
 struct sc_option {
@@ -442,6 +443,11 @@ static const struct sc_option options[] = {
                 "on Ctrl+v (like MOD+Shift+v).\n"
                 "This is a workaround for some devices not behaving as "
                 "expected when setting the device clipboard programmatically.",
+    },
+    {
+        .longopt_id = OPT_LIST_APPS,
+        .longopt = "list-apps",
+        .text = "List Android apps installed on the device.",
     },
     {
         .longopt_id = OPT_LIST_CAMERAS,
@@ -2610,6 +2616,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_LIST_CAMERA_SIZES:
                 opts->list |= SC_OPTION_LIST_CAMERA_SIZES;
+                break;
+            case OPT_LIST_APPS:
+                opts->list |= SC_OPTION_LIST_APPS;
                 break;
             case OPT_REQUIRE_AUDIO:
                 opts->require_audio = true;

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -104,6 +104,7 @@ enum {
     OPT_GAMEPAD,
     OPT_NEW_DISPLAY,
     OPT_LIST_APPS,
+    OPT_START_APP,
 };
 
 struct sc_option {
@@ -805,6 +806,12 @@ static const struct sc_option options[] = {
                 "For example, to use either LCtrl or LSuper for scrcpy "
                 "shortcuts, pass \"lctrl,lsuper\".\n"
                 "Default is \"lalt,lsuper\" (left-Alt or left-Super).",
+    },
+    {
+        .longopt_id = OPT_START_APP,
+        .longopt = "start-app",
+        .argdesc = "name",
+        .text = "Start an Android app, by its exact package name.",
     },
     {
         .shortopt = 't',
@@ -2696,6 +2703,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_NEW_DISPLAY:
                 opts->new_display = optarg ? optarg : "";
                 break;
+            case OPT_START_APP:
+                opts->start_app = optarg;
+                break;
             default:
                 // getopt prints the error message on stderr
                 return false;
@@ -3136,6 +3146,10 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         }
         if (opts->power_off_on_close) {
             LOGE("Cannot request power off on close if control is disabled");
+            return false;
+        }
+        if (opts->start_app) {
+            LOGE("Cannot start an Android app if control is disabled");
             return false;
         }
     }

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -183,6 +183,10 @@ sc_control_msg_serialize(const struct sc_control_msg *msg, uint8_t *buf) {
         case SC_CONTROL_MSG_TYPE_UHID_DESTROY:
             sc_write16be(&buf[1], msg->uhid_destroy.id);
             return 3;
+        case SC_CONTROL_MSG_TYPE_START_APP: {
+            size_t len = write_string_tiny(&buf[1], msg->start_app.name, 255);
+            return 1 + len;
+        }
         case SC_CONTROL_MSG_TYPE_EXPAND_NOTIFICATION_PANEL:
         case SC_CONTROL_MSG_TYPE_EXPAND_SETTINGS_PANEL:
         case SC_CONTROL_MSG_TYPE_COLLAPSE_PANELS:
@@ -308,6 +312,9 @@ sc_control_msg_log(const struct sc_control_msg *msg) {
         case SC_CONTROL_MSG_TYPE_OPEN_HARD_KEYBOARD_SETTINGS:
             LOG_CMSG("open hard keyboard settings");
             break;
+        case SC_CONTROL_MSG_TYPE_START_APP:
+            LOG_CMSG("start app \"%s\"", msg->start_app.name);
+            break;
         default:
             LOG_CMSG("unknown type: %u", (unsigned) msg->type);
             break;
@@ -332,6 +339,9 @@ sc_control_msg_destroy(struct sc_control_msg *msg) {
             break;
         case SC_CONTROL_MSG_TYPE_SET_CLIPBOARD:
             free(msg->set_clipboard.text);
+            break;
+        case SC_CONTROL_MSG_TYPE_START_APP:
+            free(msg->start_app.name);
             break;
         default:
             // do nothing

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -41,6 +41,7 @@ enum sc_control_msg_type {
     SC_CONTROL_MSG_TYPE_UHID_INPUT,
     SC_CONTROL_MSG_TYPE_UHID_DESTROY,
     SC_CONTROL_MSG_TYPE_OPEN_HARD_KEYBOARD_SETTINGS,
+    SC_CONTROL_MSG_TYPE_START_APP,
 };
 
 enum sc_screen_power_mode {
@@ -110,6 +111,9 @@ struct sc_control_msg {
         struct {
             uint16_t id;
         } uhid_destroy;
+        struct {
+            char *name;
+        } start_app;
     };
 };
 

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -104,6 +104,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .mouse_hover = true,
     .audio_dup = false,
     .new_display = NULL,
+    .start_app = NULL,
 };
 
 enum sc_orientation

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -103,6 +103,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .window = true,
     .mouse_hover = true,
     .audio_dup = false,
+    .new_display = NULL,
 };
 
 enum sc_orientation

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -304,6 +304,7 @@ struct scrcpy_options {
 #define SC_OPTION_LIST_DISPLAYS 0x2
 #define SC_OPTION_LIST_CAMERAS 0x4
 #define SC_OPTION_LIST_CAMERA_SIZES 0x8
+#define SC_OPTION_LIST_APPS 0x10
     uint8_t list;
     bool window;
     bool mouse_hover;

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -310,6 +310,7 @@ struct scrcpy_options {
     bool mouse_hover;
     bool audio_dup;
     const char *new_display; // [<width>x<height>][/<dpi>] parsed by the server
+    const char *start_app;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -308,6 +308,7 @@ struct scrcpy_options {
     bool window;
     bool mouse_hover;
     bool audio_dup;
+    const char *new_display; // [<width>x<height>][/<dpi>] parsed by the server
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -907,6 +907,25 @@ aoa_complete:
         init_sdl_gamepads();
     }
 
+    if (options->control && options->start_app) {
+        assert(controller);
+
+        char *name = strdup(options->start_app);
+        if (!name) {
+            LOG_OOM();
+            goto end;
+        }
+
+        struct sc_control_msg msg;
+        msg.type = SC_CONTROL_MSG_TYPE_START_APP;
+        msg.start_app.name = name;
+
+        if (!sc_controller_push_msg(controller, &msg)) {
+            LOGW("Could not request start app '%s'", name);
+            free(name);
+        }
+    }
+
     ret = event_loop(s);
     terminate_event_loop();
     LOGD("quit...");

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -431,6 +431,7 @@ scrcpy(struct scrcpy_options *options) {
         .lock_video_orientation = options->lock_video_orientation,
         .control = options->control,
         .display_id = options->display_id,
+        .new_display = options->new_display,
         .video = options->video,
         .audio = options->audio,
         .audio_dup = options->audio_dup,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -371,6 +371,9 @@ execute_server(struct sc_server *server,
     if (params->list & SC_OPTION_LIST_CAMERA_SIZES) {
         ADD_PARAM("list_camera_sizes=true");
     }
+    if (params->list & SC_OPTION_LIST_APPS) {
+        ADD_PARAM("list_apps=true");
+    }
 
 #undef ADD_PARAM
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -355,6 +355,10 @@ execute_server(struct sc_server *server,
         // By default, power_on is true
         ADD_PARAM("power_on=false");
     }
+    if (params->new_display) {
+        VALIDATE_STRING(params->new_display);
+        ADD_PARAM("new_display=%s", params->new_display);
+    }
     if (params->list & SC_OPTION_LIST_ENCODERS) {
         ADD_PARAM("list_encoders=true");
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -48,6 +48,7 @@ struct sc_server_params {
     int8_t lock_video_orientation;
     bool control;
     uint32_t display_id;
+    const char *new_display;
     bool video;
     bool audio;
     bool audio_dup;

--- a/doc/device.md
+++ b/doc/device.md
@@ -78,3 +78,48 @@ By default, on start, the device is powered on. To prevent this behavior:
 ```bash
 scrcpy --no-power-on
 ```
+
+
+## Start Android app
+
+To list the Android apps installed on the device:
+
+```bash
+scrcpy --list-apps
+```
+
+An app, selected by its package name, can be launched on start:
+
+```
+scrcpy --start-app=org.mozilla.firefox
+```
+
+This feature can be used to run an app in a [virtual
+display](virtual_display.md):
+
+```
+scrcpy --new-display=1920x1080 --start-app=org.videolan.vlc
+```
+
+The app can be optionally forced-stop before being started, by adding a `+`
+prefix:
+
+```
+scrcpy --start-app=+org.mozilla.firefox
+```
+
+For convenience, it is also possible to select an app by its name, by adding a
+`?` prefix:
+
+```
+scrcpy --start-app=?firefox
+```
+
+But retrieving app names may take some time (sometimes several seconds), so
+passing the package name is recommended.
+
+The `+` and `?` prefixes can be combined (in that order):
+
+```
+scrcpy --start-app=+?firefox
+```

--- a/doc/virtual_display.md
+++ b/doc/virtual_display.md
@@ -1,0 +1,26 @@
+# Virtual display
+
+## New display
+
+To mirror a new virtual display instead of the device screen:
+
+```bash
+scrcpy --new-display=1920x1080
+scrcpy --new-display=1920x1080/420  # force 420 dpi
+scrcpy --new-display         # use the main display size and density
+scrcpy --new-display -m1920  # ... scaled to fit a max size of 1920
+scrcpy --new-display=/240    # use the main display size and 240 dpi
+```
+
+## Start app
+
+On some devices, a launcher is available in the virtual display.
+
+When no launcher is available, the virtual display is empty. In that case, you
+must [start an Android app](device.md#start-android-app).
+
+For example:
+
+```bash
+scrcpy --new-display=1920x1080 --start-app=org.videolan.vlc
+```

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -139,8 +139,10 @@ public final class CleanUp {
 
         if (Device.isScreenOn()) {
             if (powerOffScreen) {
-                Ln.i("Power off screen");
-                Device.powerOffScreen(displayId);
+                if (displayId != Device.DISPLAY_ID_NONE) {
+                    Ln.i("Power off screen");
+                    Device.powerOffScreen(displayId);
+                }
             } else if (restoreNormalPowerMode) {
                 Ln.i("Restoring normal power mode");
                 Device.setScreenPowerMode(Device.POWER_MODE_NORMAL);

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -61,6 +61,7 @@ public class Options {
     private boolean listDisplays;
     private boolean listCameras;
     private boolean listCameraSizes;
+    private boolean listApps;
 
     // Options not used by the scrcpy client, but useful to use scrcpy-server directly
     private boolean sendDeviceMeta = true; // send device name and size
@@ -213,7 +214,7 @@ public class Options {
     }
 
     public boolean getList() {
-        return listEncoders || listDisplays || listCameras || listCameraSizes;
+        return listEncoders || listDisplays || listCameras || listCameraSizes || listApps;
     }
 
     public boolean getListEncoders() {
@@ -230,6 +231,10 @@ public class Options {
 
     public boolean getListCameraSizes() {
         return listCameraSizes;
+    }
+
+    public boolean getListApps() {
+        return listApps;
     }
 
     public boolean getSendDeviceMeta() {
@@ -394,6 +399,9 @@ public class Options {
                     break;
                 case "list_camera_sizes":
                     options.listCameraSizes = Boolean.parseBoolean(value);
+                    break;
+                case "list_apps":
+                    options.listApps = Boolean.parseBoolean(value);
                     break;
                 case "camera_id":
                     if (!value.isEmpty()) {

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy;
 
 import com.genymobile.scrcpy.audio.AudioCodec;
 import com.genymobile.scrcpy.audio.AudioSource;
+import com.genymobile.scrcpy.device.NewDisplay;
 import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.CodecOption;
 import com.genymobile.scrcpy.util.Ln;
@@ -53,6 +54,8 @@ public class Options {
     private boolean downsizeOnError = true;
     private boolean cleanup = true;
     private boolean powerOn = true;
+
+    private NewDisplay newDisplay;
 
     private boolean listEncoders;
     private boolean listDisplays;
@@ -203,6 +206,10 @@ public class Options {
 
     public boolean getPowerOn() {
         return powerOn;
+    }
+
+    public NewDisplay getNewDisplay() {
+        return newDisplay;
     }
 
     public boolean getList() {
@@ -418,6 +425,9 @@ public class Options {
                 case "camera_high_speed":
                     options.cameraHighSpeed = Boolean.parseBoolean(value);
                     break;
+                case "new_display":
+                    options.newDisplay = parseNewDisplay(value);
+                    break;
                 case "send_device_meta":
                     options.sendDeviceMeta = Boolean.parseBoolean(value);
                     break;
@@ -503,5 +513,37 @@ public class Options {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid float value for " + key + ": \"" + value + "\"");
         }
+    }
+
+    private static NewDisplay parseNewDisplay(String newDisplay) {
+        // Possible inputs:
+        //  - "" (empty string)
+        //  - "<width>x<height>/<dpi>"
+        //  - "<width>x<height>"
+        //  - "/<dpi>"
+        if (newDisplay.isEmpty()) {
+            return new NewDisplay();
+        }
+
+        String[] tokens = newDisplay.split("/");
+
+        Size size;
+        if (!tokens[0].isEmpty()) {
+            size = parseSize(tokens[0]);
+        } else {
+            size = null;
+        }
+
+        int dpi;
+        if (tokens.length >= 2) {
+            dpi = Integer.parseInt(tokens[1]);
+            if (dpi <= 0) {
+                throw new IllegalArgumentException("Invalid non-positive dpi: " + tokens[1]);
+            }
+        } else {
+            dpi = 0;
+        }
+
+        return new NewDisplay(size, dpi);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -139,9 +139,6 @@ public final class Server {
         boolean video = options.getVideo();
         boolean audio = options.getAudio();
         boolean sendDummyByte = options.getSendDummyByte();
-        boolean camera = video && options.getVideoSource() == VideoSource.CAMERA;
-
-        final Device device = camera ? null : new Device();
 
         Workarounds.apply();
 
@@ -153,10 +150,11 @@ public final class Server {
                 connection.sendDeviceMeta(Device.getDeviceName());
             }
 
+            Controller controller = null;
+
             if (control) {
                 ControlChannel controlChannel = connection.getControlChannel();
-                Controller controller = new Controller(
-                        device, options.getDisplayId(), controlChannel, cleanUp, options.getClipboardAutosync(), options.getPowerOn());
+                controller = new Controller(options.getDisplayId(), controlChannel, cleanUp, options.getClipboardAutosync(), options.getPowerOn());
                 asyncProcessors.add(controller);
             }
 
@@ -186,7 +184,7 @@ public final class Server {
                         options.getSendFrameMeta());
                 SurfaceCapture surfaceCapture;
                 if (options.getVideoSource() == VideoSource.DISPLAY) {
-                    surfaceCapture = new ScreenCapture(device, options.getDisplayId(), options.getMaxSize(), options.getCrop(),
+                    surfaceCapture = new ScreenCapture(controller, options.getDisplayId(), options.getMaxSize(), options.getCrop(),
                             options.getLockVideoOrientation());
                 } else {
                     surfaceCapture = new CameraCapture(options.getCameraId(), options.getCameraFacing(), options.getCameraSize(),

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -156,7 +156,8 @@ public final class Server {
 
             if (control) {
                 ControlChannel controlChannel = connection.getControlChannel();
-                Controller controller = new Controller(device, controlChannel, cleanUp, options.getClipboardAutosync(), options.getPowerOn());
+                Controller controller = new Controller(
+                        device, options.getDisplayId(), controlChannel, cleanUp, options.getClipboardAutosync(), options.getPowerOn());
                 device.setClipboardListener(text -> {
                     DeviceMessage msg = DeviceMessage.createClipboard(text);
                     controller.getSender().send(msg);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -190,7 +190,8 @@ public final class Server {
                         options.getSendFrameMeta());
                 SurfaceCapture surfaceCapture;
                 if (options.getVideoSource() == VideoSource.DISPLAY) {
-                    surfaceCapture = new ScreenCapture(device);
+                    surfaceCapture = new ScreenCapture(device, options.getDisplayId(), options.getMaxSize(), options.getCrop(),
+                            options.getLockVideoOrientation());
                 } else {
                     surfaceCapture = new CameraCapture(options.getCameraId(), options.getCameraFacing(), options.getCameraSize(),
                             options.getMaxSize(), options.getCameraAspectRatio(), options.getCameraFps(), options.getCameraHighSpeed());

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -9,7 +9,6 @@ import com.genymobile.scrcpy.audio.AudioRawRecorder;
 import com.genymobile.scrcpy.audio.AudioSource;
 import com.genymobile.scrcpy.control.ControlChannel;
 import com.genymobile.scrcpy.control.Controller;
-import com.genymobile.scrcpy.control.DeviceMessage;
 import com.genymobile.scrcpy.device.ConfigurationException;
 import com.genymobile.scrcpy.device.DesktopConnection;
 import com.genymobile.scrcpy.device.Device;
@@ -142,7 +141,7 @@ public final class Server {
         boolean sendDummyByte = options.getSendDummyByte();
         boolean camera = video && options.getVideoSource() == VideoSource.CAMERA;
 
-        final Device device = camera ? null : new Device(options);
+        final Device device = camera ? null : new Device();
 
         Workarounds.apply();
 
@@ -158,10 +157,6 @@ public final class Server {
                 ControlChannel controlChannel = connection.getControlChannel();
                 Controller controller = new Controller(
                         device, options.getDisplayId(), controlChannel, cleanUp, options.getClipboardAutosync(), options.getPowerOn());
-                device.setClipboardListener(text -> {
-                    DeviceMessage msg = DeviceMessage.createClipboard(text);
-                    controller.getSender().send(msg);
-                });
                 asyncProcessors.add(controller);
             }
 

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -127,6 +127,11 @@ public final class Server {
             throw new ConfigurationException("Camera mirroring is not supported");
         }
 
+        if (Build.VERSION.SDK_INT < AndroidVersions.API_29_ANDROID_10 && options.getNewDisplay() != null) {
+            Ln.e("New virtual display is not supported before Android 10");
+            throw new ConfigurationException("New virtual display is not supported");
+        }
+
         CleanUp cleanUp = null;
         Thread initThread = null;
 

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -292,6 +292,11 @@ public final class Server {
                 Workarounds.apply();
                 Ln.i(LogUtils.buildCameraListMessage(options.getListCameraSizes()));
             }
+            if (options.getListApps()) {
+                Workarounds.apply();
+                Ln.i("Processing Android apps... (this may take some time)");
+                Ln.i(LogUtils.buildAppListMessage());
+            }
             // Just print the requested data, do not mirror
             return;
         }

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
@@ -23,6 +23,7 @@ public final class ControlMessage {
     public static final int TYPE_UHID_INPUT = 13;
     public static final int TYPE_UHID_DESTROY = 14;
     public static final int TYPE_OPEN_HARD_KEYBOARD_SETTINGS = 15;
+    public static final int TYPE_START_APP = 16;
 
     public static final long SEQUENCE_INVALID = 0;
 
@@ -152,6 +153,13 @@ public final class ControlMessage {
         ControlMessage msg = new ControlMessage();
         msg.type = TYPE_UHID_DESTROY;
         msg.id = id;
+        return msg;
+    }
+
+    public static ControlMessage createStartApp(String name) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_START_APP;
+        msg.text = name;
         return msg;
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
@@ -53,6 +53,8 @@ public class ControlMessageReader {
                 return parseUhidInput();
             case ControlMessage.TYPE_UHID_DESTROY:
                 return parseUhidDestroy();
+            case ControlMessage.TYPE_START_APP:
+                return parseStartApp();
             default:
                 throw new ControlProtocolException("Unknown event type: " + type);
         }
@@ -153,6 +155,11 @@ public class ControlMessageReader {
     private ControlMessage parseUhidDestroy() throws IOException {
         int id = dis.readUnsignedShort();
         return ControlMessage.createUhidDestroy(id);
+    }
+
+    private ControlMessage parseStartApp() throws IOException {
+        String name = parseString(1);
+        return ControlMessage.createStartApp(name);
     }
 
     private Position parsePosition() throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -8,6 +8,7 @@ import com.genymobile.scrcpy.device.DeviceApp;
 import com.genymobile.scrcpy.device.Point;
 import com.genymobile.scrcpy.device.Position;
 import com.genymobile.scrcpy.util.Ln;
+import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.VirtualDisplayListener;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.InputManager;
@@ -23,6 +24,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -599,10 +601,31 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
             name = name.substring(1);
         }
 
-        DeviceApp app = Device.findByPackageName(name);
-        if (app == null) {
-            Ln.w("No app found for package \"" + name + "\"");
-            return;
+        DeviceApp app;
+        boolean searchByName = name.startsWith("?");
+        if (searchByName) {
+            name = name.substring(1);
+
+            Ln.i("Processing Android apps... (this may take some time)");
+            List<DeviceApp> apps = Device.findByName(name);
+            if (apps.isEmpty()) {
+                Ln.w("No app found for name \"" + name + "\"");
+                return;
+            }
+
+            if (apps.size() > 1) {
+                String title = "No unique app found for name \"" + name + "\":";
+                Ln.w(LogUtils.buildAppListMessage(title, apps));
+                return;
+            }
+
+            app = apps.get(0);
+        } else {
+            app = Device.findByPackageName(name);
+            if (app == null) {
+                Ln.w("No app found for package \"" + name + "\"");
+                return;
+            }
         }
 
         int startAppDisplayId = getStartAppDisplayId();

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -594,6 +594,11 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     }
 
     private void startApp(String name) {
+        boolean forceStopBeforeStart = name.startsWith("+");
+        if (forceStopBeforeStart) {
+            name = name.substring(1);
+        }
+
         DeviceApp app = Device.findByPackageName(name);
         if (app == null) {
             Ln.w("No app found for package \"" + name + "\"");
@@ -607,7 +612,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
         }
 
         Ln.i("Starting app \"" + app.getName() + "\" [" + app.getPackageName() + "] on display " + startAppDisplayId + "...");
-        Device.startApp(app.getPackageName(), startAppDisplayId);
+        Device.startApp(app.getPackageName(), startAppDisplayId, forceStopBeforeStart);
     }
 
     private int getStartAppDisplayId() {

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -7,9 +7,11 @@ import com.genymobile.scrcpy.device.Device;
 import com.genymobile.scrcpy.device.Point;
 import com.genymobile.scrcpy.device.Position;
 import com.genymobile.scrcpy.util.Ln;
+import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.InputManager;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
+import android.content.IOnPrimaryClipChangedListener;
 import android.content.Intent;
 import android.os.Build;
 import android.os.SystemClock;
@@ -23,6 +25,7 @@ import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Controller implements AsyncProcessor {
 
@@ -48,6 +51,8 @@ public class Controller implements AsyncProcessor {
 
     private final KeyCharacterMap charMap = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
 
+    private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
+
     private long lastTouchDown;
     private final PointersState pointersState = new PointersState();
     private final MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[PointersState.MAX_POINTERS];
@@ -68,6 +73,29 @@ public class Controller implements AsyncProcessor {
         supportsInputEvents = Device.supportsInputEvents(displayId);
         if (!supportsInputEvents) {
             Ln.w("Input events are not supported for secondary displays before Android 10");
+        }
+
+        if (clipboardAutosync) {
+            // If control and autosync are enabled, synchronize Android clipboard to the computer automatically
+            ClipboardManager clipboardManager = ServiceManager.getClipboardManager();
+            if (clipboardManager != null) {
+                clipboardManager.addPrimaryClipChangedListener(new IOnPrimaryClipChangedListener.Stub() {
+                    @Override
+                    public void dispatchPrimaryClipChanged() {
+                        if (isSettingClipboard.get()) {
+                            // This is a notification for the change we are currently applying, ignore it
+                            return;
+                        }
+                        String text = Device.getClipboardText();
+                        if (text != null) {
+                            DeviceMessage msg = DeviceMessage.createClipboard(text);
+                            sender.send(msg);
+                        }
+                    }
+                });
+            } else {
+                Ln.w("No clipboard manager, copy-paste between device and computer will not work");
+            }
         }
     }
 
@@ -146,10 +174,6 @@ public class Controller implements AsyncProcessor {
             thread.join();
         }
         sender.join();
-    }
-
-    public DeviceMessageSender getSender() {
-        return sender;
     }
 
     private boolean handleEvent() throws IOException {
@@ -452,7 +476,9 @@ public class Controller implements AsyncProcessor {
     }
 
     private boolean setClipboard(String text, boolean paste, long sequence) {
-        boolean ok = device.setClipboardText(text);
+        isSettingClipboard.set(true);
+        boolean ok = Device.setClipboardText(text);
+        isSettingClipboard.set(false);
         if (ok) {
             Ln.i("Device clipboard set");
         }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -7,6 +7,7 @@ import com.genymobile.scrcpy.device.Device;
 import com.genymobile.scrcpy.device.Point;
 import com.genymobile.scrcpy.device.Position;
 import com.genymobile.scrcpy.util.Ln;
+import com.genymobile.scrcpy.video.VirtualDisplayListener;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.InputManager;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
@@ -26,8 +27,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
-public class Controller implements AsyncProcessor {
+public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     private static final int DEFAULT_DEVICE_ID = 0;
 
@@ -40,7 +42,6 @@ public class Controller implements AsyncProcessor {
 
     private UhidManager uhidManager;
 
-    private final Device device;
     private final int displayId;
     private final boolean supportsInputEvents;
     private final ControlChannel controlChannel;
@@ -53,6 +54,8 @@ public class Controller implements AsyncProcessor {
 
     private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
 
+    private final AtomicReference<PositionMapper> positionMapper = new AtomicReference<>();
+
     private long lastTouchDown;
     private final PointersState pointersState = new PointersState();
     private final MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[PointersState.MAX_POINTERS];
@@ -60,8 +63,7 @@ public class Controller implements AsyncProcessor {
 
     private boolean keepPowerModeOff;
 
-    public Controller(Device device, int displayId, ControlChannel controlChannel, CleanUp cleanUp, boolean clipboardAutosync, boolean powerOn) {
-        this.device = device;
+    public Controller(int displayId, ControlChannel controlChannel, CleanUp cleanUp, boolean clipboardAutosync, boolean powerOn) {
         this.displayId = displayId;
         this.controlChannel = controlChannel;
         this.cleanUp = cleanUp;
@@ -97,6 +99,11 @@ public class Controller implements AsyncProcessor {
                 Ln.w("No clipboard manager, copy-paste between device and computer will not work");
             }
         }
+    }
+
+    @Override
+    public void onNewVirtualDisplay(PositionMapper positionMapper) {
+        this.positionMapper.set(positionMapper);
     }
 
     private UhidManager getUhidManager() {
@@ -299,7 +306,7 @@ public class Controller implements AsyncProcessor {
     private boolean injectTouch(int action, long pointerId, Position position, float pressure, int actionButton, int buttons) {
         long now = SystemClock.uptimeMillis();
 
-        Point point = device.getPhysicalPoint(position);
+        Point point = getPhysicalPoint(position);
         if (point == null) {
             Ln.w("Ignore touch event, it was generated for a different device size");
             return false;
@@ -407,9 +414,9 @@ public class Controller implements AsyncProcessor {
 
     private boolean injectScroll(Position position, float hScroll, float vScroll, int buttons) {
         long now = SystemClock.uptimeMillis();
-        Point point = device.getPhysicalPoint(position);
+        Point point = getPhysicalPoint(position);
         if (point == null) {
-            // ignore event
+            Ln.w("Ignore scroll event, it was generated for a different device size");
             return false;
         }
 
@@ -425,6 +432,17 @@ public class Controller implements AsyncProcessor {
         MotionEvent event = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, buttons, 1f, 1f,
                 DEFAULT_DEVICE_ID, 0, InputDevice.SOURCE_MOUSE, 0);
         return injectEvent(event, Device.INJECT_MODE_ASYNC);
+    }
+
+    private Point getPhysicalPoint(Position position) {
+        // it hides the field on purpose, to read it with atomic access
+        @SuppressWarnings("checkstyle:HiddenField")
+        PositionMapper positionMapper = this.positionMapper.get();
+        if (positionMapper == null) {
+            return null;
+        }
+
+        return positionMapper.map(position);
     }
 
     /**

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -17,7 +17,6 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.SystemClock;
 import android.view.InputDevice;
-import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -30,6 +29,28 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class Controller implements AsyncProcessor, VirtualDisplayListener {
+
+    /*
+     * For event injection, there are two display ids:
+     *  - the displayId passed to the constructor (which comes from --display-id passed by the client, 0 for the main display);
+     *  - the virtualDisplayId used for mirroring, notified by the capture instance via the VirtualDisplayListener interface.
+     *
+     * (In case the ScreenCapture uses the "SurfaceControl API", then both ids are equals, but this is an implementation detail.)
+     *
+     * In order to make events work correctly in all cases:
+     *  - virtualDisplayId must be used for events relative to the display (mouse and touch events with coordinates);
+     *  - displayId must be used for other events (like key events).
+     */
+
+    private static final class DisplayData {
+        private final int virtualDisplayId;
+        private final PositionMapper positionMapper;
+
+        private DisplayData(int virtualDisplayId, PositionMapper positionMapper) {
+            this.virtualDisplayId = virtualDisplayId;
+            this.positionMapper = positionMapper;
+        }
+    }
 
     private static final int DEFAULT_DEVICE_ID = 0;
 
@@ -54,7 +75,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
 
-    private final AtomicReference<PositionMapper> positionMapper = new AtomicReference<>();
+    private final AtomicReference<DisplayData> displayData = new AtomicReference<>();
 
     private long lastTouchDown;
     private final PointersState pointersState = new PointersState();
@@ -102,8 +123,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     }
 
     @Override
-    public void onNewVirtualDisplay(PositionMapper positionMapper) {
-        this.positionMapper.set(positionMapper);
+    public void onNewVirtualDisplay(int virtualDisplayId, PositionMapper positionMapper) {
+        DisplayData data = new DisplayData(virtualDisplayId, positionMapper);
+        this.displayData.set(data);
     }
 
     private UhidManager getUhidManager() {
@@ -284,7 +306,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
             return false;
         }
         for (KeyEvent event : events) {
-            if (!injectEvent(event, Device.INJECT_MODE_ASYNC)) {
+            if (!Device.injectEvent(event, displayId, Device.INJECT_MODE_ASYNC)) {
                 return false;
             }
         }
@@ -306,7 +328,12 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private boolean injectTouch(int action, long pointerId, Position position, float pressure, int actionButton, int buttons) {
         long now = SystemClock.uptimeMillis();
 
-        Point point = getPhysicalPoint(position);
+        // it hides the field on purpose, to read it with atomic access
+        @SuppressWarnings("checkstyle:HiddenField")
+        DisplayData displayData = this.displayData.get();
+        assert displayData != null : "Cannot receive a touch event without a display";
+
+        Point point = displayData.positionMapper.map(position);
         if (point == null) {
             Ln.w("Ignore touch event, it was generated for a different device size");
             return false;
@@ -365,7 +392,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                     // First button pressed: ACTION_DOWN
                     MotionEvent downEvent = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_DOWN, pointerCount, pointerProperties,
                             pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0, source, 0);
-                    if (!injectEvent(downEvent, Device.INJECT_MODE_ASYNC)) {
+                    if (!Device.injectEvent(downEvent, displayData.virtualDisplayId, Device.INJECT_MODE_ASYNC)) {
                         return false;
                     }
                 }
@@ -376,7 +403,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 if (!InputManager.setActionButton(pressEvent, actionButton)) {
                     return false;
                 }
-                if (!injectEvent(pressEvent, Device.INJECT_MODE_ASYNC)) {
+                if (!Device.injectEvent(pressEvent, displayData.virtualDisplayId, Device.INJECT_MODE_ASYNC)) {
                     return false;
                 }
 
@@ -390,7 +417,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 if (!InputManager.setActionButton(releaseEvent, actionButton)) {
                     return false;
                 }
-                if (!injectEvent(releaseEvent, Device.INJECT_MODE_ASYNC)) {
+                if (!Device.injectEvent(releaseEvent, displayData.virtualDisplayId, Device.INJECT_MODE_ASYNC)) {
                     return false;
                 }
 
@@ -398,7 +425,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                     // Last button released: ACTION_UP
                     MotionEvent upEvent = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_UP, pointerCount, pointerProperties,
                             pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0, source, 0);
-                    if (!injectEvent(upEvent, Device.INJECT_MODE_ASYNC)) {
+                    if (!Device.injectEvent(upEvent, displayData.virtualDisplayId, Device.INJECT_MODE_ASYNC)) {
                         return false;
                     }
                 }
@@ -409,12 +436,18 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
         MotionEvent event = MotionEvent.obtain(lastTouchDown, now, action, pointerCount, pointerProperties, pointerCoords, 0, buttons, 1f, 1f,
                 DEFAULT_DEVICE_ID, 0, source, 0);
-        return injectEvent(event, Device.INJECT_MODE_ASYNC);
+        return Device.injectEvent(event, displayData.virtualDisplayId, Device.INJECT_MODE_ASYNC);
     }
 
     private boolean injectScroll(Position position, float hScroll, float vScroll, int buttons) {
         long now = SystemClock.uptimeMillis();
-        Point point = getPhysicalPoint(position);
+
+        // it hides the field on purpose, to read it with atomic access
+        @SuppressWarnings("checkstyle:HiddenField")
+        DisplayData displayData = this.displayData.get();
+        assert displayData != null : "Cannot receive a scroll event without a display";
+
+        Point point = displayData.positionMapper.map(position);
         if (point == null) {
             Ln.w("Ignore scroll event, it was generated for a different device size");
             return false;
@@ -431,18 +464,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
         MotionEvent event = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, buttons, 1f, 1f,
                 DEFAULT_DEVICE_ID, 0, InputDevice.SOURCE_MOUSE, 0);
-        return injectEvent(event, Device.INJECT_MODE_ASYNC);
-    }
-
-    private Point getPhysicalPoint(Position position) {
-        // it hides the field on purpose, to read it with atomic access
-        @SuppressWarnings("checkstyle:HiddenField")
-        PositionMapper positionMapper = this.positionMapper.get();
-        if (positionMapper == null) {
-            return null;
-        }
-
-        return positionMapper.map(position);
+        return Device.injectEvent(event, displayData.virtualDisplayId, Device.INJECT_MODE_ASYNC);
     }
 
     /**
@@ -518,10 +540,6 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private void openHardKeyboardSettings() {
         Intent intent = new Intent("android.settings.HARD_KEYBOARD_SETTINGS");
         ServiceManager.getActivityManager().startActivity(intent);
-    }
-
-    private boolean injectEvent(InputEvent event, int injectMode) {
-        return Device.injectEvent(event, displayId, injectMode);
     }
 
     private boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int injectMode) {

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -14,6 +14,7 @@ import android.content.Intent;
 import android.os.Build;
 import android.os.SystemClock;
 import android.view.InputDevice;
+import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -37,6 +38,8 @@ public class Controller implements AsyncProcessor {
     private UhidManager uhidManager;
 
     private final Device device;
+    private final int displayId;
+    private final boolean supportsInputEvents;
     private final ControlChannel controlChannel;
     private final CleanUp cleanUp;
     private final DeviceMessageSender sender;
@@ -52,14 +55,20 @@ public class Controller implements AsyncProcessor {
 
     private boolean keepPowerModeOff;
 
-    public Controller(Device device, ControlChannel controlChannel, CleanUp cleanUp, boolean clipboardAutosync, boolean powerOn) {
+    public Controller(Device device, int displayId, ControlChannel controlChannel, CleanUp cleanUp, boolean clipboardAutosync, boolean powerOn) {
         this.device = device;
+        this.displayId = displayId;
         this.controlChannel = controlChannel;
         this.cleanUp = cleanUp;
         this.clipboardAutosync = clipboardAutosync;
         this.powerOn = powerOn;
         initPointers();
         sender = new DeviceMessageSender(controlChannel);
+
+        supportsInputEvents = Device.supportsInputEvents(displayId);
+        if (!supportsInputEvents) {
+            Ln.w("Input events are not supported for secondary displays before Android 10");
+        }
     }
 
     private UhidManager getUhidManager() {
@@ -86,7 +95,7 @@ public class Controller implements AsyncProcessor {
     private void control() throws IOException {
         // on start, power on the device
         if (powerOn && !Device.isScreenOn()) {
-            device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, Device.INJECT_MODE_ASYNC);
+            Device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, displayId, Device.INJECT_MODE_ASYNC);
 
             // dirty hack
             // After POWER is injected, the device is powered on asynchronously.
@@ -154,27 +163,27 @@ public class Controller implements AsyncProcessor {
 
         switch (msg.getType()) {
             case ControlMessage.TYPE_INJECT_KEYCODE:
-                if (device.supportsInputEvents()) {
+                if (supportsInputEvents) {
                     injectKeycode(msg.getAction(), msg.getKeycode(), msg.getRepeat(), msg.getMetaState());
                 }
                 break;
             case ControlMessage.TYPE_INJECT_TEXT:
-                if (device.supportsInputEvents()) {
+                if (supportsInputEvents) {
                     injectText(msg.getText());
                 }
                 break;
             case ControlMessage.TYPE_INJECT_TOUCH_EVENT:
-                if (device.supportsInputEvents()) {
+                if (supportsInputEvents) {
                     injectTouch(msg.getAction(), msg.getPointerId(), msg.getPosition(), msg.getPressure(), msg.getActionButton(), msg.getButtons());
                 }
                 break;
             case ControlMessage.TYPE_INJECT_SCROLL_EVENT:
-                if (device.supportsInputEvents()) {
+                if (supportsInputEvents) {
                     injectScroll(msg.getPosition(), msg.getHScroll(), msg.getVScroll(), msg.getButtons());
                 }
                 break;
             case ControlMessage.TYPE_BACK_OR_SCREEN_ON:
-                if (device.supportsInputEvents()) {
+                if (supportsInputEvents) {
                     pressBackOrTurnScreenOn(msg.getAction());
                 }
                 break;
@@ -194,7 +203,7 @@ public class Controller implements AsyncProcessor {
                 setClipboard(msg.getText(), msg.getPaste(), msg.getSequence());
                 break;
             case ControlMessage.TYPE_SET_SCREEN_POWER_MODE:
-                if (device.supportsInputEvents()) {
+                if (supportsInputEvents) {
                     int mode = msg.getAction();
                     boolean setPowerModeOk = Device.setScreenPowerMode(mode);
                     if (setPowerModeOk) {
@@ -208,7 +217,7 @@ public class Controller implements AsyncProcessor {
                 }
                 break;
             case ControlMessage.TYPE_ROTATE_DEVICE:
-                device.rotateDevice();
+                Device.rotateDevice(displayId);
                 break;
             case ControlMessage.TYPE_UHID_CREATE:
                 getUhidManager().open(msg.getId(), msg.getText(), msg.getData());
@@ -233,7 +242,7 @@ public class Controller implements AsyncProcessor {
         if (keepPowerModeOff && action == KeyEvent.ACTION_UP && (keycode == KeyEvent.KEYCODE_POWER || keycode == KeyEvent.KEYCODE_WAKEUP)) {
             schedulePowerModeOff();
         }
-        return device.injectKeyEvent(action, keycode, repeat, metaState, Device.INJECT_MODE_ASYNC);
+        return injectKeyEvent(action, keycode, repeat, metaState, Device.INJECT_MODE_ASYNC);
     }
 
     private boolean injectChar(char c) {
@@ -244,7 +253,7 @@ public class Controller implements AsyncProcessor {
             return false;
         }
         for (KeyEvent event : events) {
-            if (!device.injectEvent(event, Device.INJECT_MODE_ASYNC)) {
+            if (!injectEvent(event, Device.INJECT_MODE_ASYNC)) {
                 return false;
             }
         }
@@ -325,7 +334,7 @@ public class Controller implements AsyncProcessor {
                     // First button pressed: ACTION_DOWN
                     MotionEvent downEvent = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_DOWN, pointerCount, pointerProperties,
                             pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0, source, 0);
-                    if (!device.injectEvent(downEvent, Device.INJECT_MODE_ASYNC)) {
+                    if (!injectEvent(downEvent, Device.INJECT_MODE_ASYNC)) {
                         return false;
                     }
                 }
@@ -336,7 +345,7 @@ public class Controller implements AsyncProcessor {
                 if (!InputManager.setActionButton(pressEvent, actionButton)) {
                     return false;
                 }
-                if (!device.injectEvent(pressEvent, Device.INJECT_MODE_ASYNC)) {
+                if (!injectEvent(pressEvent, Device.INJECT_MODE_ASYNC)) {
                     return false;
                 }
 
@@ -350,7 +359,7 @@ public class Controller implements AsyncProcessor {
                 if (!InputManager.setActionButton(releaseEvent, actionButton)) {
                     return false;
                 }
-                if (!device.injectEvent(releaseEvent, Device.INJECT_MODE_ASYNC)) {
+                if (!injectEvent(releaseEvent, Device.INJECT_MODE_ASYNC)) {
                     return false;
                 }
 
@@ -358,7 +367,7 @@ public class Controller implements AsyncProcessor {
                     // Last button released: ACTION_UP
                     MotionEvent upEvent = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_UP, pointerCount, pointerProperties,
                             pointerCoords, 0, buttons, 1f, 1f, DEFAULT_DEVICE_ID, 0, source, 0);
-                    if (!device.injectEvent(upEvent, Device.INJECT_MODE_ASYNC)) {
+                    if (!injectEvent(upEvent, Device.INJECT_MODE_ASYNC)) {
                         return false;
                     }
                 }
@@ -369,7 +378,7 @@ public class Controller implements AsyncProcessor {
 
         MotionEvent event = MotionEvent.obtain(lastTouchDown, now, action, pointerCount, pointerProperties, pointerCoords, 0, buttons, 1f, 1f,
                 DEFAULT_DEVICE_ID, 0, source, 0);
-        return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
+        return injectEvent(event, Device.INJECT_MODE_ASYNC);
     }
 
     private boolean injectScroll(Position position, float hScroll, float vScroll, int buttons) {
@@ -391,7 +400,7 @@ public class Controller implements AsyncProcessor {
 
         MotionEvent event = MotionEvent.obtain(lastTouchDown, now, MotionEvent.ACTION_SCROLL, 1, pointerProperties, pointerCoords, 0, buttons, 1f, 1f,
                 DEFAULT_DEVICE_ID, 0, InputDevice.SOURCE_MOUSE, 0);
-        return device.injectEvent(event, Device.INJECT_MODE_ASYNC);
+        return injectEvent(event, Device.INJECT_MODE_ASYNC);
     }
 
     /**
@@ -406,7 +415,7 @@ public class Controller implements AsyncProcessor {
 
     private boolean pressBackOrTurnScreenOn(int action) {
         if (Device.isScreenOn()) {
-            return device.injectKeyEvent(action, KeyEvent.KEYCODE_BACK, 0, 0, Device.INJECT_MODE_ASYNC);
+            return injectKeyEvent(action, KeyEvent.KEYCODE_BACK, 0, 0, Device.INJECT_MODE_ASYNC);
         }
 
         // Screen is off
@@ -419,15 +428,15 @@ public class Controller implements AsyncProcessor {
         if (keepPowerModeOff) {
             schedulePowerModeOff();
         }
-        return device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, Device.INJECT_MODE_ASYNC);
+        return pressReleaseKeycode(KeyEvent.KEYCODE_POWER, Device.INJECT_MODE_ASYNC);
     }
 
     private void getClipboard(int copyKey) {
         // On Android >= 7, press the COPY or CUT key if requested
-        if (copyKey != ControlMessage.COPY_KEY_NONE && Build.VERSION.SDK_INT >= AndroidVersions.API_24_ANDROID_7_0 && device.supportsInputEvents()) {
+        if (copyKey != ControlMessage.COPY_KEY_NONE && Build.VERSION.SDK_INT >= AndroidVersions.API_24_ANDROID_7_0 && supportsInputEvents) {
             int key = copyKey == ControlMessage.COPY_KEY_COPY ? KeyEvent.KEYCODE_COPY : KeyEvent.KEYCODE_CUT;
             // Wait until the event is finished, to ensure that the clipboard text we read just after is the correct one
-            device.pressReleaseKeycode(key, Device.INJECT_MODE_WAIT_FOR_FINISH);
+            pressReleaseKeycode(key, Device.INJECT_MODE_WAIT_FOR_FINISH);
         }
 
         // If clipboard autosync is enabled, then the device clipboard is synchronized to the computer clipboard whenever it changes, in
@@ -449,8 +458,8 @@ public class Controller implements AsyncProcessor {
         }
 
         // On Android >= 7, also press the PASTE key if requested
-        if (paste && Build.VERSION.SDK_INT >= AndroidVersions.API_24_ANDROID_7_0 && device.supportsInputEvents()) {
-            device.pressReleaseKeycode(KeyEvent.KEYCODE_PASTE, Device.INJECT_MODE_ASYNC);
+        if (paste && Build.VERSION.SDK_INT >= AndroidVersions.API_24_ANDROID_7_0 && supportsInputEvents) {
+            pressReleaseKeycode(KeyEvent.KEYCODE_PASTE, Device.INJECT_MODE_ASYNC);
         }
 
         if (sequence != ControlMessage.SEQUENCE_INVALID) {
@@ -465,5 +474,17 @@ public class Controller implements AsyncProcessor {
     private void openHardKeyboardSettings() {
         Intent intent = new Intent("android.settings.HARD_KEYBOARD_SETTINGS");
         ServiceManager.getActivityManager().startActivity(intent);
+    }
+
+    private boolean injectEvent(InputEvent event, int injectMode) {
+        return Device.injectEvent(event, displayId, injectMode);
+    }
+
+    private boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int injectMode) {
+        return Device.injectKeyEvent(action, keyCode, repeat, metaState, displayId, injectMode);
+    }
+
+    private boolean pressReleaseKeycode(int keyCode, int injectMode) {
+        return Device.pressReleaseKeycode(keyCode, displayId, injectMode);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -40,6 +40,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
      * In order to make events work correctly in all cases:
      *  - virtualDisplayId must be used for events relative to the display (mouse and touch events with coordinates);
      *  - displayId must be used for other events (like key events).
+     *
+     * If a new separate virtual display is created (using --new-display), then displayId == Device.DISPLAY_ID_NONE. In that case, all events are
+     * sent to the virtual display id.
      */
 
     private static final class DisplayData {
@@ -151,7 +154,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     private void control() throws IOException {
         // on start, power on the device
-        if (powerOn && !Device.isScreenOn()) {
+        if (powerOn && displayId != Device.DISPLAY_ID_NONE && !Device.isScreenOn()) {
             Device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, displayId, Device.INJECT_MODE_ASYNC);
 
             // dirty hack
@@ -270,7 +273,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 }
                 break;
             case ControlMessage.TYPE_ROTATE_DEVICE:
-                Device.rotateDevice(displayId);
+                Device.rotateDevice(getActionDisplayId());
                 break;
             case ControlMessage.TYPE_UHID_CREATE:
                 getUhidManager().open(msg.getId(), msg.getText(), msg.getData());
@@ -305,8 +308,10 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
         if (events == null) {
             return false;
         }
+
+        int actionDisplayId = getActionDisplayId();
         for (KeyEvent event : events) {
-            if (!Device.injectEvent(event, displayId, Device.INJECT_MODE_ASYNC)) {
+            if (!Device.injectEvent(event, actionDisplayId, Device.INJECT_MODE_ASYNC)) {
                 return false;
             }
         }
@@ -543,10 +548,26 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     }
 
     private boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int injectMode) {
-        return Device.injectKeyEvent(action, keyCode, repeat, metaState, displayId, injectMode);
+        return Device.injectKeyEvent(action, keyCode, repeat, metaState, getActionDisplayId(), injectMode);
     }
 
     private boolean pressReleaseKeycode(int keyCode, int injectMode) {
-        return Device.pressReleaseKeycode(keyCode, displayId, injectMode);
+        return Device.pressReleaseKeycode(keyCode, getActionDisplayId(), injectMode);
+    }
+
+    private int getActionDisplayId() {
+        if (displayId != Device.DISPLAY_ID_NONE) {
+            // Real screen mirrored, use the source display id
+            return displayId;
+        }
+
+        // Virtual display created by --new-display, use the virtualDisplayId
+        DisplayData data = displayData.get();
+        if (data == null) {
+            // If no virtual display id is initialized yet, use the main display id
+            return 0;
+        }
+
+        return data.virtualDisplayId;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -4,6 +4,7 @@ import com.genymobile.scrcpy.AndroidVersions;
 import com.genymobile.scrcpy.AsyncProcessor;
 import com.genymobile.scrcpy.CleanUp;
 import com.genymobile.scrcpy.device.Device;
+import com.genymobile.scrcpy.device.DeviceApp;
 import com.genymobile.scrcpy.device.Point;
 import com.genymobile.scrcpy.device.Position;
 import com.genymobile.scrcpy.util.Ln;
@@ -22,6 +23,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -61,6 +63,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private static final int POINTER_ID_MOUSE = -1;
 
     private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
+    private ExecutorService startAppExecutor;
 
     private Thread thread;
 
@@ -79,6 +82,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
 
     private final AtomicReference<DisplayData> displayData = new AtomicReference<>();
+    private final Object displayDataAvailable = new Object(); // condition variable
 
     private long lastTouchDown;
     private final PointersState pointersState = new PointersState();
@@ -128,7 +132,13 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     @Override
     public void onNewVirtualDisplay(int virtualDisplayId, PositionMapper positionMapper) {
         DisplayData data = new DisplayData(virtualDisplayId, positionMapper);
-        this.displayData.set(data);
+        DisplayData old = this.displayData.getAndSet(data);
+        if (old == null) {
+            // The very first time the Controller is notified of a new virtual display
+            synchronized (displayDataAvailable) {
+                displayDataAvailable.notify();
+            }
+        }
     }
 
     private UhidManager getUhidManager() {
@@ -286,6 +296,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 break;
             case ControlMessage.TYPE_OPEN_HARD_KEYBOARD_SETTINGS:
                 openHardKeyboardSettings();
+                break;
+            case ControlMessage.TYPE_START_APP:
+                startAppAsync(msg.getText());
                 break;
             default:
                 // do nothing
@@ -569,5 +582,69 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
         }
 
         return data.virtualDisplayId;
+    }
+
+    private void startAppAsync(String name) {
+        if (startAppExecutor == null) {
+            startAppExecutor = Executors.newSingleThreadExecutor();
+        }
+
+        // Listing and selecting the app may take a lot of time
+        startAppExecutor.submit(() -> startApp(name));
+    }
+
+    private void startApp(String name) {
+        DeviceApp app = Device.findByPackageName(name);
+        if (app == null) {
+            Ln.w("No app found for package \"" + name + "\"");
+            return;
+        }
+
+        int startAppDisplayId = getStartAppDisplayId();
+        if (startAppDisplayId == Device.DISPLAY_ID_NONE) {
+            Ln.e("No known display id to start app \"" + name + "\"");
+            return;
+        }
+
+        Ln.i("Starting app \"" + app.getName() + "\" [" + app.getPackageName() + "] on display " + startAppDisplayId + "...");
+        Device.startApp(app.getPackageName(), startAppDisplayId);
+    }
+
+    private int getStartAppDisplayId() {
+        if (displayId != Device.DISPLAY_ID_NONE) {
+            return displayId;
+        }
+
+        // Mirroring a new virtual display id (using --new-display-id feature)
+        try {
+            // Wait for at most 1 second until a virtual display id is known
+            DisplayData data = waitDisplayData(1000);
+            if (data != null) {
+                return data.virtualDisplayId;
+            }
+        } catch (InterruptedException e) {
+            // do nothing
+        }
+
+        // No display id available
+        return Device.DISPLAY_ID_NONE;
+    }
+
+    private DisplayData waitDisplayData(long timeoutMillis) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + timeoutMillis;
+
+        synchronized (displayDataAvailable) {
+            DisplayData data = displayData.get();
+            while (data == null) {
+                long timeout = deadline - System.currentTimeMillis();
+                if (timeout < 0) {
+                    return null;
+                }
+                displayDataAvailable.wait(timeout);
+                data = displayData.get();
+            }
+
+            return data;
+        }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/control/PositionMapper.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/PositionMapper.java
@@ -1,0 +1,48 @@
+package com.genymobile.scrcpy.control;
+
+import com.genymobile.scrcpy.device.Point;
+import com.genymobile.scrcpy.device.Position;
+import com.genymobile.scrcpy.device.Size;
+import com.genymobile.scrcpy.video.ScreenInfo;
+
+import android.graphics.Rect;
+
+public final class PositionMapper {
+
+    private final Size videoSize;
+    private final Rect contentRect;
+    private final int coordsRotation;
+
+    public PositionMapper(Size videoSize, Rect contentRect, int videoRotation) {
+        this.videoSize = videoSize;
+        this.contentRect = contentRect;
+        this.coordsRotation = reverseRotation(videoRotation);
+    }
+
+    public static PositionMapper from(ScreenInfo screenInfo) {
+        // ignore the locked video orientation, the events will apply in coordinates considered in the physical device orientation
+        Size videoSize = screenInfo.getUnlockedVideoSize();
+        return new PositionMapper(videoSize, screenInfo.getContentRect(), screenInfo.getVideoRotation());
+    }
+
+    private static int reverseRotation(int rotation) {
+        return (4 - rotation) % 4;
+    }
+
+    public Point map(Position position) {
+        // reverse the video rotation to apply the events
+        Position devicePosition = position.rotate(coordsRotation);
+
+        Size clientVideoSize = devicePosition.getScreenSize();
+        if (!videoSize.equals(clientVideoSize)) {
+            // The client sends a click relative to a video with wrong dimensions,
+            // the device may have been rotated since the event was generated, so ignore the event
+            return null;
+        }
+
+        Point point = devicePosition.getPoint();
+        int convertedX = contentRect.left + point.getX() * contentRect.width() / videoSize.getWidth();
+        int convertedY = contentRect.top + point.getY() * contentRect.height() / videoSize.getHeight();
+        return new Point(convertedX, convertedY);
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -264,7 +264,7 @@ public final class Device {
         return null;
     }
 
-    public static void startApp(String packageName, int displayId) {
+    public static void startApp(String packageName, int displayId, boolean forceStop) {
         PackageManager pm = FakeContext.get().getPackageManager();
 
         Intent launchIntent = getLaunchIntent(pm, packageName);
@@ -283,6 +283,9 @@ public final class Device {
         }
 
         ActivityManager am = ServiceManager.getActivityManager();
+        if (forceStop) {
+            am.forceStopPackage(packageName);
+        }
         am.startActivity(launchIntent, options);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -1,8 +1,8 @@
 package com.genymobile.scrcpy.device;
 
 import com.genymobile.scrcpy.AndroidVersions;
+import com.genymobile.scrcpy.control.PositionMapper;
 import com.genymobile.scrcpy.util.Ln;
-import com.genymobile.scrcpy.video.ScreenInfo;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.DisplayControl;
 import com.genymobile.scrcpy.wrappers.InputManager;
@@ -10,7 +10,6 @@ import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
 import com.genymobile.scrcpy.wrappers.WindowManager;
 
-import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.SystemClock;
@@ -33,34 +32,17 @@ public final class Device {
     public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
 
-    private final AtomicReference<ScreenInfo> screenInfo = new AtomicReference<>(); // set by the ScreenCapture instance
+    private final AtomicReference<PositionMapper> positionMapper = new AtomicReference<>(); // set by the ScreenCapture instance
 
     public Point getPhysicalPoint(Position position) {
         // it hides the field on purpose, to read it with atomic access
         @SuppressWarnings("checkstyle:HiddenField")
-        ScreenInfo screenInfo = this.screenInfo.get();
-        if (screenInfo == null) {
+        PositionMapper positionMapper = this.positionMapper.get();
+        if (positionMapper == null) {
             return null;
         }
 
-        // ignore the locked video orientation, the events will apply in coordinates considered in the physical device orientation
-        Size unlockedVideoSize = screenInfo.getUnlockedVideoSize();
-
-        int reverseVideoRotation = screenInfo.getReverseVideoRotation();
-        // reverse the video rotation to apply the events
-        Position devicePosition = position.rotate(reverseVideoRotation);
-
-        Size clientVideoSize = devicePosition.getScreenSize();
-        if (!unlockedVideoSize.equals(clientVideoSize)) {
-            // The client sends a click relative to a video with wrong dimensions,
-            // the device may have been rotated since the event was generated, so ignore the event
-            return null;
-        }
-        Rect contentRect = screenInfo.getContentRect();
-        Point point = devicePosition.getPoint();
-        int convertedX = contentRect.left + point.getX() * contentRect.width() / unlockedVideoSize.getWidth();
-        int convertedY = contentRect.top + point.getY() * contentRect.height() / unlockedVideoSize.getHeight();
-        return new Point(convertedX, convertedY);
+        return positionMapper.map(position);
     }
 
     public static String getDeviceName() {
@@ -72,8 +54,8 @@ public final class Device {
         return displayId == 0 || Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10;
     }
 
-    public void setScreenInfo(ScreenInfo screenInfo) {
-        this.screenInfo.set(screenInfo);
+    public void setPositionMapper(PositionMapper positionMapper) {
+        this.positionMapper.set(positionMapper);
     }
 
     public static boolean injectEvent(InputEvent inputEvent, int displayId, int injectMode) {

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -3,7 +3,6 @@ package com.genymobile.scrcpy.device;
 import com.genymobile.scrcpy.AndroidVersions;
 import com.genymobile.scrcpy.Options;
 import com.genymobile.scrcpy.util.Ln;
-import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.ScreenInfo;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.DisplayControl;
@@ -17,14 +16,13 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.SystemClock;
-import android.view.IDisplayFoldListener;
-import android.view.IRotationWatcher;
 import android.view.InputDevice;
 import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 public final class Device {
 
@@ -38,26 +36,10 @@ public final class Device {
     public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
 
-    public interface RotationListener {
-        void onRotationChanged(int rotation);
-    }
-
-    public interface FoldListener {
-        void onFoldChanged(int displayId, boolean folded);
-    }
-
     public interface ClipboardListener {
         void onClipboardTextChanged(String text);
     }
 
-    private final Rect crop;
-    private int maxSize;
-    private final int lockVideoOrientation;
-
-    private Size deviceSize;
-    private ScreenInfo screenInfo;
-    private RotationListener rotationListener;
-    private FoldListener foldListener;
     private ClipboardListener clipboardListener;
     private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
 
@@ -66,71 +48,12 @@ public final class Device {
      */
     private final int displayId;
 
-    /**
-     * The surface flinger layer stack associated with this logical display
-     */
-    private final int layerStack;
-
     private final boolean supportsInputEvents;
 
-    public Device(Options options) throws ConfigurationException {
+    private final AtomicReference<ScreenInfo> screenInfo = new AtomicReference<>(); // set by the ScreenCapture instance
+
+    public Device(Options options) {
         displayId = options.getDisplayId();
-        DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
-        if (displayInfo == null) {
-            Ln.e("Display " + displayId + " not found\n" + LogUtils.buildDisplayListMessage());
-            throw new ConfigurationException("Unknown display id: " + displayId);
-        }
-
-        int displayInfoFlags = displayInfo.getFlags();
-
-        deviceSize = displayInfo.getSize();
-        crop = options.getCrop();
-        maxSize = options.getMaxSize();
-        lockVideoOrientation = options.getLockVideoOrientation();
-
-        screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), deviceSize, crop, maxSize, lockVideoOrientation);
-        layerStack = displayInfo.getLayerStack();
-
-        ServiceManager.getWindowManager().registerRotationWatcher(new IRotationWatcher.Stub() {
-            @Override
-            public void onRotationChanged(int rotation) {
-                synchronized (Device.this) {
-                    screenInfo = screenInfo.withDeviceRotation(rotation);
-
-                    // notify
-                    if (rotationListener != null) {
-                        rotationListener.onRotationChanged(rotation);
-                    }
-                }
-            }
-        }, displayId);
-
-        if (Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10) {
-            ServiceManager.getWindowManager().registerDisplayFoldListener(new IDisplayFoldListener.Stub() {
-                @Override
-                public void onDisplayFoldChanged(int displayId, boolean folded) {
-                    if (Device.this.displayId != displayId) {
-                        // Ignore events related to other display ids
-                        return;
-                    }
-
-                    synchronized (Device.this) {
-                        DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
-                        if (displayInfo == null) {
-                            Ln.e("Display " + displayId + " not found\n" + LogUtils.buildDisplayListMessage());
-                            return;
-                        }
-
-                        deviceSize = displayInfo.getSize();
-                        screenInfo = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), deviceSize, crop, maxSize, lockVideoOrientation);
-                        // notify
-                        if (foldListener != null) {
-                            foldListener.onFoldChanged(displayId, folded);
-                        }
-                    }
-                }
-            });
-        }
 
         if (options.getControl() && options.getClipboardAutosync()) {
             // If control and autosync are enabled, synchronize Android clipboard to the computer automatically
@@ -158,38 +81,20 @@ public final class Device {
             }
         }
 
-        if ((displayInfoFlags & DisplayInfo.FLAG_SUPPORTS_PROTECTED_BUFFERS) == 0) {
-            Ln.w("Display doesn't have FLAG_SUPPORTS_PROTECTED_BUFFERS flag, mirroring can be restricted");
-        }
-
         // main display or any display on Android >= 10
-        supportsInputEvents = displayId == 0 || Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10;
+        supportsInputEvents = options.getDisplayId() == 0 || Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10;
         if (!supportsInputEvents) {
             Ln.w("Input events are not supported for secondary displays before Android 10");
         }
     }
 
-    public int getDisplayId() {
-        return displayId;
-    }
-
-    public synchronized void setMaxSize(int newMaxSize) {
-        maxSize = newMaxSize;
-        screenInfo = ScreenInfo.computeScreenInfo(screenInfo.getReverseVideoRotation(), deviceSize, crop, newMaxSize, lockVideoOrientation);
-    }
-
-    public synchronized ScreenInfo getScreenInfo() {
-        return screenInfo;
-    }
-
-    public int getLayerStack() {
-        return layerStack;
-    }
-
     public Point getPhysicalPoint(Position position) {
-        // it hides the field on purpose, to read it with a lock
+        // it hides the field on purpose, to read it with atomic access
         @SuppressWarnings("checkstyle:HiddenField")
-        ScreenInfo screenInfo = getScreenInfo(); // read with synchronization
+        ScreenInfo screenInfo = this.screenInfo.get();
+        if (screenInfo == null) {
+            return null;
+        }
 
         // ignore the locked video orientation, the events will apply in coordinates considered in the physical device orientation
         Size unlockedVideoSize = screenInfo.getUnlockedVideoSize();
@@ -221,6 +126,10 @@ public final class Device {
 
     public boolean supportsInputEvents() {
         return supportsInputEvents;
+    }
+
+    public void setScreenInfo(ScreenInfo screenInfo) {
+        this.screenInfo.set(screenInfo);
     }
 
     public static boolean injectEvent(InputEvent inputEvent, int displayId, int injectMode) {
@@ -261,14 +170,6 @@ public final class Device {
 
     public static boolean isScreenOn() {
         return ServiceManager.getPowerManager().isScreenOn();
-    }
-
-    public synchronized void setRotationListener(RotationListener rotationListener) {
-        this.rotationListener = rotationListener;
-    }
-
-    public synchronized void setFoldListener(FoldListener foldlistener) {
-        this.foldListener = foldlistener;
     }
 
     public synchronized void setClipboardListener(ClipboardListener clipboardListener) {

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -1,7 +1,6 @@
 package com.genymobile.scrcpy.device;
 
 import com.genymobile.scrcpy.AndroidVersions;
-import com.genymobile.scrcpy.Options;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.video.ScreenInfo;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
@@ -11,7 +10,6 @@ import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
 import com.genymobile.scrcpy.wrappers.WindowManager;
 
-import android.content.IOnPrimaryClipChangedListener;
 import android.graphics.Rect;
 import android.os.Build;
 import android.os.IBinder;
@@ -21,7 +19,6 @@ import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 public final class Device {
@@ -36,42 +33,7 @@ public final class Device {
     public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
 
-    public interface ClipboardListener {
-        void onClipboardTextChanged(String text);
-    }
-
-    private ClipboardListener clipboardListener;
-    private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
-
     private final AtomicReference<ScreenInfo> screenInfo = new AtomicReference<>(); // set by the ScreenCapture instance
-
-    public Device(Options options) {
-        if (options.getControl() && options.getClipboardAutosync()) {
-            // If control and autosync are enabled, synchronize Android clipboard to the computer automatically
-            ClipboardManager clipboardManager = ServiceManager.getClipboardManager();
-            if (clipboardManager != null) {
-                clipboardManager.addPrimaryClipChangedListener(new IOnPrimaryClipChangedListener.Stub() {
-                    @Override
-                    public void dispatchPrimaryClipChanged() {
-                        if (isSettingClipboard.get()) {
-                            // This is a notification for the change we are currently applying, ignore it
-                            return;
-                        }
-                        synchronized (Device.this) {
-                            if (clipboardListener != null) {
-                                String text = getClipboardText();
-                                if (text != null) {
-                                    clipboardListener.onClipboardTextChanged(text);
-                                }
-                            }
-                        }
-                    }
-                });
-            } else {
-                Ln.w("No clipboard manager, copy-paste between device and computer will not work");
-            }
-        }
-    }
 
     public Point getPhysicalPoint(Position position) {
         // it hides the field on purpose, to read it with atomic access
@@ -142,10 +104,6 @@ public final class Device {
         return ServiceManager.getPowerManager().isScreenOn();
     }
 
-    public synchronized void setClipboardListener(ClipboardListener clipboardListener) {
-        this.clipboardListener = clipboardListener;
-    }
-
     public static void expandNotificationPanel() {
         ServiceManager.getStatusBarManager().expandNotificationsPanel();
     }
@@ -170,7 +128,7 @@ public final class Device {
         return s.toString();
     }
 
-    public boolean setClipboardText(String text) {
+    public static boolean setClipboardText(String text) {
         ClipboardManager clipboardManager = ServiceManager.getClipboardManager();
         if (clipboardManager == null) {
             return false;
@@ -185,10 +143,7 @@ public final class Device {
             return false;
         }
 
-        isSettingClipboard.set(true);
-        boolean ok = clipboardManager.setText(text);
-        isSettingClipboard.set(false);
-        return ok;
+        return clipboardManager.setText(text);
     }
 
     /**

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -1,7 +1,6 @@
 package com.genymobile.scrcpy.device;
 
 import com.genymobile.scrcpy.AndroidVersions;
-import com.genymobile.scrcpy.control.PositionMapper;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.DisplayControl;
@@ -18,8 +17,6 @@ import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 public final class Device {
 
     public static final int POWER_MODE_OFF = SurfaceControl.POWER_MODE_OFF;
@@ -32,17 +29,8 @@ public final class Device {
     public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
 
-    private final AtomicReference<PositionMapper> positionMapper = new AtomicReference<>(); // set by the ScreenCapture instance
-
-    public Point getPhysicalPoint(Position position) {
-        // it hides the field on purpose, to read it with atomic access
-        @SuppressWarnings("checkstyle:HiddenField")
-        PositionMapper positionMapper = this.positionMapper.get();
-        if (positionMapper == null) {
-            return null;
-        }
-
-        return positionMapper.map(position);
+    private Device() {
+        // not instantiable
     }
 
     public static String getDeviceName() {
@@ -52,10 +40,6 @@ public final class Device {
     public static boolean supportsInputEvents(int displayId) {
         // main display or any display on Android >= 10
         return displayId == 0 || Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10;
-    }
-
-    public void setPositionMapper(PositionMapper positionMapper) {
-        this.positionMapper.set(positionMapper);
     }
 
     public static boolean injectEvent(InputEvent inputEvent, int displayId, int injectMode) {

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -43,18 +43,9 @@ public final class Device {
     private ClipboardListener clipboardListener;
     private final AtomicBoolean isSettingClipboard = new AtomicBoolean();
 
-    /**
-     * Logical display identifier
-     */
-    private final int displayId;
-
-    private final boolean supportsInputEvents;
-
     private final AtomicReference<ScreenInfo> screenInfo = new AtomicReference<>(); // set by the ScreenCapture instance
 
     public Device(Options options) {
-        displayId = options.getDisplayId();
-
         if (options.getControl() && options.getClipboardAutosync()) {
             // If control and autosync are enabled, synchronize Android clipboard to the computer automatically
             ClipboardManager clipboardManager = ServiceManager.getClipboardManager();
@@ -79,12 +70,6 @@ public final class Device {
             } else {
                 Ln.w("No clipboard manager, copy-paste between device and computer will not work");
             }
-        }
-
-        // main display or any display on Android >= 10
-        supportsInputEvents = options.getDisplayId() == 0 || Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10;
-        if (!supportsInputEvents) {
-            Ln.w("Input events are not supported for secondary displays before Android 10");
         }
     }
 
@@ -121,11 +106,8 @@ public final class Device {
     }
 
     public static boolean supportsInputEvents(int displayId) {
+        // main display or any display on Android >= 10
         return displayId == 0 || Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10;
-    }
-
-    public boolean supportsInputEvents() {
-        return supportsInputEvents;
     }
 
     public void setScreenInfo(ScreenInfo screenInfo) {
@@ -144,10 +126,6 @@ public final class Device {
         return ServiceManager.getInputManager().injectInputEvent(inputEvent, injectMode);
     }
 
-    public boolean injectEvent(InputEvent event, int injectMode) {
-        return injectEvent(event, displayId, injectMode);
-    }
-
     public static boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int displayId, int injectMode) {
         long now = SystemClock.uptimeMillis();
         KeyEvent event = new KeyEvent(now, now, action, keyCode, repeat, metaState, KeyCharacterMap.VIRTUAL_KEYBOARD, 0, 0,
@@ -155,17 +133,9 @@ public final class Device {
         return injectEvent(event, displayId, injectMode);
     }
 
-    public boolean injectKeyEvent(int action, int keyCode, int repeat, int metaState, int injectMode) {
-        return injectKeyEvent(action, keyCode, repeat, metaState, displayId, injectMode);
-    }
-
     public static boolean pressReleaseKeycode(int keyCode, int displayId, int injectMode) {
         return injectKeyEvent(KeyEvent.ACTION_DOWN, keyCode, 0, 0, displayId, injectMode)
                 && injectKeyEvent(KeyEvent.ACTION_UP, keyCode, 0, 0, displayId, injectMode);
-    }
-
-    public boolean pressReleaseKeycode(int keyCode, int injectMode) {
-        return pressReleaseKeycode(keyCode, displayId, injectMode);
     }
 
     public static boolean isScreenOn() {
@@ -277,7 +247,7 @@ public final class Device {
     /**
      * Disable auto-rotation (if enabled), set the screen rotation and re-enable auto-rotation (if it was enabled).
      */
-    public void rotateDevice() {
+    public static void rotateDevice(int displayId) {
         WindowManager wm = ServiceManager.getWindowManager();
 
         boolean accelerometerRotation = !wm.isRotationFrozen(displayId);

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -19,6 +19,8 @@ import android.view.KeyEvent;
 
 public final class Device {
 
+    public static final int DISPLAY_ID_NONE = -1;
+
     public static final int POWER_MODE_OFF = SurfaceControl.POWER_MODE_OFF;
     public static final int POWER_MODE_NORMAL = SurfaceControl.POWER_MODE_NORMAL;
 
@@ -159,6 +161,8 @@ public final class Device {
     }
 
     public static boolean powerOffScreen(int displayId) {
+        assert displayId != DISPLAY_ID_NONE;
+
         if (!isScreenOn()) {
             return true;
         }
@@ -169,6 +173,8 @@ public final class Device {
      * Disable auto-rotation (if enabled), set the screen rotation and re-enable auto-rotation (if it was enabled).
      */
     public static void rotateDevice(int displayId) {
+        assert displayId != DISPLAY_ID_NONE;
+
         WindowManager wm = ServiceManager.getWindowManager();
 
         boolean accelerometerRotation = !wm.isRotationFrozen(displayId);
@@ -187,6 +193,8 @@ public final class Device {
     }
 
     private static int getCurrentRotation(int displayId) {
+        assert displayId != DISPLAY_ID_NONE;
+
         if (displayId == 0) {
             return ServiceManager.getWindowManager().getRotation();
         }

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -1,6 +1,7 @@
 package com.genymobile.scrcpy.device;
 
 import com.genymobile.scrcpy.AndroidVersions;
+import com.genymobile.scrcpy.FakeContext;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.DisplayControl;
@@ -9,6 +10,10 @@ import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
 import com.genymobile.scrcpy.wrappers.WindowManager;
 
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.IBinder;
 import android.os.SystemClock;
@@ -16,6 +21,9 @@ import android.view.InputDevice;
 import android.view.InputEvent;
 import android.view.KeyCharacterMap;
 import android.view.KeyEvent;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public final class Device {
 
@@ -201,5 +209,38 @@ public final class Device {
 
         DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
         return displayInfo.getRotation();
+    }
+
+    public static List<DeviceApp> listApps() {
+        List<DeviceApp> apps = new ArrayList<>();
+        PackageManager pm = FakeContext.get().getPackageManager();
+        for (ApplicationInfo appInfo : getLaunchableApps(pm)) {
+            String name = pm.getApplicationLabel(appInfo).toString();
+            boolean system = (appInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0;
+            apps.add(new DeviceApp(appInfo.packageName, name, system));
+        }
+
+        return apps;
+    }
+
+    @SuppressLint("QueryPermissionsNeeded")
+    private static List<ApplicationInfo> getLaunchableApps(PackageManager pm) {
+        List<ApplicationInfo> result = new ArrayList<>();
+        for (ApplicationInfo appInfo : pm.getInstalledApplications(PackageManager.GET_META_DATA)) {
+            if (appInfo.enabled && getLaunchIntent(pm, appInfo.packageName) != null) {
+                result.add(appInfo);
+            }
+        }
+
+        return result;
+    }
+
+    public static Intent getLaunchIntent(PackageManager pm, String packageName) {
+        Intent launchIntent = pm.getLaunchIntentForPackage(packageName);
+        if (launchIntent != null) {
+            return launchIntent;
+        }
+
+        return pm.getLeanbackLaunchIntentForPackage(packageName);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -27,6 +27,7 @@ import android.view.KeyEvent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 public final class Device {
 
@@ -262,6 +263,23 @@ public final class Device {
         }
 
         return null;
+    }
+
+    @SuppressLint("QueryPermissionsNeeded")
+    public static List<DeviceApp> findByName(String searchName) {
+        List<DeviceApp> result = new ArrayList<>();
+        searchName = searchName.toLowerCase(Locale.getDefault());
+
+        PackageManager pm = FakeContext.get().getPackageManager();
+        for (ApplicationInfo appInfo : getLaunchableApps(pm)) {
+            String name = pm.getApplicationLabel(appInfo).toString();
+            if (name.toLowerCase(Locale.getDefault()).startsWith(searchName)) {
+                boolean system = (appInfo.flags & ApplicationInfo.FLAG_SYSTEM) != 0;
+                result.add(new DeviceApp(appInfo.packageName, name, system));
+            }
+        }
+
+        return result;
     }
 
     public static void startApp(String packageName, int displayId, boolean forceStop) {

--- a/server/src/main/java/com/genymobile/scrcpy/device/DeviceApp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/DeviceApp.java
@@ -1,0 +1,26 @@
+package com.genymobile.scrcpy.device;
+
+public final class DeviceApp {
+
+    private final String packageName;
+    private final String name;
+    private final boolean system;
+
+    public DeviceApp(String packageName, String name, boolean system) {
+        this.packageName = packageName;
+        this.name = name;
+        this.system = system;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isSystem() {
+        return system;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/device/DisplayInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/DisplayInfo.java
@@ -6,15 +6,17 @@ public final class DisplayInfo {
     private final int rotation;
     private final int layerStack;
     private final int flags;
+    private final int dpi;
 
     public static final int FLAG_SUPPORTS_PROTECTED_BUFFERS = 0x00000001;
 
-    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags) {
+    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags, int dpi) {
         this.displayId = displayId;
         this.size = size;
         this.rotation = rotation;
         this.layerStack = layerStack;
         this.flags = flags;
+        this.dpi = dpi;
     }
 
     public int getDisplayId() {
@@ -35,6 +37,10 @@ public final class DisplayInfo {
 
     public int getFlags() {
         return flags;
+    }
+
+    public int getDpi() {
+        return dpi;
     }
 }
 

--- a/server/src/main/java/com/genymobile/scrcpy/device/NewDisplay.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/NewDisplay.java
@@ -1,0 +1,31 @@
+package com.genymobile.scrcpy.device;
+
+public final class NewDisplay {
+    private Size size;
+    private int dpi;
+
+    public NewDisplay() {
+        // Auto size and dpi
+    }
+
+    public NewDisplay(Size size, int dpi) {
+        this.size = size;
+        this.dpi = dpi;
+    }
+
+    public Size getSize() {
+        return size;
+    }
+
+    public int getDpi() {
+        return dpi;
+    }
+
+    public boolean hasExplicitSize() {
+        return size != null;
+    }
+
+    public boolean hasExplicitDpi() {
+        return dpi != 0;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -21,6 +21,10 @@ public final class Size {
         return height;
     }
 
+    public int getMax() {
+        return Math.max(width, height);
+    }
+
     public Size rotate() {
         return new Size(height, width);
     }

--- a/server/src/main/java/com/genymobile/scrcpy/util/LogUtils.java
+++ b/server/src/main/java/com/genymobile/scrcpy/util/LogUtils.java
@@ -160,11 +160,15 @@ public final class LogUtils {
         return set;
     }
 
-    @SuppressLint("QueryPermissionsNeeded")
-    public static String buildAppListMessage() {
-        StringBuilder builder = new StringBuilder("List of apps:");
 
+    public static String buildAppListMessage() {
         List<DeviceApp> apps = Device.listApps();
+        return buildAppListMessage("List of apps:", apps);
+    }
+
+    @SuppressLint("QueryPermissionsNeeded")
+    public static String buildAppListMessage(String title, List<DeviceApp> apps) {
+        StringBuilder builder = new StringBuilder(title);
 
         // Sort by:
         //  1. system flag (system apps are before non-system apps)

--- a/server/src/main/java/com/genymobile/scrcpy/util/LogUtils.java
+++ b/server/src/main/java/com/genymobile/scrcpy/util/LogUtils.java
@@ -1,10 +1,13 @@
 package com.genymobile.scrcpy.util;
 
+import com.genymobile.scrcpy.device.Device;
+import com.genymobile.scrcpy.device.DeviceApp;
 import com.genymobile.scrcpy.device.DisplayInfo;
 import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.wrappers.DisplayManager;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
+import android.annotation.SuppressLint;
 import android.graphics.Rect;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCharacteristics;
@@ -13,7 +16,9 @@ import android.hardware.camera2.params.StreamConfigurationMap;
 import android.media.MediaCodec;
 import android.util.Range;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
@@ -153,5 +158,54 @@ public final class LogUtils {
             set.add(range.getUpper());
         }
         return set;
+    }
+
+    @SuppressLint("QueryPermissionsNeeded")
+    public static String buildAppListMessage() {
+        StringBuilder builder = new StringBuilder("List of apps:");
+
+        List<DeviceApp> apps = Device.listApps();
+
+        // Sort by:
+        //  1. system flag (system apps are before non-system apps)
+        //  2. name
+        //  3. package name
+        // Comparator.comparing() was introduced in API 24, so it cannot be used here to simplify the code
+        Collections.sort(apps, (thisApp, otherApp) -> {
+            // System apps first
+            int cmp = -Boolean.compare(thisApp.isSystem(), otherApp.isSystem());
+            if (cmp != 0) {
+                return cmp;
+            }
+
+            cmp = Objects.compare(thisApp.getName(), otherApp.getName(), String::compareTo);
+            if (cmp != 0) {
+                return cmp;
+            }
+
+            return Objects.compare(thisApp.getPackageName(), otherApp.getPackageName(), String::compareTo);
+        });
+
+        final int column = 30;
+        for (DeviceApp app : apps) {
+            String name = app.getName();
+            int padding = column - name.length();
+            builder.append("\n ");
+            if (app.isSystem()) {
+                builder.append("* ");
+            } else {
+                builder.append("- ");
+
+            }
+            builder.append(name);
+            if (padding > 0) {
+                builder.append(String.format("%" + padding + "s", " "));
+            } else {
+                builder.append("\n   ").append(String.format("%" + column + "s", " "));
+            }
+            builder.append(" [").append(app.getPackageName()).append(']');
+        }
+
+        return builder.toString();
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -1,0 +1,146 @@
+package com.genymobile.scrcpy.video;
+
+import com.genymobile.scrcpy.AndroidVersions;
+import com.genymobile.scrcpy.control.PositionMapper;
+import com.genymobile.scrcpy.device.DisplayInfo;
+import com.genymobile.scrcpy.device.NewDisplay;
+import com.genymobile.scrcpy.device.Size;
+import com.genymobile.scrcpy.util.Ln;
+import com.genymobile.scrcpy.wrappers.ServiceManager;
+
+import android.graphics.Rect;
+import android.hardware.display.DisplayManager;
+import android.hardware.display.VirtualDisplay;
+import android.os.Build;
+import android.view.Surface;
+
+public class NewDisplayCapture extends SurfaceCapture {
+
+    // Internal fields copied from android.hardware.display.DisplayManager
+    private static final int VIRTUAL_DISPLAY_FLAG_SUPPORTS_TOUCH = 1 << 6;
+    private static final int VIRTUAL_DISPLAY_FLAG_ROTATES_WITH_CONTENT = 1 << 7;
+    private static final int VIRTUAL_DISPLAY_FLAG_DESTROY_CONTENT_ON_REMOVAL = 1 << 8;
+    private static final int VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS = 1 << 9;
+    private static final int VIRTUAL_DISPLAY_FLAG_TRUSTED = 1 << 10;
+    private static final int VIRTUAL_DISPLAY_FLAG_OWN_DISPLAY_GROUP = 1 << 11;
+    private static final int VIRTUAL_DISPLAY_FLAG_ALWAYS_UNLOCKED = 1 << 12;
+    private static final int VIRTUAL_DISPLAY_FLAG_TOUCH_FEEDBACK_DISABLED = 1 << 13;
+    private static final int VIRTUAL_DISPLAY_FLAG_OWN_FOCUS = 1 << 14;
+    private static final int VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP = 1 << 15;
+
+    private final VirtualDisplayListener vdListener;
+    private final NewDisplay newDisplay;
+
+    private Size mainDisplaySize;
+    private int mainDisplayDpi;
+    private int maxSize; // only used if newDisplay.getSize() != null
+
+    private VirtualDisplay virtualDisplay;
+    private Size size;
+    private int dpi;
+
+    public NewDisplayCapture(VirtualDisplayListener vdListener, NewDisplay newDisplay, int maxSize) {
+        this.vdListener = vdListener;
+        this.newDisplay = newDisplay;
+        this.maxSize = maxSize;
+    }
+
+    @Override
+    public void init() {
+        size = newDisplay.getSize();
+        dpi = newDisplay.getDpi();
+        if (size == null || dpi == 0) {
+            DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(0);
+            if (displayInfo != null) {
+                mainDisplaySize = displayInfo.getSize();
+                mainDisplayDpi = displayInfo.getDpi();
+            } else {
+                Ln.w("Main display not found, fallback to 1920x1080 240dpi");
+                mainDisplaySize = new Size(1920, 1080);
+                mainDisplayDpi = 240;
+            }
+        }
+    }
+
+    @Override
+    public void prepare() {
+        if (!newDisplay.hasExplicitSize()) {
+            size = ScreenInfo.computeVideoSize(mainDisplaySize.getWidth(), mainDisplaySize.getHeight(), maxSize);
+        }
+        if (!newDisplay.hasExplicitDpi()) {
+            dpi = scaleDpi(mainDisplaySize, mainDisplayDpi, size);
+        }
+    }
+
+    @Override
+    public void start(Surface surface) {
+        if (virtualDisplay != null) {
+            virtualDisplay.release();
+            virtualDisplay = null;
+        }
+
+        int virtualDisplayId;
+        try {
+            int flags = DisplayManager.VIRTUAL_DISPLAY_FLAG_PUBLIC
+                    | DisplayManager.VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY
+                    | VIRTUAL_DISPLAY_FLAG_SUPPORTS_TOUCH
+                    | VIRTUAL_DISPLAY_FLAG_ROTATES_WITH_CONTENT
+                    | VIRTUAL_DISPLAY_FLAG_DESTROY_CONTENT_ON_REMOVAL
+                    | VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS;
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_33_ANDROID_13) {
+                flags |= VIRTUAL_DISPLAY_FLAG_TRUSTED
+                        | VIRTUAL_DISPLAY_FLAG_OWN_DISPLAY_GROUP
+                        | VIRTUAL_DISPLAY_FLAG_ALWAYS_UNLOCKED
+                        | VIRTUAL_DISPLAY_FLAG_TOUCH_FEEDBACK_DISABLED;
+                if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
+                     flags |= VIRTUAL_DISPLAY_FLAG_OWN_FOCUS
+                             | VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP;
+                }
+            }
+            virtualDisplay = ServiceManager.getDisplayManager()
+                    .createNewVirtualDisplay("scrcpy", size.getWidth(), size.getHeight(), dpi, surface, flags);
+            virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
+            Ln.i("New display: " + size.getWidth() + "x" + size.getHeight() + "/" + dpi + " (id=" + virtualDisplayId + ")");
+        } catch (Exception e) {
+            Ln.e("Could not create display", e);
+            throw new AssertionError("Could not create display");
+        }
+
+        if (vdListener != null) {
+            virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
+            Rect contentRect = new Rect(0, 0, size.getWidth(), size.getHeight());
+            PositionMapper positionMapper = new PositionMapper(size, contentRect, 0);
+            vdListener.onNewVirtualDisplay(virtualDisplayId, positionMapper);
+        }
+    }
+
+    @Override
+    public void release() {
+        if (virtualDisplay != null) {
+            virtualDisplay.release();
+            virtualDisplay = null;
+        }
+    }
+
+    @Override
+    public synchronized Size getSize() {
+        return size;
+    }
+
+    @Override
+    public synchronized boolean setMaxSize(int newMaxSize) {
+        if (newDisplay.hasExplicitSize()) {
+            // Cannot retry with a different size if the display size was explicitly provided
+            return false;
+        }
+
+        maxSize = newMaxSize;
+        return true;
+    }
+
+    private static int scaleDpi(Size initialSize, int initialDpi, Size size) {
+        int den = initialSize.getMax();
+        int num = size.getMax();
+        return initialDpi * num / den;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -1,9 +1,12 @@
 package com.genymobile.scrcpy.video;
 
 import com.genymobile.scrcpy.AndroidVersions;
+import com.genymobile.scrcpy.device.ConfigurationException;
 import com.genymobile.scrcpy.device.Device;
+import com.genymobile.scrcpy.device.DisplayInfo;
 import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.Ln;
+import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
 
@@ -11,33 +14,104 @@ import android.graphics.Rect;
 import android.hardware.display.VirtualDisplay;
 import android.os.Build;
 import android.os.IBinder;
+import android.view.IDisplayFoldListener;
+import android.view.IRotationWatcher;
 import android.view.Surface;
 
-public class ScreenCapture extends SurfaceCapture implements Device.RotationListener, Device.FoldListener {
+public class ScreenCapture extends SurfaceCapture {
 
     private final Device device;
+
+    private final int displayId;
+    private int maxSize;
+    private final Rect crop;
+    private final int lockVideoOrientation;
+    private int layerStack;
+
+    private Size deviceSize;
+    private ScreenInfo screenInfo;
+
     private IBinder display;
     private VirtualDisplay virtualDisplay;
 
-    public ScreenCapture(Device device) {
+    private IRotationWatcher rotationWatcher;
+    private IDisplayFoldListener displayFoldListener;
+
+    public ScreenCapture(Device device, int displayId, int maxSize, Rect crop, int lockVideoOrientation) {
         this.device = device;
+        this.displayId = displayId;
+        this.maxSize = maxSize;
+        this.crop = crop;
+        this.lockVideoOrientation = lockVideoOrientation;
     }
 
     @Override
-    public void init() {
-        device.setRotationListener(this);
-        device.setFoldListener(this);
+    public void init() throws ConfigurationException {
+        DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
+        if (displayInfo == null) {
+            Ln.e("Display " + displayId + " not found\n" + LogUtils.buildDisplayListMessage());
+            throw new ConfigurationException("Unknown display id: " + displayId);
+        }
+
+        deviceSize = displayInfo.getSize();
+        ScreenInfo si = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), deviceSize, crop, maxSize, lockVideoOrientation);
+        setScreenInfo(si);
+        layerStack = displayInfo.getLayerStack();
+
+        if (displayId == 0) {
+            rotationWatcher = new IRotationWatcher.Stub() {
+                @Override
+                public void onRotationChanged(int rotation) {
+                    synchronized (ScreenCapture.this) {
+                        ScreenInfo si = screenInfo.withDeviceRotation(rotation);
+                        setScreenInfo(si);
+                    }
+
+                    requestReset();
+                }
+            };
+            ServiceManager.getWindowManager().registerRotationWatcher(rotationWatcher, displayId);
+        }
+
+        if (Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10) {
+            displayFoldListener = new IDisplayFoldListener.Stub() {
+                @Override
+                public void onDisplayFoldChanged(int displayId, boolean folded) {
+                    if (ScreenCapture.this.displayId != displayId) {
+                        // Ignore events related to other display ids
+                        return;
+                    }
+
+                    synchronized (ScreenCapture.this) {
+                        DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
+                        if (displayInfo == null) {
+                            Ln.e("Display " + displayId + " not found\n" + LogUtils.buildDisplayListMessage());
+                            return;
+                        }
+
+                        deviceSize = displayInfo.getSize();
+                        ScreenInfo si = ScreenInfo.computeScreenInfo(displayInfo.getRotation(), deviceSize, crop, maxSize, lockVideoOrientation);
+                        setScreenInfo(si);
+                    }
+
+                    requestReset();
+                }
+            };
+            ServiceManager.getWindowManager().registerDisplayFoldListener(displayFoldListener);
+        }
+
+        if ((displayInfo.getFlags() & DisplayInfo.FLAG_SUPPORTS_PROTECTED_BUFFERS) == 0) {
+            Ln.w("Display doesn't have FLAG_SUPPORTS_PROTECTED_BUFFERS flag, mirroring can be restricted");
+        }
     }
 
     @Override
     public void start(Surface surface) {
-        ScreenInfo screenInfo = device.getScreenInfo();
         Rect contentRect = screenInfo.getContentRect();
 
         // does not include the locked video orientation
         Rect unlockedVideoRect = screenInfo.getUnlockedVideoSize().toRect();
         int videoRotation = screenInfo.getVideoRotation();
-        int layerStack = device.getLayerStack();
 
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
@@ -51,7 +125,7 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
         try {
             Rect videoRect = screenInfo.getVideoSize().toRect();
             virtualDisplay = ServiceManager.getDisplayManager()
-                    .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), device.getDisplayId(), surface);
+                    .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), displayId, surface);
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
             try {
@@ -68,8 +142,12 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
 
     @Override
     public void release() {
-        device.setRotationListener(null);
-        device.setFoldListener(null);
+        if (rotationWatcher != null) {
+            ServiceManager.getWindowManager().unregisterRotationWatcher(rotationWatcher);
+        }
+        if (Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10) {
+            ServiceManager.getWindowManager().unregisterDisplayFoldListener(displayFoldListener);
+        }
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
             display = null;
@@ -81,24 +159,16 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
     }
 
     @Override
-    public Size getSize() {
-        return device.getScreenInfo().getVideoSize();
+    public synchronized Size getSize() {
+        return screenInfo.getVideoSize();
     }
 
     @Override
-    public boolean setMaxSize(int maxSize) {
-        device.setMaxSize(maxSize);
+    public synchronized boolean setMaxSize(int newMaxSize) {
+        maxSize = newMaxSize;
+        ScreenInfo si = ScreenInfo.computeScreenInfo(screenInfo.getReverseVideoRotation(), deviceSize, crop, newMaxSize, lockVideoOrientation);
+        setScreenInfo(si);
         return true;
-    }
-
-    @Override
-    public void onFoldChanged(int displayId, boolean folded) {
-        requestReset();
-    }
-
-    @Override
-    public void onRotationChanged(int rotation) {
-        requestReset();
     }
 
     private static IBinder createDisplay() throws Exception {
@@ -118,5 +188,10 @@ public class ScreenCapture extends SurfaceCapture implements Device.RotationList
         } finally {
             SurfaceControl.closeTransaction();
         }
+    }
+
+    private void setScreenInfo(ScreenInfo si) {
+        screenInfo = si;
+        device.setScreenInfo(si);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -116,12 +116,6 @@ public class ScreenCapture extends SurfaceCapture {
 
     @Override
     public void start(Surface surface) {
-        Rect contentRect = screenInfo.getContentRect();
-
-        // does not include the locked video orientation
-        Rect unlockedVideoRect = screenInfo.getUnlockedVideoSize().toRect();
-        int videoRotation = screenInfo.getVideoRotation();
-
         if (display != null) {
             SurfaceControl.destroyDisplay(display);
             display = null;
@@ -139,6 +133,13 @@ public class ScreenCapture extends SurfaceCapture {
         } catch (Exception displayManagerException) {
             try {
                 display = createDisplay();
+
+                Rect contentRect = screenInfo.getContentRect();
+
+                // does not include the locked video orientation
+                Rect unlockedVideoRect = screenInfo.getUnlockedVideoSize().toRect();
+                int videoRotation = screenInfo.getVideoRotation();
+
                 setDisplaySurface(display, surface, videoRotation, contentRect, unlockedVideoRect, layerStack);
                 Ln.d("Display: using SurfaceControl API");
             } catch (Exception surfaceControlException) {

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -126,9 +126,9 @@ public class ScreenCapture extends SurfaceCapture {
         }
 
         try {
-            Rect videoRect = screenInfo.getVideoSize().toRect();
+            Size videoSize = screenInfo.getVideoSize();
             virtualDisplay = ServiceManager.getDisplayManager()
-                    .createVirtualDisplay("scrcpy", videoRect.width(), videoRect.height(), displayId, surface);
+                    .createVirtualDisplay("scrcpy", videoSize.getWidth(), videoSize.getHeight(), displayId, surface);
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
             try {

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -3,7 +3,6 @@ package com.genymobile.scrcpy.video;
 import com.genymobile.scrcpy.AndroidVersions;
 import com.genymobile.scrcpy.control.PositionMapper;
 import com.genymobile.scrcpy.device.ConfigurationException;
-import com.genymobile.scrcpy.device.Device;
 import com.genymobile.scrcpy.device.DisplayInfo;
 import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.Ln;
@@ -21,8 +20,7 @@ import android.view.Surface;
 
 public class ScreenCapture extends SurfaceCapture {
 
-    private final Device device;
-
+    private final VirtualDisplayListener vdListener;
     private final int displayId;
     private int maxSize;
     private final Rect crop;
@@ -37,8 +35,8 @@ public class ScreenCapture extends SurfaceCapture {
     private IRotationWatcher rotationWatcher;
     private IDisplayFoldListener displayFoldListener;
 
-    public ScreenCapture(Device device, int displayId, int maxSize, Rect crop, int lockVideoOrientation) {
-        this.device = device;
+    public ScreenCapture(VirtualDisplayListener vdListener, int displayId, int maxSize, Rect crop, int lockVideoOrientation) {
+        this.vdListener = vdListener;
         this.displayId = displayId;
         this.maxSize = maxSize;
         this.crop = crop;
@@ -133,8 +131,10 @@ public class ScreenCapture extends SurfaceCapture {
             }
         }
 
-        PositionMapper positionMapper = PositionMapper.from(screenInfo);
-        device.setPositionMapper(positionMapper);
+        if (vdListener != null) {
+            PositionMapper positionMapper = PositionMapper.from(screenInfo);
+            vdListener.onNewVirtualDisplay(positionMapper);
+        }
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -75,8 +75,17 @@ public class ScreenCapture extends SurfaceCapture {
 
         if (Build.VERSION.SDK_INT >= AndroidVersions.API_29_ANDROID_10) {
             displayFoldListener = new IDisplayFoldListener.Stub() {
+
+                private boolean first = true;
+
                 @Override
                 public void onDisplayFoldChanged(int displayId, boolean folded) {
+                    if (first) {
+                        // An event is posted on registration to signal the initial state. Ignore it to avoid restarting encoding.
+                        first = false;
+                        return;
+                    }
+
                     if (ScreenCapture.this.displayId != displayId) {
                         // Ignore events related to other display ids
                         return;

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -1,6 +1,7 @@
 package com.genymobile.scrcpy.video;
 
 import com.genymobile.scrcpy.AndroidVersions;
+import com.genymobile.scrcpy.control.PositionMapper;
 import com.genymobile.scrcpy.device.ConfigurationException;
 import com.genymobile.scrcpy.device.Device;
 import com.genymobile.scrcpy.device.DisplayInfo;
@@ -132,7 +133,8 @@ public class ScreenCapture extends SurfaceCapture {
             }
         }
 
-        device.setScreenInfo(screenInfo);
+        PositionMapper positionMapper = PositionMapper.from(screenInfo);
+        device.setPositionMapper(positionMapper);
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenInfo.java
@@ -63,28 +63,6 @@ public final class ScreenInfo {
         return unlockedVideoSize.rotate();
     }
 
-    public int getDeviceRotation() {
-        return deviceRotation;
-    }
-
-    public ScreenInfo withDeviceRotation(int newDeviceRotation) {
-        if (newDeviceRotation == deviceRotation) {
-            return this;
-        }
-        // true if changed between portrait and landscape
-        boolean orientationChanged = (deviceRotation + newDeviceRotation) % 2 != 0;
-        Rect newContentRect;
-        Size newUnlockedVideoSize;
-        if (orientationChanged) {
-            newContentRect = flipRect(contentRect);
-            newUnlockedVideoSize = unlockedVideoSize.rotate();
-        } else {
-            newContentRect = contentRect;
-            newUnlockedVideoSize = unlockedVideoSize;
-        }
-        return new ScreenInfo(newContentRect, newUnlockedVideoSize, newDeviceRotation, lockedVideoOrientation);
-    }
-
     public static ScreenInfo computeScreenInfo(int rotation, Size deviceSize, Rect crop, int maxSize, int lockedVideoOrientation) {
         if (lockedVideoOrientation == Device.LOCK_VIDEO_ORIENTATION_INITIAL) {
             // The user requested to lock the video orientation to the current orientation

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenInfo.java
@@ -90,7 +90,7 @@ public final class ScreenInfo {
         return rect.width() + ":" + rect.height() + ":" + rect.left + ":" + rect.top;
     }
 
-    private static Size computeVideoSize(int w, int h, int maxSize) {
+    public static Size computeVideoSize(int w, int h, int maxSize) {
         // Compute the video size and the padding of the content inside this video.
         // Principle:
         // - scale down the great side of the screen to maxSize (if necessary);

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -1,5 +1,6 @@
 package com.genymobile.scrcpy.video;
 
+import com.genymobile.scrcpy.device.ConfigurationException;
 import com.genymobile.scrcpy.device.Size;
 
 import android.view.Surface;
@@ -34,7 +35,7 @@ public abstract class SurfaceCapture {
     /**
      * Called once before the capture starts.
      */
-    public abstract void init() throws IOException;
+    public abstract void init() throws ConfigurationException, IOException;
 
     /**
      * Called after the capture ends (if and only if {@link #init()} has been called).

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -33,14 +33,21 @@ public abstract class SurfaceCapture {
     }
 
     /**
-     * Called once before the capture starts.
+     * Called once before the first capture starts.
      */
     public abstract void init() throws ConfigurationException, IOException;
 
     /**
-     * Called after the capture ends (if and only if {@link #init()} has been called).
+     * Called after the last capture ends (if and only if {@link #init()} has been called).
      */
     public abstract void release();
+
+    /**
+     * Called once before each capture starts, before {@link #getSize()}.
+     */
+    public void prepare() throws ConfigurationException {
+        // empty by default
+    }
 
     /**
      * Start the capture to the target surface.

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -68,12 +68,16 @@ public class SurfaceEncoder implements AsyncProcessor {
         capture.init();
 
         try {
-            streamer.writeVideoHeader(capture.getSize());
-
             boolean alive;
+            boolean headerWritten = false;
 
             do {
                 Size size = capture.getSize();
+                if (!headerWritten) {
+                    streamer.writeVideoHeader(size);
+                    headerWritten = true;
+                }
+
                 format.setInteger(MediaFormat.KEY_WIDTH, size.getWidth());
                 format.setInteger(MediaFormat.KEY_HEIGHT, size.getHeight());
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -72,6 +72,7 @@ public class SurfaceEncoder implements AsyncProcessor {
             boolean headerWritten = false;
 
             do {
+                capture.prepare();
                 Size size = capture.getSize();
                 if (!headerWritten) {
                     streamer.writeVideoHeader(size);

--- a/server/src/main/java/com/genymobile/scrcpy/video/VirtualDisplayListener.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VirtualDisplayListener.java
@@ -3,5 +3,5 @@ package com.genymobile.scrcpy.video;
 import com.genymobile.scrcpy.control.PositionMapper;
 
 public interface VirtualDisplayListener {
-    void onNewVirtualDisplay(PositionMapper positionMapper);
+    void onNewVirtualDisplay(int displayId, PositionMapper positionMapper);
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/VirtualDisplayListener.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VirtualDisplayListener.java
@@ -1,0 +1,7 @@
+package com.genymobile.scrcpy.video;
+
+import com.genymobile.scrcpy.control.PositionMapper;
+
+public interface VirtualDisplayListener {
+    void onNewVirtualDisplay(PositionMapper positionMapper);
+}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
@@ -118,8 +118,12 @@ public final class ActivityManager {
         return startActivityAsUserMethod;
     }
 
-    @SuppressWarnings("ConstantConditions")
     public int startActivity(Intent intent) {
+        return startActivity(intent, null);
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    public int startActivity(Intent intent, Bundle options) {
         try {
             Method method = getStartActivityAsUserMethod();
             return (int) method.invoke(
@@ -133,7 +137,7 @@ public final class ActivityManager {
                     /* requestCode */ 0,
                     /* startFlags */ 0,
                     /* profilerInfo */ null,
-                    /* bOptions */ null,
+                    /* bOptions */ options,
                     /* userId */ /* UserHandle.USER_CURRENT */ -2);
         } catch (Throwable e) {
             Ln.e("Could not invoke method", e);

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -1,15 +1,18 @@
 package com.genymobile.scrcpy.wrappers;
 
+import com.genymobile.scrcpy.FakeContext;
 import com.genymobile.scrcpy.device.DisplayInfo;
 import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.Command;
 import com.genymobile.scrcpy.util.Ln;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.hardware.display.VirtualDisplay;
 import android.view.Display;
 import android.view.Surface;
 
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.regex.Matcher;
@@ -125,5 +128,13 @@ public final class DisplayManager {
     public VirtualDisplay createVirtualDisplay(String name, int width, int height, int displayIdToMirror, Surface surface) throws Exception {
         Method method = getCreateVirtualDisplayMethod();
         return (VirtualDisplay) method.invoke(null, name, width, height, displayIdToMirror, surface);
+    }
+
+    public VirtualDisplay createNewVirtualDisplay(String name, int width, int height, int dpi, Surface surface, int flags) throws Exception {
+        Constructor<android.hardware.display.DisplayManager> ctor = android.hardware.display.DisplayManager.class.getDeclaredConstructor(
+                Context.class);
+        ctor.setAccessible(true);
+        android.hardware.display.DisplayManager dm = ctor.newInstance(FakeContext.get());
+        return dm.createVirtualDisplay(name, width, height, dpi, surface, flags);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -39,7 +39,7 @@ public final class DisplayManager {
     public static DisplayInfo parseDisplayInfo(String dumpsysDisplayOutput, int displayId) {
         Pattern regex = Pattern.compile(
                 "^    mOverrideDisplayInfo=DisplayInfo\\{\".*?, displayId " + displayId + ".*?(, FLAG_.*)?, real ([0-9]+) x ([0-9]+).*?, "
-                        + "rotation ([0-9]+).*?, layerStack ([0-9]+)",
+                        + "rotation ([0-9]+).*?, density ([0-9]+).*?, layerStack ([0-9]+)",
                 Pattern.MULTILINE);
         Matcher m = regex.matcher(dumpsysDisplayOutput);
         if (!m.find()) {
@@ -49,9 +49,10 @@ public final class DisplayManager {
         int width = Integer.parseInt(m.group(2));
         int height = Integer.parseInt(m.group(3));
         int rotation = Integer.parseInt(m.group(4));
-        int layerStack = Integer.parseInt(m.group(5));
+        int density = Integer.parseInt(m.group(5));
+        int layerStack = Integer.parseInt(m.group(6));
 
-        return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags);
+        return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, density);
     }
 
     private static DisplayInfo getDisplayInfoFromDumpsysDisplay(int displayId) {
@@ -98,7 +99,8 @@ public final class DisplayManager {
             int rotation = cls.getDeclaredField("rotation").getInt(displayInfo);
             int layerStack = cls.getDeclaredField("layerStack").getInt(displayInfo);
             int flags = cls.getDeclaredField("flags").getInt(displayInfo);
-            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags);
+            int dpi = cls.getDeclaredField("logicalDensityDpi").getInt(displayInfo);
+            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, dpi);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -201,13 +201,29 @@ public final class WindowManager {
         }
     }
 
+    public void unregisterRotationWatcher(IRotationWatcher rotationWatcher) {
+        try {
+            manager.getClass().getMethod("removeRotationWatcher", IRotationWatcher.class).invoke(manager, rotationWatcher);
+        } catch (Exception e) {
+            Ln.e("Could not unregister rotation watcher", e);
+        }
+    }
+
     @TargetApi(AndroidVersions.API_29_ANDROID_10)
     public void registerDisplayFoldListener(IDisplayFoldListener foldListener) {
         try {
-            Class<?> cls = manager.getClass();
-            cls.getMethod("registerDisplayFoldListener", IDisplayFoldListener.class).invoke(manager, foldListener);
+            manager.getClass().getMethod("registerDisplayFoldListener", IDisplayFoldListener.class).invoke(manager, foldListener);
         } catch (Exception e) {
             Ln.e("Could not register display fold listener", e);
+        }
+    }
+
+    @TargetApi(AndroidVersions.API_29_ANDROID_10)
+    public void unregisterDisplayFoldListener(IDisplayFoldListener foldListener) {
+        try {
+            manager.getClass().getMethod("unregisterDisplayFoldListener", IDisplayFoldListener.class).invoke(manager, foldListener);
+        } catch (Exception e) {
+            Ln.e("Could not unregister display fold listener", e);
         }
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/control/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/control/ControlMessageReaderTest.java
@@ -400,6 +400,27 @@ public class ControlMessageReaderTest {
     }
 
     @Test
+    public void testParseStartApp() throws IOException {
+        byte[] name = "firefox".getBytes(StandardCharsets.UTF_8);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeByte(ControlMessage.TYPE_START_APP);
+        dos.writeByte(name.length);
+        dos.write(name);
+        byte[] packet = bos.toByteArray();
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(packet);
+        ControlMessageReader reader = new ControlMessageReader(bis);
+
+        ControlMessage event = reader.read();
+        Assert.assertEquals(ControlMessage.TYPE_START_APP, event.getType());
+        Assert.assertEquals("firefox", event.getText());
+
+        Assert.assertEquals(-1, bis.read()); // EOS
+    }
+
+    @Test
     public void testMultiEvents() throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(bos);


### PR DESCRIPTION
This PR adds the possibility to start a new virtual display instead of mirroring the screen.

## Implementation

There are 3 steps:
 1. refactors
 2. rework event handling for virtual displays
 3. add virtual display features

### Refactors

The (7) firsts commits refactor to move code from `Device` to `Controller` and `ScreenCapture`, to prepare the next commits.

### Events handling

The commit `Inject display-related events to virtual display` aims to fix #4598 and #5137 (based on the work by @mengyanshou in #5137 and #5214), also necessary for making virtual display events work.

Basically, for event injection, there are two display ids:
 - the source display id (`--display-id=…`, default to 0 for the main display)
 - the id of the virtual display used for mirroring

(In case the ScreenCapture uses the "SurfaceControl API", then both ids are equals, but this is an implementation detail.)

In order to make events work correctly in all cases:
 - the virtual display id must be used for events relative to the display (mouse and touch events with coordinates);
 - the source display id must be used for other events (like key events).

### Virtual display

Then, based on the discussions in #1887 and the work by @yume-chan and @anirudhb:
 - https://github.com/yume-chan/scrcpy/commits/feat/virtual-display-3/ (https://github.com/Genymobile/scrcpy/issues/1887#issuecomment-1405184608)
 - https://github.com/anirudhb/scrcpy/commits/virtual-display/ (https://github.com/Genymobile/scrcpy/issues/1887#issuecomment-2240359603)

The commit `Add virtual display feature` implements a first version of virtual display support:

```bash
scrcpy --new-display=1920x1080
scrcpy --new-display=1920x1080/420  # force 420 dpi
scrcpy --new-display         # use the default screen size and density
scrcpy --new-display=/240    # use the default screen size and 240 dpi
scrcpy --new-display -m1920  # use the default screen size and density, scaled to fit in 1920
```

The size is fixed (not resizable).

On a Pixel 8, the virtual display contains a menu, so it is possible to open an app easily.

On other devices, it may be empty. In that case, you can start your app manually. Find the new display id is scrcpy logs (let's say it's 42), and start an app manually:


```bash
adb shell am start -a android.settings.SETTINGS --display 42
```

To start an app manually:

```bash
adb shell cmd package resolve-activity --brief org.mozilla.firefox | tail -n 1  # get the activity name
adb shell am start -S -n org.mozilla.firefox/.App --display 5
```


## TODO

### Start app

The feature really needs a new command to start an app, for example:

```bash
# not implemented, just an idea
scrcpy --new-display --start-app=firefox
```

_I might need to rework how arguments are passed to the server (to start an app "My gallery" for example), because currently it does not support spaces or other special characters (see bec3321fff4c6dc3b3dbc61fdc6fd98913988a78)._

I don't know if the expected behavior is to just have a virtual display and open any app (like on Pixel 8, where there is a "launcher"), or expose something like a "single app" feature.

It probably depends on the device (I don't know if it's possible to limit a single app on Pixel 8 for example, or to navigate to other apps on device without a launcher). What do you think? (also ref discussion https://github.com/Genymobile/scrcpy/issues/1887#issuecomment-1407012535 @4nric)

### Detect failure

If I run `scrcpy --new-display` on a Nexus 5 with Android 6, it does not fail, it just waits indefinitely for a frame. How to detect that "it works"? Should we only use checks based on the Android version?

---

## Draft v2

### Start app

Here is a draft v2, with new options to list and start apps (edit: changed by https://github.com/Genymobile/scrcpy/pull/5370#issuecomment-2424988000):

```bash
scrcpy --list-apps
scrcpy --new-display --start-app=org.mozilla.firefox  # start app by package name
scrcpy --new-display --start-app=?firefox             # start app by name with '?' prefix (takes more time)
scrcpy --start-app=org.mozilla.firefox   # also works for real display mirroring
scrcpy --start-app=+org.mozilla.firefox  # prefix by '+' to force-stop before starting the app
```

There is a performance issue on some devices to retrieve the app names (but not package names), because [`loadLabel()`](https://developer.android.com/reference/android/content/pm/PackageItemInfo#loadLabel(android.content.pm.PackageManager)) must be called for each app). As a consequence, `--list-apps` may take several seconds, and selecting an application by name may also take time. However, starting via package name is quick. Any solution welcome.


## Binary

Here is a Windows binary:

- [`scrcpy-win64-vd3.zip`](https://tmp.rom1v.com/scrcpy/5370/3/scrcpy-win64-vd3.zip) <sub>`SHA-256: 013a4b2a82d12d2a006f128c243130f939331cdd71e0c28886438da1a83c38b`</sub>

<details><summary>old binaries</summary>

- [`scrcpy-win64-vd.zip`](https://tmp.rom1v.com/scrcpy/5370/1/scrcpy-win64-vd.zip) <sub>`SHA-256: bda97902fe727dd236879c0c3850f62e0bdb85aac50f37aa5dc44f8fc91c65f`</sub>
- [`scrcpy-win64-vd2.zip`](https://tmp.rom1v.com/scrcpy/5370/2/scrcpy-win64-vd2.zip) <sub>`SHA-256: ab509d5943bc9e86739c1e6e1abab12f8bc75eb5f414b5c4b25cc7e1b1a3e11`</sub>

</details>