### PR TITLE
macos: enable static binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-            echo TODO
+            brew install meson ninja automake
 
       - name: Build macOS
         run: release/build_macos.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,33 @@ jobs:
           name: build-win64-intermediate
           path: release/work/build-win64/dist-tar/
 
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+            echo TODO
+
+      - name: Build macOS
+        run: release/build_macos.sh
+
+      # upload-artifact does not preserve permissions
+      - name: Tar
+        run: |
+            cd release/work/build-macos
+            mkdir dist-tar
+            cd dist-tar
+            tar -C .. -cvf dist.tar.gz dist/
+
+      - name: Upload build-macos artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-macos-intermediate
+          path: release/work/build-macos/dist-tar/
+
   package-linux:
     needs:
       - build-scrcpy-server
@@ -272,6 +299,42 @@ jobs:
         with:
           name: release-win64
           path: release/output
+
+  package-macos:
+    needs:
+      - build-scrcpy-server
+      - build-macos
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download scrcpy-server
+        uses: actions/download-artifact@v4
+        with:
+          name: scrcpy-server
+          path: release/work/build-server/server/
+
+      - name: Download build-macos
+        uses: actions/download-artifact@v4
+        with:
+          name: build-macos-intermediate
+          path: release/work/build-macos/dist-tar/
+
+      # upload-artifact does not preserve permissions
+      - name: Detar
+        run: |
+            cd release/work/build-macos
+            tar xf dist-tar/dist.tar.gz
+
+      - name: Package macos
+        run: release/package_client.sh macos
+
+      - name: Upload macos release
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos
+          path: release/output/
 
   release:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,36 @@ jobs:
       - name: Test
         run: release/test_client.sh
 
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y meson ninja-build nasm ffmpeg libsdl2-2.0-0 \
+             libsdl2-dev libavcodec-dev libavdevice-dev libavformat-dev \
+             libavutil-dev libswresample-dev libusb-1.0-0 libusb-1.0-0-dev
+
+      - name: Build linux
+        run: release/build_linux.sh
+
+      # upload-artifact does not preserve permissions
+      - name: Tar
+        run: |
+            cd release/work/build-linux
+            mkdir dist-tar
+            cd dist-tar
+            tar -C .. -cvf dist.tar.gz dist/
+
+      - name: Upload build-linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-linux-intermediate
+          path: release/work/build-linux/dist-tar/
+
   build-win32:
     runs-on: ubuntu-latest
     steps:
@@ -134,6 +164,42 @@ jobs:
         with:
           name: build-win64-intermediate
           path: release/work/build-win64/dist-tar/
+
+  package-linux:
+    needs:
+      - build-scrcpy-server
+      - build-linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download scrcpy-server
+        uses: actions/download-artifact@v4
+        with:
+          name: scrcpy-server
+          path: release/work/build-server/server/
+
+      - name: Download build-linux
+        uses: actions/download-artifact@v4
+        with:
+          name: build-linux-intermediate
+          path: release/work/build-linux/dist-tar/
+
+      # upload-artifact does not preserve permissions
+      - name: Detar
+        run: |
+            cd release/work/build-linux
+            tar xf dist-tar/dist.tar.gz
+
+      - name: Package linux
+        run: release/package_client.sh linux tar.gz
+
+      - name: Upload linux release
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-linux
+          path: release/output/
 
   package-win32:
     needs:
@@ -210,6 +276,7 @@ jobs:
   release:
     needs:
       - build-scrcpy-server
+      - build-linux
       - package-win32
       - package-win64
     runs-on: ubuntu-latest
@@ -222,6 +289,12 @@ jobs:
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
+
+      - name: Download release-linux
+        uses: actions/download-artifact@v4
+        with:
+          name: release-linux
+          path: release/output/
 
       - name: Download release-win32
         uses: actions/download-artifact@v4

--- a/app/data/scrcpy_static_wrapper.sh
+++ b/app/data/scrcpy_static_wrapper.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+cd "$(dirname ${BASH_SOURCE[0]})"
+export ADB=./adb
+export SCRCPY_SERVER_PATH=./scrcpy-server
+export ICON=./icon.png
+scrcpy "$@"

