### PR TITLE
introduce new debugging method that works on devices > android-11

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -165,8 +165,10 @@ conf.set('DEFAULT_LOCAL_PORT_RANGE_LAST', '27199')
 # run a server debugger and wait for a client to be attached
 conf.set('SERVER_DEBUGGER', get_option('server_debugger'))
 
-# select the debugger method ('old' for Android < 9, 'new' for Android >= 9)
+# select the debugger method ('old' for Android < 9, 'new' for Android >= 9, 'adbconnection' for Android >= XXX)
 conf.set('SERVER_DEBUGGER_METHOD_NEW', get_option('server_debugger_method') == 'new')
+
+conf.set('SERVER_DEBUGGER_METHOD_ADBCONNECT', get_option('server_debugger_method') == 'adbconnection')
 
 # enable V4L2 support (linux only)
 conf.set('HAVE_V4L2', v4l2_support)

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -253,15 +253,18 @@ execute_server(struct sc_server *server,
 #ifdef SERVER_DEBUGGER
 # define SERVER_DEBUGGER_PORT "5005"
     cmd[count++] =
-# ifdef SERVER_DEBUGGER_METHOD_NEW
+# if defined(SERVER_DEBUGGER_METHOD_ADBCONNECTION)
+        "-XjdwpProvider:adbconnection";
+# elif defined(SERVER_DEBUGGER_METHOD_NEW)
         /* Android 9 and above */
         "-XjdwpProvider:internal -XjdwpOptions:transport=dt_socket,suspend=y,"
         "server=y,address="
+            SERVER_DEBUGGER_PORT;
 # else
         /* Android 8 and below */
         "-agentlib:jdwp=transport=dt_socket,suspend=y,server=y,address="
-# endif
             SERVER_DEBUGGER_PORT;
+# endif
 #endif
     cmd[count++] = "/"; // unused
     cmd[count++] = "com.genymobile.scrcpy.Server";

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -470,13 +470,32 @@ meson setup x -Dserver_debugger=true -Dserver_debugger_method=old
 meson configure x -Dserver_debugger=true -Dserver_debugger_method=old
 ```
 
+If your device runs Android 11 or below, set the `server_debugger_method` to 
+`new` in addition:
+
+```bash
+meson setup x -Dserver_debugger=true -Dserver_debugger_method=new
+# or, if x is already configured
+meson configure x -Dserver_debugger=true -Dserver_debugger_method=new
+```
+
 Then recompile.
 
 When you start scrcpy, it will start a debugger on port 5005 on the device.
 Redirect that port to the computer:
 
+for the `old` and `new` methods:
+
 ```bash
 adb forward tcp:5005 tcp:5005
+```
+
+Otherwise, for the default method:
+
+```bash
+adb jdwp
+# note the returned PID. The adb command won't return until you press Ctrl+C
+adb forward tcp:5005 jdwp:<PID>
 ```
 
 In Android Studio, _Run_ > _Debug_ > _Edit configurations..._ On the left, click on

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,6 @@ option('compile_server', type: 'boolean', value: true, description: 'Build the s
 option('prebuilt_server', type: 'string', description: 'Path of the prebuilt server')
 option('portable', type: 'boolean', value: false, description: 'Use scrcpy-server from the same directory as the scrcpy executable')
 option('server_debugger', type: 'boolean', value: false, description: 'Run a server debugger and wait for a client to be attached')
-option('server_debugger_method', type: 'combo', choices: ['old', 'new'], value: 'new', description: 'Select the debugger method (Android < 9: "old", Android >= 9: "new")')
+option('server_debugger_method', type: 'combo', choices: ['old', 'new', 'adbconnection'], value: 'adbconnection', description: 'Select the debugger method (Android < 9: "old", Android >= 9: "new", Android >= XXX: adbconnection)')
 option('v4l2', type: 'boolean', value: true, description: 'Enable V4L2 feature when supported')
 option('usb', type: 'boolean', value: true, description: 'Enable HID/OTG features when supported')


### PR DESCRIPTION
This introduces a new debugging mode that works with my android 11 device. I'm not yet sure if it is the earliest version that needs this change though.

TODO:

* [ ] verify, that Android 11 is the earliest version that need the adbconnection method.