### PR TITLE
Support refresh rates over 60 FPS in NewDisplayCapture

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -11,6 +11,7 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.display.VirtualDisplay;
+import android.hardware.display.VirtualDisplayConfig;
 import android.os.Handler;
 import android.view.Display;
 import android.view.Surface;
@@ -162,6 +163,15 @@ public final class DisplayManager {
         ctor.setAccessible(true);
         android.hardware.display.DisplayManager dm = ctor.newInstance(FakeContext.get());
         return dm.createVirtualDisplay(name, width, height, dpi, surface, flags);
+    }
+
+    @TargetApi(AndroidVersions.API_34_ANDROID_14)
+    public VirtualDisplay createNewVirtualDisplay(VirtualDisplayConfig config) throws Exception {
+        Constructor<android.hardware.display.DisplayManager> ctor = android.hardware.display.DisplayManager.class.getDeclaredConstructor(
+                Context.class);
+        ctor.setAccessible(true);
+        android.hardware.display.DisplayManager dm = ctor.newInstance(FakeContext.get());
+        return dm.createVirtualDisplay(config);
     }
 
     private Method getRequestDisplayPowerMethod() throws NoSuchMethodException {


### PR DESCRIPTION
When `maxFps` exceeds 60, use the `setRequestedRefreshRate` method to configure the refresh rate for the virtual display.  
Otherwise, the refresh rate will default to a maximum of 60 FPS.  

[Related Android commit](https://android.googlesource.com/platform/frameworks/base/+/6c57176e9a2882eff03c5b3f3cccfd988d38488d)  
[Code limiting the frame rate to 60 FPS](https://android.googlesource.com/platform/frameworks/base/+/6c57176e9a2882eff03c5b3f3cccfd988d38488d/services/core/java/com/android/server/display/VirtualDisplayAdapter.java#562)