--- a/app/deps/adb_linux.sh
+++ b/app/deps/adb_linux.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -ex
+DEPS_DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DEPS_DIR"
+. common
+
+VERSION=35.0.2
+FILENAME=platform-tools_r$VERSION-linux.zip
+PROJECT_DIR=platform-tools-$VERSION-linux
+SHA256SUM=acfdcccb123a8718c46c46c059b2f621140194e5ec1ac9d81715be3d6ab6cd0a
+
+cd "$SOURCES_DIR"
+
+if [[ -d "$PROJECT_DIR" ]]
+then
+    echo "$PWD/$PROJECT_DIR" found
+else
+    get_file "https://dl.google.com/android/repository/$FILENAME" "$FILENAME" "$SHA256SUM"
+    mkdir -p "$PROJECT_DIR"
+    cd "$PROJECT_DIR"
+    ZIP_PREFIX=platform-tools
+    unzip "../$FILENAME" "$ZIP_PREFIX"/adb
+    mv "$ZIP_PREFIX"/* .
+    rmdir "$ZIP_PREFIX"
+fi
+
+mkdir -p "$INSTALL_DIR/adb-linux"
+cd "$INSTALL_DIR/adb-linux"
+cp -r "$SOURCES_DIR/$PROJECT_DIR"/. "$INSTALL_DIR/adb-linux/"

--- a/app/deps/adb_macos.sh
+++ b/app/deps/adb_macos.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -ex
+DEPS_DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DEPS_DIR"
+. common
+
+VERSION=35.0.2
+FILENAME=platform-tools_r$VERSION-darwin.zip
+PROJECT_DIR=platform-tools-$VERSION-darwin
+SHA256SUM=1820078db90bf21628d257ff052528af1c61bb48f754b3555648f5652fa35d78
+
+cd "$SOURCES_DIR"
+
+if [[ -d "$PROJECT_DIR" ]]
+then
+    echo "$PWD/$PROJECT_DIR" found
+else
+    get_file "https://dl.google.com/android/repository/$FILENAME" "$FILENAME" "$SHA256SUM"
+    mkdir -p "$PROJECT_DIR"
+    cd "$PROJECT_DIR"
+    ZIP_PREFIX=platform-tools
+    unzip "../$FILENAME" "$ZIP_PREFIX"/adb
+    mv "$ZIP_PREFIX"/* .
+    rmdir "$ZIP_PREFIX"
+fi
+
+mkdir -p "$INSTALL_DIR/adb-macos"
+cd "$INSTALL_DIR/adb-macos"
+cp -r "$SOURCES_DIR/$PROJECT_DIR"/. "$INSTALL_DIR/adb-macos/"

--- a/app/deps/common
+++ b/app/deps/common
@@ -59,7 +59,13 @@ checksum() {
     local file="$1"
     local sum="$2"
     echo "$file: verifying checksum..."
-    echo "$sum  $file" | sha256sum -c
+    if [[ "$OSTYPE" == darwin* ]]
+    then
+        # macOS does not have sha256sum
+        echo "$sum  $file" | shasum -a 256 -c
+    else
+        echo "$sum  $file" | sha256sum -c
+    fi
 }
 
 get_file() {

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -48,7 +48,6 @@ else
         --disable-swscale
         --disable-postproc
         --disable-avfilter
-        --disable-avdevice
         --disable-network
         --disable-everything
         --disable-vulkan
@@ -73,6 +72,14 @@ else
         --enable-muxer=flac
         --enable-muxer=wav
     )
+
+    if [[ "$HOST" != linux ]]
+    then
+        # libavdevice is only used for V4L2 on Linux
+        conf+=(
+            --disable-avdevice
+        )
+    fi
 
     if [[ "$LINK_TYPE" == static ]]
     then

--- a/app/deps/sdl.sh
+++ b/app/deps/sdl.sh
@@ -38,6 +38,14 @@ else
         --prefix="$INSTALL_DIR/$DIRNAME"
     )
 
+    if [[ "$HOST" == linux ]]
+    then
+        conf+=(
+            --enable-video-wayland
+            --enable-video-x11
+        )
+    fi
+
     if [[ "$LINK_TYPE" == static ]]
     then
         conf+=(

--- a/release/build_linux.sh
+++ b/release/build_linux.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+cd "$(dirname ${BASH_SOURCE[0]})"
+. build_common
+cd .. # root project dir
+
+LINUX_BUILD_DIR="$WORK_DIR/build-linux"
+
+app/deps/adb_linux.sh
+app/deps/sdl.sh linux native static
+app/deps/ffmpeg.sh linux native static
+app/deps/libusb.sh linux native static
+
+DEPS_INSTALL_DIR="$PWD/app/deps/work/install/linux-native-static"
+ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-linux"
+
+rm -rf "$LINUX_BUILD_DIR"
+meson setup "$LINUX_BUILD_DIR" \
+    --pkg-config-path="$DEPS_INSTALL_DIR/lib/pkgconfig" \
+    -Dc_args="-I$DEPS_INSTALL_DIR/include" \
+    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
+    --buildtype=release \
+    --strip \
+    -Db_lto=true \
+    -Dcompile_server=false \
+    -Dportable=true \
+    -Dstatic=true
+ninja -C "$LINUX_BUILD_DIR"
+
+# Group intermediate outputs into a 'dist' directory
+mkdir -p "$LINUX_BUILD_DIR/dist"
+cp "$LINUX_BUILD_DIR"/app/scrcpy "$LINUX_BUILD_DIR/dist/scrcpy_bin"
+cp app/data/icon.png "$LINUX_BUILD_DIR/dist/"
+cp app/data/scrcpy_static_wrapper.sh "$LINUX_BUILD_DIR/dist/scrcpy"
+cp -r "$ADB_INSTALL_DIR"/. "$LINUX_BUILD_DIR/dist/"

--- a/release/build_macos.sh
+++ b/release/build_macos.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -ex
+cd "$(dirname ${BASH_SOURCE[0]})"
+. build_common
+cd .. # root project dir
+
+MACOS_BUILD_DIR="$WORK_DIR/build-macos"
+
+app/deps/adb_macos.sh
+app/deps/sdl.sh macos native static
+app/deps/ffmpeg.sh macos native static
+app/deps/libusb.sh macos native static
+
+DEPS_INSTALL_DIR="$PWD/app/deps/work/install/macos-native-static"
+ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-macos"
+
+rm -rf "$MACOS_BUILD_DIR"
+meson setup "$MACOS_BUILD_DIR" \
+    --pkg-config-path="$DEPS_INSTALL_DIR/lib/pkgconfig" \
+    -Dc_args="-I$DEPS_INSTALL_DIR/include" \
+    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
+    --buildtype=release \
+    --strip \
+    -Db_lto=true \
+    -Dcompile_server=false \
+    -Dportable=true \
+    -Dstatic=true
+ninja -C "$MACOS_BUILD_DIR"
+
+# Group intermediate outputs into a 'dist' directory
+mkdir -p "$MACOS_BUILD_DIR/dist"
+cp "$MACOS_BUILD_DIR"/app/scrcpy "$MACOS_BUILD_DIR/dist/scrcpy_bin"
+cp app/data/icon.png "$MACOS_BUILD_DIR/dist/"
+cp app/data/scrcpy_static_wrapper.sh "$MACOS_BUILD_DIR/dist/scrcpy"
+cp -r "$ADB_INSTALL_DIR"/. "$MACOS_BUILD_DIR/dist/"

--- a/release/generate_checksums.sh
+++ b/release/generate_checksums.sh
@@ -5,6 +5,7 @@ cd "$(dirname ${BASH_SOURCE[0]})"
 
 cd "$OUTPUT_DIR"
 sha256sum "scrcpy-server-$VERSION" \
+    "scrcpy-linux-$VERSION.zip" \
     "scrcpy-win32-$VERSION.zip" \
     "scrcpy-win64-$VERSION.zip" \
         | tee SHA256SUMS.txt

--- a/release/generate_checksums.sh
+++ b/release/generate_checksums.sh
@@ -8,5 +8,6 @@ sha256sum "scrcpy-server-$VERSION" \
     "scrcpy-linux-$VERSION.zip" \
     "scrcpy-win32-$VERSION.zip" \
     "scrcpy-win64-$VERSION.zip" \
+    "scrcpy-macos-$VERSION.zip" \
         | tee SHA256SUMS.txt
 echo "Release checksums generated in $PWD/SHA256SUMS.txt"

--- a/release/release.sh
+++ b/release/release.sh
@@ -12,10 +12,12 @@ rm -rf output
 ./build_server.sh
 ./build_windows.sh 32
 ./build_windows.sh 64
+./build_linux.sh
 
 ./package_server.sh
 ./package_client.sh win32 zip
 ./package_client.sh win64 zip
+./package_client.sh linux tar.gz
 
 ./generate_checksums.sh
 


### PR DESCRIPTION
Here is the build log, ran on macOS arm64 15.1.1 (24B91).
```bash
release/build_macos.sh 2&>1 > build_log.txt
```
[build_log.txt](https://github.com/user-attachments/files/17880211/build_log.txt)

I saw some warnings about `objc` which might be useful:
```
WARNING: Static library 'objc' not found for dependency 'sdl2', may not be statically linked
```

When I run it against a locally running emulator, I had to copy `scrcpy-server` into the folder the binary exists.
```bash
curl -Lo release/work/build-macos/dist/scrcpy-server https://github.com/Genymobile/scrcpy/releases/download/v2.7/scrcpy-server-v2.7
```
```bash
$ ./scrcpy_bin
scrcpy 2.7 <https://github.com/Genymobile/scrcpy>
INFO: ADB device found:
INFO:     --> (tcpip)  emulator-5554                   device  sdk_gphone64_arm64
ERROR: Could not get local file path, using scrcpy-server from current directory
scrcpy-server: 1 file pushed, 0 skipped. 46.9 MB/s (71200 bytes in 0.001s)
[server] INFO: Device: [Google] google sdk_gphone64_arm64 (Android 15)
ERROR: Could not get icon path
WARN: Could not load icon
INFO: Renderer: metal
INFO: Texture: 1080x2400
2024-11-23 18:17:09.632 scrcpy_bin[4677:907645] +[IMKClient subclass]: chose IMKClient_Modern
2024-11-23 18:17:09.632 scrcpy_bin[4677:907645] +[IMKInputSession subclass]: chose IMKInputSession_Modern
WARN: Killing the server...
```

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/40ffb08e-7d13-46ed-b8da-5f200520cc24">
