### PR TITLE
Power on the device only for main display

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -166,7 +166,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     private void control() throws IOException {
         // on start, power on the device
-        if (powerOn && displayId != Device.DISPLAY_ID_NONE && !Device.isScreenOn()) {
+        if (powerOn && displayId == 0 && !Device.isScreenOn()) {
             Device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, displayId, Device.INJECT_MODE_ASYNC);
 
             // dirty hack


### PR DESCRIPTION
Power on the device on start only if scrcpy is mirroring the main display.

---

If I create a new display with `scrcpy --new-display`, then mirrors it with another scrcpy instance (`scrcpy --display-id=ID`), then it powers on the physical device, which is unexpected.