### PR TITLE
Disable broken options on Android 14

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -2812,7 +2812,8 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 SC_LOCK_VIDEO_ORIENTATION_UNLOCKED) {
             LOGI("Video orientation is locked for v4l2 sink. "
                  "See --lock-video-orientation.");
-            opts->lock_video_orientation = SC_LOCK_VIDEO_ORIENTATION_INITIAL;
+            opts->lock_video_orientation =
+                SC_LOCK_VIDEO_ORIENTATION_INITIAL_AUTO;
         }
 
         // V4L2 could not handle size change.

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -134,6 +134,8 @@ enum sc_lock_video_orientation {
     SC_LOCK_VIDEO_ORIENTATION_UNLOCKED = -1,
     // lock the current orientation when scrcpy starts
     SC_LOCK_VIDEO_ORIENTATION_INITIAL = -2,
+    // like SC_LOCK_VIDEO_ORIENTATION_INITIAL, but set automatically
+    SC_LOCK_VIDEO_ORIENTATION_INITIAL_AUTO = -3,
     SC_LOCK_VIDEO_ORIENTATION_0 = 0,
     SC_LOCK_VIDEO_ORIENTATION_90 = 3,
     SC_LOCK_VIDEO_ORIENTATION_180 = 2,

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy;
 
 import com.genymobile.scrcpy.audio.AudioCodec;
 import com.genymobile.scrcpy.audio.AudioSource;
+import com.genymobile.scrcpy.device.Device;
 import com.genymobile.scrcpy.device.NewDisplay;
 import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.CodecOption;
@@ -31,7 +32,7 @@ public class Options {
     private int videoBitRate = 8000000;
     private int audioBitRate = 128000;
     private float maxFps;
-    private int lockVideoOrientation = -1;
+    private int lockVideoOrientation = Device.LOCK_VIDEO_ORIENTATION_UNLOCKED;
     private boolean tunnelForward;
     private Rect crop;
     private boolean control = true;
@@ -251,6 +252,10 @@ public class Options {
 
     public boolean getSendCodecMeta() {
         return sendCodecMeta;
+    }
+
+    public void resetLockVideoOrientation() {
+        this.lockVideoOrientation = Device.LOCK_VIDEO_ORIENTATION_UNLOCKED;
     }
 
     @SuppressWarnings("MethodLength")

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -132,6 +132,23 @@ public final class Server {
             throw new ConfigurationException("New virtual display is not supported");
         }
 
+        if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
+            int lockVideoOrientation = options.getLockVideoOrientation();
+            if (lockVideoOrientation != Device.LOCK_VIDEO_ORIENTATION_UNLOCKED) {
+                if (lockVideoOrientation != Device.LOCK_VIDEO_ORIENTATION_INITIAL_AUTO) {
+                    Ln.e("--lock-video-orientation is broken on Android >= 14: <https://github.com/Genymobile/scrcpy/issues/4011>");
+                    throw new ConfigurationException("--lock-video-orientation is broken on Android >= 14");
+                } else {
+                    // If the flag has been set automatically (because v4l2 sink is enabled), do not fail
+                    Ln.w("--lock-video-orientation is ignored on Android >= 14: <https://github.com/Genymobile/scrcpy/issues/4011>");
+                }
+            }
+            if (options.getCrop() != null) {
+                Ln.e("--crop is broken on Android >= 14: <https://github.com/Genymobile/scrcpy/issues/4162>");
+                throw new ConfigurationException("Crop is not broken on Android >= 14");
+            }
+        }
+
         CleanUp cleanUp = null;
         Thread initThread = null;
 

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -42,6 +42,8 @@ public final class Device {
 
     public static final int LOCK_VIDEO_ORIENTATION_UNLOCKED = -1;
     public static final int LOCK_VIDEO_ORIENTATION_INITIAL = -2;
+    // like SC_LOCK_VIDEO_ORIENTATION_INITIAL, but set automatically
+    public static final int LOCK_VIDEO_ORIENTATION_INITIAL_AUTO = -3;
 
     private Device() {
         // not instantiable

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenInfo.java
@@ -64,7 +64,7 @@ public final class ScreenInfo {
     }
 
     public static ScreenInfo computeScreenInfo(int rotation, Size deviceSize, Rect crop, int maxSize, int lockedVideoOrientation) {
-        if (lockedVideoOrientation == Device.LOCK_VIDEO_ORIENTATION_INITIAL) {
+        if (lockedVideoOrientation == Device.LOCK_VIDEO_ORIENTATION_INITIAL || lockedVideoOrientation == Device.LOCK_VIDEO_ORIENTATION_INITIAL_AUTO) {
             // The user requested to lock the video orientation to the current orientation
             lockedVideoOrientation = rotation;
         }


### PR DESCRIPTION
The options `--lock-video-orientation` and `--crop` are broken since Android 14. Hopefully, they will be reimplemented differently.

Meanwhile, when running Android >= 14, fail with an error to prevent incorrect behavior.

Refs #4011
Refs #4162