### PR TITLE
Add screen off timeout configuration

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -77,6 +77,7 @@ _scrcpy() {
         --rotation=
         -s --serial=
         -S --turn-screen-off
+        --screen-off-timeout=
         --shortcut-mod=
         --start-app=
         -t --show-touches

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -80,6 +80,7 @@ arguments=(
     '--require-audio=[Make scrcpy fail if audio is enabled but does not work]'
     {-s,--serial=}'[The device serial number \(mandatory for multiple devices only\)]:serial:($("${ADB-adb}" devices | awk '\''$2 == "device" {print $1}'\''))'
     {-S,--turn-screen-off}'[Turn the device screen off immediately]'
+    '--screen-off-timeout=[Set the screen off timeout in seconds]'
     '--shortcut-mod=[\[key1,key2+key3,...\] Specify the modifiers to use for scrcpy shortcuts]:shortcut mod:(lctrl rctrl lalt ralt lsuper rsuper)'
     '--start-app=[Start an Android app]'
     {-t,--show-touches}'[Show physical touches]'

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -62,6 +62,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .audio_buffer = -1, // depends on the audio format,
     .audio_output_buffer = SC_TICK_FROM_MS(5),
     .time_limit = 0,
+    .screen_off_timeout = -1,
 #ifdef HAVE_V4L2
     .v4l2_device = NULL,
     .v4l2_buffer = 0,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -265,6 +265,7 @@ struct scrcpy_options {
     sc_tick audio_buffer;
     sc_tick audio_output_buffer;
     sc_tick time_limit;
+    sc_tick screen_off_timeout;
 #ifdef HAVE_V4L2
     const char *v4l2_device;
     sc_tick v4l2_buffer;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -428,6 +428,7 @@ scrcpy(struct scrcpy_options *options) {
         .video_bit_rate = options->video_bit_rate,
         .audio_bit_rate = options->audio_bit_rate,
         .max_fps = options->max_fps,
+        .screen_off_timeout = options->screen_off_timeout,
         .lock_video_orientation = options->lock_video_orientation,
         .control = options->control,
         .display_id = options->display_id,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -320,6 +320,11 @@ execute_server(struct sc_server *server,
     if (params->stay_awake) {
         ADD_PARAM("stay_awake=true");
     }
+    if (params->screen_off_timeout != -1) {
+        assert(params->screen_off_timeout >= 0);
+        uint64_t ms = SC_TICK_TO_MS(params->screen_off_timeout);
+        ADD_PARAM("screen_off_timeout=%" PRIu64, ms);
+    }
     if (params->video_codec_options) {
         VALIDATE_STRING(params->video_codec_options);
         ADD_PARAM("video_codec_options=%s", params->video_codec_options);

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -45,6 +45,7 @@ struct sc_server_params {
     uint32_t video_bit_rate;
     uint32_t audio_bit_rate;
     const char *max_fps; // float to be parsed by the server
+    sc_tick screen_off_timeout;
     int8_t lock_video_orientation;
     bool control;
     uint32_t display_id;

--- a/doc/device.md
+++ b/doc/device.md
@@ -71,6 +71,31 @@ adb shell cmd display power-on 0
 ```
 
 
+## Screen off timeout
+
+The Android screen automatically turns off after some delay.
+
+To change this delay while scrcpy is running:
+
+```bash
+scrcpy --screen-off-timeout=300  # 300 seconds (5 minutes)
+```
+
+The initial value is restored on exit.
+
+It is possible to change this setting manually:
+
+```bash
+# get the current screen_off_timeout value
+adb shell settings get system screen_off_timeout
+# set a new value (in milliseconds)
+adb shell settings put system screen_off_timeout 30000
+```
+
+Note that the Android value is in milliseconds, but the scrcpy command line
+argument is in seconds.
+
+
 ## Show touches
 
 For presentations, it may be useful to show physical touches (on the physical

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -45,6 +45,7 @@ public class Options {
     private boolean cameraHighSpeed;
     private boolean showTouches;
     private boolean stayAwake;
+    private int screenOffTimeout = -1;
     private List<CodecOption> videoCodecOptions;
     private List<CodecOption> audioCodecOptions;
 
@@ -172,6 +173,10 @@ public class Options {
 
     public boolean getStayAwake() {
         return stayAwake;
+    }
+
+    public int getScreenOffTimeout() {
+        return screenOffTimeout;
     }
 
     public List<CodecOption> getVideoCodecOptions() {
@@ -362,6 +367,12 @@ public class Options {
                     break;
                 case "stay_awake":
                     options.stayAwake = Boolean.parseBoolean(value);
+                    break;
+                case "screen_off_timeout":
+                    options.screenOffTimeout = Integer.parseInt(value);
+                    if (options.screenOffTimeout < -1) {
+                        throw new IllegalArgumentException("Invalid screen off timeout: " + options.screenOffTimeout);
+                    }
                     break;
                 case "video_codec_options":
                     options.videoCodecOptions = CodecOption.parse(value);


### PR DESCRIPTION
The Android screen automatically turns off after some delay.

To change this delay while scrcpy is running:

```bash
scrcpy --screen-off-timeout=300  # 300 seconds (5 minutes)
```

The initial value is restored on exit.

This may be useful as an alternative to `--stay-awake` (which only works while the device is plugged in).