### PR TITLE
Add macOS intel64 build-action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,7 @@ jobs:
           path: release/work/build-win64/dist-tar/
 
   build-macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,35 @@ jobs:
           name: build-win64-intermediate
           path: release/work/build-win64/dist-tar/
 
-  build-macos:
+  build-macos-aarch64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+            brew install meson ninja nasm libiconv zlib automake autoconf \
+                libtool
+
+      - name: Build macOS-aarch64
+        run: release/build_macos-aarch64.sh
+
+      # upload-artifact does not preserve permissions
+      - name: Tar
+        run: |
+            cd release/work/build-macos-aarch64
+            mkdir dist-tar
+            cd dist-tar
+            tar -C .. -cvf dist.tar.gz dist/
+
+      - name: Upload build-macos-aarch64 artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-macos-aarch64-intermediate
+          path: release/work/build-macos-aarch64/dist-tar/
+
+  build-macos-intel:
     runs-on: macos-13
     steps:
       - name: Checkout code
@@ -193,22 +221,22 @@ jobs:
             brew install meson ninja nasm libiconv zlib automake autoconf \
                 libtool
 
-      - name: Build macOS
-        run: release/build_macos.sh
+      - name: Build macOS-intel
+        run: release/build_macos-intel.sh
 
       # upload-artifact does not preserve permissions
       - name: Tar
         run: |
-            cd release/work/build-macos
+            cd release/work/build-macos-intel
             mkdir dist-tar
             cd dist-tar
             tar -C .. -cvf dist.tar.gz dist/
 
-      - name: Upload build-macos artifact
+      - name: Upload build-macos-intel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-macos-intermediate
-          path: release/work/build-macos/dist-tar/
+          name: build-macos-intel-intermediate
+          path: release/work/build-macos-intel/dist-tar/
 
   package-linux:
     needs:
@@ -318,10 +346,10 @@ jobs:
           name: release-win64
           path: release/output
 
-  package-macos:
+  package-macos-aarch64:
     needs:
       - build-scrcpy-server
-      - build-macos
+      - build-macos-aarch64
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -333,25 +361,61 @@ jobs:
           name: scrcpy-server
           path: release/work/build-server/server/
 
-      - name: Download build-macos
+      - name: Download build-macos-aarch64
         uses: actions/download-artifact@v4
         with:
-          name: build-macos-intermediate
-          path: release/work/build-macos/dist-tar/
+          name: build-macos-aarch64-intermediate
+          path: release/work/build-macos-aarch64/dist-tar/
 
       # upload-artifact does not preserve permissions
       - name: Detar
         run: |
-            cd release/work/build-macos
+            cd release/work/build-macos-aarch64
             tar xf dist-tar/dist.tar.gz
 
-      - name: Package macos
-        run: release/package_client.sh macos tar.gz
+      - name: Package macos-aarch64
+        run: release/package_client.sh macos-aarch64 tar.gz
 
-      - name: Upload macos release
+      - name: Upload macos-aarch64 release
         uses: actions/upload-artifact@v4
         with:
-          name: release-macos
+          name: release-macos-aarch64
+          path: release/output/
+  
+  package-macos-intel:
+    needs:
+      - build-scrcpy-server
+      - build-macos-intel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download scrcpy-server
+        uses: actions/download-artifact@v4
+        with:
+          name: scrcpy-server
+          path: release/work/build-server/server/
+
+      - name: Download build-macos-intel
+        uses: actions/download-artifact@v4
+        with:
+          name: build-macos-intel-intermediate
+          path: release/work/build-macos-intel/dist-tar/
+
+      # upload-artifact does not preserve permissions
+      - name: Detar
+        run: |
+            cd release/work/build-macos-intel
+            tar xf dist-tar/dist.tar.gz
+
+      - name: Package macos-intel
+        run: release/package_client.sh macos-intel tar.gz
+
+      - name: Upload macos-intel release
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-macos-intel
           path: release/output/
 
   release:
@@ -360,7 +424,8 @@ jobs:
       - package-linux
       - package-win32
       - package-win64
