### PR TITLE
Add FakeContext.getContentResolver()

### DIFF
--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -50,6 +50,11 @@ cd "$SERVER_DIR/src/main/aidl"
     android/content/IOnPrimaryClipChangedListener.aidl
 "$BUILD_TOOLS_DIR/aidl" -o"$GEN_DIR" -I. android/view/IDisplayFoldListener.aidl
 
+# Fake sources to expose hidden Android types to the project
+FAKE_SRC=( \
+    android/content/*java \
+)
+
 SRC=( \
     com/genymobile/scrcpy/*.java \
     com/genymobile/scrcpy/audio/*.java \
@@ -72,6 +77,7 @@ javac -encoding UTF-8 -bootclasspath "$ANDROID_JAR" \
     -cp "$LAMBDA_JAR:$GEN_DIR" \
     -d "$CLASSES_DIR" \
     -source 1.8 -target 1.8 \
+    ${FAKE_SRC[@]} \
     ${SRC[@]}
 
 echo "Dexing..."

--- a/server/src/main/java/android/content/IContentProvider.java
+++ b/server/src/main/java/android/content/IContentProvider.java
@@ -1,0 +1,5 @@
+package android.content;
+
+public interface IContentProvider {
+    // android.content.IContentProvider is hidden, this is a fake one to expose the type to the project
+}

--- a/server/src/main/java/com/genymobile/scrcpy/FakeContext.java
+++ b/server/src/main/java/com/genymobile/scrcpy/FakeContext.java
@@ -2,8 +2,10 @@ package com.genymobile.scrcpy;
 
 import android.annotation.TargetApi;
 import android.content.AttributionSource;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.IContentProvider;
 import android.os.Process;
 
 public final class FakeContext extends ContextWrapper {
@@ -16,6 +18,38 @@ public final class FakeContext extends ContextWrapper {
     public static FakeContext get() {
         return INSTANCE;
     }
+
+    private final ContentResolver contentResolver = new ContentResolver(this) {
+        @SuppressWarnings({"unused", "ProtectedMemberInFinalClass"})
+        // @Override (but super-class method not visible)
+        protected IContentProvider acquireProvider(Context c, String name) {
+            return null;
+        }
+
+        @SuppressWarnings("unused")
+        // @Override (but super-class method not visible)
+        public boolean releaseProvider(IContentProvider icp) {
+            return false;
+        }
+
+        @SuppressWarnings({"unused", "ProtectedMemberInFinalClass"})
+        // @Override (but super-class method not visible)
+        protected IContentProvider acquireUnstableProvider(Context c, String name) {
+            return null;
+        }
+
+        @SuppressWarnings("unused")
+        // @Override (but super-class method not visible)
+        public boolean releaseUnstableProvider(IContentProvider icp) {
+            return false;
+        }
+
+        @SuppressWarnings("unused")
+        // @Override (but super-class method not visible)
+        public void unstableProviderDied(IContentProvider icp) {
+            // ignore
+        }
+    };
 
     private FakeContext() {
         super(Workarounds.getSystemContext());
@@ -48,5 +82,10 @@ public final class FakeContext extends ContextWrapper {
     @Override
     public Context getApplicationContext() {
         return this;
+    }
+
+    @Override
+    public ContentResolver getContentResolver() {
+        return contentResolver;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
@@ -6,6 +6,7 @@ import com.genymobile.scrcpy.util.Ln;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
+import android.content.IContentProvider;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.Bundle;
@@ -64,7 +65,7 @@ public final class ActivityManager {
     }
 
     @TargetApi(AndroidVersions.API_29_ANDROID_10)
-    private ContentProvider getContentProviderExternal(String name, IBinder token) {
+    private IContentProvider getContentProviderExternal(String name, IBinder token) {
         try {
             Method method = getGetContentProviderExternalMethod();
             Object[] args;
@@ -83,11 +84,7 @@ public final class ActivityManager {
             // IContentProvider provider = providerHolder.provider;
             Field providerField = providerHolder.getClass().getDeclaredField("provider");
             providerField.setAccessible(true);
-            Object provider = providerField.get(providerHolder);
-            if (provider == null) {
-                return null;
-            }
-            return new ContentProvider(this, provider, name, token);
+            return (IContentProvider) providerField.get(providerHolder);
         } catch (ReflectiveOperationException e) {
             Ln.e("Could not invoke method", e);
             return null;
@@ -104,7 +101,12 @@ public final class ActivityManager {
     }
 
     public ContentProvider createSettingsProvider() {
-        return getContentProviderExternal("settings", new Binder());
+        IBinder token = new Binder();
+        IContentProvider provider = getContentProviderExternal("settings", token);
+        if (provider == null) {
+            return null;
+        }
+        return new ContentProvider(this, provider, "settings", token);
     }
 
     private Method getStartActivityAsUserMethod() throws NoSuchMethodException, ClassNotFoundException {


### PR DESCRIPTION
This avoids the following error on some devices:

    Given calling package android does not match caller's uid 2000

This is basically the commit from @yume-chan here: https://github.com/Genymobile/scrcpy/issues/4639
(I've just made minor changes)

Here is a full Windows binary from the current branch:
- [`scrcpy-win64-pr5476.zip`](https://tmp.rom1v.com/scrcpy/5476/1/scrcpy-win64-pr5476.zip) <sub>`SHA-256: 893957c7e71271158eab69e7b32d91de2f86d13f6e738331946099ad8e7e953`</sub>