### PR TITLE
Use explicit file protocol for AVIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 /build_*/
 /release-*/
 .idea/
+.vscode/
 .gradle/
 /x/
 local.properties

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -143,8 +143,14 @@ sc_recorder_open_output_file(struct sc_recorder *recorder) {
         return false;
     }
 
-    int ret = avio_open(&recorder->ctx->pb, recorder->filename,
-                        AVIO_FLAG_WRITE);
+    char *file_url = sc_str_prepend(recorder->filename, "file:");
+    if (!file_url) {
+        avformat_free_context(recorder->ctx);
+        return false;
+    }
+
+    int ret = avio_open(&recorder->ctx->pb, file_url, AVIO_FLAG_WRITE);
+    free(file_url);
     if (ret < 0) {
         LOGE("Failed to open output file: %s", recorder->filename);
         avformat_free_context(recorder->ctx);

--- a/app/src/util/str.c
+++ b/app/src/util/str.c
@@ -64,6 +64,27 @@ sc_str_quote(const char *src) {
     return quoted;
 }
 
+char *
+sc_str_prepend(const char *src, const char *prefix) {
+    assert(src);
+    assert(prefix);
+
+    size_t prefix_len = strlen(prefix);
+    size_t src_len = strlen(src);
+
+    size_t new_len = prefix_len + src_len + 1;
+    char *result = malloc(new_len);
+    if (!result) {
+        LOG_OOM();
+        return NULL;
+    }
+
+    memcpy(result, prefix, prefix_len);
+    memcpy(result + prefix_len, src, src_len + 1);
+
+    return result;
+}
+
 bool
 sc_str_parse_integer(const char *s, long *out) {
     char *endptr;

--- a/app/src/util/str.h
+++ b/app/src/util/str.h
@@ -39,6 +39,14 @@ char *
 sc_str_quote(const char *src);
 
 /**
+ * Prefix a string
+ *
+ * Return a new allocated prefixed string.
+ */
+char *
+sc_str_prepend(const char *src, const char *prefix);
+
+/**
  * Parse `s` as an integer into `out`
  *
  * Return true if the conversion succeeded, false otherwise.

--- a/app/tests/test_str.c
+++ b/app/tests/test_str.c
@@ -141,6 +141,16 @@ static void test_quote(void) {
     free(out);
 }
 
+static void test_prepend(void) {
+    const char *s = "2024:11";
+    char *out = sc_str_prepend(s, "my-prefix:");
+
+    // prefix with 'my-prefix:'
+    assert(!strcmp("my-prefix:2024:11", out));
+
+    free(out);
+}
+
 static void test_utf8_truncate(void) {
     const char *s = "aÉbÔc";
     assert(strlen(s) == 7); // É and Ô are 2 bytes-wide
@@ -389,6 +399,7 @@ int main(int argc, char *argv[]) {
     test_join_truncated_before_sep();
     test_join_truncated_after_sep();
     test_quote();
+    test_prepend();
     test_utf8_truncate();
     test_parse_integer();
     test_parse_integers();


### PR DESCRIPTION
AVIO expects a `url` to locate a resource.
Use the file protocol to handle filenames containing colons.

#5487 