-      - package-macos
+      - package-macos-aarch64
+      - package-macos-intel
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -390,10 +455,16 @@ jobs:
           name: release-win64
           path: release/output/
 
-      - name: Download release-macos
+      - name: Download release-macos-aarch64
         uses: actions/download-artifact@v4
         with:
-          name: release-macos
+          name: release-macos-aarch64
+          path: release/output/
+
+      - name: Download release-macos-intel
+        uses: actions/download-artifact@v4
+        with:
+          name: release-macos-intel
           path: release/output/
 
       - name: Package server

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build/
 /x/
 local.properties
 /scrcpy-server
+.DS_Store

--- a/release/build_macos-aarch64.sh
+++ b/release/build_macos-aarch64.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ex
+cd "$(dirname ${BASH_SOURCE[0]})"
+. build_common
+cd .. # root project dir
+
+MACOS_BUILD_DIR="$WORK_DIR/build-macos-aarch64"
+
+app/deps/adb_macos.sh
+app/deps/sdl.sh macos native static
+app/deps/ffmpeg.sh macos native static
+app/deps/libusb.sh macos native static
+
+DEPS_INSTALL_DIR="$PWD/app/deps/work/install/macos-native-static"
+ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-macos"
+
+rm -rf "$MACOS_BUILD_DIR"
+meson setup "$MACOS_BUILD_DIR" \
+    --pkg-config-path="$DEPS_INSTALL_DIR/lib/pkgconfig" \
+    -Dc_args="-I$DEPS_INSTALL_DIR/include" \
+    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
+    --buildtype=release \
+    --strip \
+    -Db_lto=true \
+    -Dcompile_server=false \
+    -Dportable=true \
+    -Dstatic=true
+ninja -C "$MACOS_BUILD_DIR"
+
+# Group intermediate outputs into a 'dist' directory
+mkdir -p "$MACOS_BUILD_DIR/dist"
+cp "$MACOS_BUILD_DIR"/app/scrcpy "$MACOS_BUILD_DIR/dist/scrcpy_bin"
+cp app/data/icon.png "$MACOS_BUILD_DIR/dist/"
+cp app/data/scrcpy_static_wrapper.sh "$MACOS_BUILD_DIR/dist/scrcpy"
+cp app/scrcpy.1 "$MACOS_BUILD_DIR/dist/"
+cp -r "$ADB_INSTALL_DIR"/. "$MACOS_BUILD_DIR/dist/"

--- a/release/build_macos-intel.sh
+++ b/release/build_macos-intel.sh
@@ -4,7 +4,7 @@ cd "$(dirname ${BASH_SOURCE[0]})"
 . build_common
 cd .. # root project dir
 
-MACOS_BUILD_DIR="$WORK_DIR/build-macos"
+MACOS_BUILD_DIR="$WORK_DIR/build-macos-intel"
 
 app/deps/adb_macos.sh
 app/deps/sdl.sh macos native static

--- a/release/generate_checksums.sh
+++ b/release/generate_checksums.sh
@@ -8,6 +8,7 @@ sha256sum "scrcpy-server-$VERSION" \
     "scrcpy-linux-$VERSION.tar.gz" \
     "scrcpy-win32-$VERSION.zip" \
     "scrcpy-win64-$VERSION.zip" \
-    "scrcpy-macos-$VERSION.tar.gz" \
+    "scrcpy-macos-intel-$VERSION.tar.gz" \
+    "scrcpy-macos-aarch64-$VERSION.tar.gz" \
         | tee SHA256SUMS.txt
 echo "Release checksums generated in $PWD/SHA256SUMS.txt"


### PR DESCRIPTION
I just changed runner machine to macos-13.You can check artifacts here.https://github.com/Genxster1998/scrcpy-old/actions/runs/12000259857
For intel machine it is working.
![2024-11-25 04 39 45 github com ec1e0c3d3bbd](https://github.com/user-attachments/assets/4a97e6b6-eac5-41b9-bd35-95d145c0ac84)
~~PS: Forgot to reflect changes in  generate-checksums.sh.~~


  