### PR TITLE
Listen to display changed events

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -52,6 +52,6 @@ public final class Size {
 
     @Override
     public String toString() {
-        return "Size{" + "width=" + width + ", height=" + height + '}';
+        return "Size{" + width + 'x' + height + '}';
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -72,6 +72,7 @@ public class SurfaceEncoder implements AsyncProcessor {
             boolean headerWritten = false;
 
             do {
+                capture.consumeReset(); // If a capture reset was requested, it is implicitly fulfilled
                 capture.prepare();
                 Size size = capture.getSize();
                 if (!headerWritten) {

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -11,17 +11,40 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.display.VirtualDisplay;
+import android.os.Handler;
 import android.view.Display;
 import android.view.Surface;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @SuppressLint("PrivateApi,DiscouragedPrivateApi")
 public final class DisplayManager {
+
+    // android.hardware.display.DisplayManager.EVENT_FLAG_DISPLAY_CHANGED
+    public static final long EVENT_FLAG_DISPLAY_CHANGED = 1L << 2;
+
+    public interface DisplayListener {
+        /**
+         * Called whenever the properties of a logical {@link android.view.Display},
+         * such as size and density, have changed.
+         *
+         * @param displayId The id of the logical display that changed.
+         */
+        void onDisplayChanged(int displayId);
+    }
+
+    public static final class DisplayListenerHandle {
+        private final Object displayListenerProxy;
+        private DisplayListenerHandle(Object displayListenerProxy) {
+            this.displayListenerProxy = displayListenerProxy;
+        }
+    }
+
     private final Object manager; // instance of hidden class android.hardware.display.DisplayManagerGlobal
     private Method createVirtualDisplayMethod;
     private Method requestDisplayPowerMethod;
@@ -156,6 +179,52 @@ public final class DisplayManager {
         } catch (ReflectiveOperationException e) {
             Ln.e("Could not invoke method", e);
             return false;
+        }
+    }
+
+    public DisplayListenerHandle registerDisplayListener(DisplayListener listener, Handler handler) {
+        try {
+            Class<?> displayListenerClass = Class.forName("android.hardware.display.DisplayManager$DisplayListener");
+            Object displayListenerProxy = Proxy.newProxyInstance(
+                    ClassLoader.getSystemClassLoader(),
+                    new Class[] {displayListenerClass},
+                    (proxy, method, args) -> {
+                        if ("onDisplayChanged".equals(method.getName())) {
+                            listener.onDisplayChanged((int) args[0]);
+                        }
+                        return null;
+                    });
+            try {
+                manager.getClass()
+                        .getMethod("registerDisplayListener", displayListenerClass, Handler.class, long.class, String.class)
+                        .invoke(manager, displayListenerProxy, handler, EVENT_FLAG_DISPLAY_CHANGED, FakeContext.PACKAGE_NAME);
+            } catch (NoSuchMethodException e) {
+                try {
+                    manager.getClass()
+                            .getMethod("registerDisplayListener", displayListenerClass, Handler.class, long.class)
+                            .invoke(manager, displayListenerProxy, handler, EVENT_FLAG_DISPLAY_CHANGED);
+                } catch (NoSuchMethodException e2) {
+                    manager.getClass()
+                            .getMethod("registerDisplayListener", displayListenerClass, Handler.class)
+                            .invoke(manager, displayListenerProxy, handler);
+                }
+            }
+
+            return new DisplayListenerHandle(displayListenerProxy);
+        } catch (Exception e) {
+            // Rotation and screen size won't be updated, not a fatal error
+            Ln.e("Could not register display listener", e);
+        }
+
+        return null;
+    }
+
+    public void unregisterDisplayListener(DisplayListenerHandle listener) {
+        try {
+            Class<?> displayListenerClass = Class.forName("android.hardware.display.DisplayManager$DisplayListener");
+            manager.getClass().getMethod("unregisterDisplayListener", displayListenerClass).invoke(manager, listener.displayListenerProxy);
+        } catch (Exception e) {
+            Ln.e("Could not unregister display listener", e);
         }
     }
 }


### PR DESCRIPTION
Whenever the display size changes, scrcpy must reset the capture/encoding to stream a video at the new size.

The display size may change for several reasons:
 - device rotation
 - device folding/unfolding
 - resolution change
 - …

Currently, scrcpy only listened for device rotation and device folding/unfolding events.

This was sometimes insufficient:
 - #161
 - #1918
 - #4152
 - https://github.com/Genymobile/scrcpy/issues/5362#issuecomment-2416219316

Instead of listening to specific events that could cause a display size change, @yume-chan submitted #4469 to listen to display changed events directly. It was almost ready to be merged, but we noticed that it didn't work on Android 14: https://github.com/Genymobile/scrcpy/pull/4469#issuecomment-1836572786 (the events were never received)

In recent Android 14 upgrades, it seems the behavior is fixed (the display changed events are correctly received).

But we must still support the devices with a broken version of Android 14, so this PR implements the following behavior:
 - on Android != 14: only use display changed events
 - on Android 14: register rotation/fold listeners (like before) and listen to display changed events. On the first display changed event received, we know that the device has an Android 14 version where the `DisplayListener` works, so unregister rotation/fold listeners (to avoid resetting the capture/encoding twice)

The display changed events are triggered for many reasons, not only the size. This PR stores the current size and reset only if the new size is different.

@yume-chan Please review :wink: