### PR TITLE
Implement get_executable_path() for macOS

### DIFF
--- a/app/data/scrcpy_static_wrapper.sh
+++ b/app/data/scrcpy_static_wrapper.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-cd "$(dirname ${BASH_SOURCE[0]})"
-export ADB="${ADB:-./adb}"
-export SCRCPY_SERVER_PATH="${SCRCPY_SERVER_PATH:-./scrcpy-server}"
-export SCRCPY_ICON_PATH="${SCRCPY_ICON_PATH:-./icon.png}"
-./scrcpy_bin "$@"

--- a/app/meson.build
+++ b/app/meson.build
@@ -46,6 +46,7 @@ src = [
     'src/util/acksync.c',
     'src/util/audiobuf.c',
     'src/util/average.c',
+    'src/util/env.c',
     'src/util/file.c',
     'src/util/intmap.c',
     'src/util/intr.c',

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -7,6 +7,7 @@
 
 #include "adb_device.h"
 #include "adb_parser.h"
+#include "util/env.h"
 #include "util/file.h"
 #include "util/log.h"
 #include "util/process_intr.h"
@@ -24,15 +25,31 @@
  */
 #define SC_ADB_COMMAND(...) { sc_adb_get_executable(), __VA_ARGS__, NULL }
 
-static const char *adb_executable;
+static char *adb_executable;
+
+bool
+sc_adb_init(void) {
+    adb_executable = sc_get_env("ADB");
+    if (adb_executable) {
+        return true;
+    }
+
+    adb_executable = strdup("adb");
+    if (!adb_executable) {
+        LOG_OOM();
+        return false;
+    }
+
+    return true;
+}
+
+void
+sc_adb_destroy(void) {
+    free(adb_executable);
+}
 
 const char *
 sc_adb_get_executable(void) {
-    if (!adb_executable) {
-        adb_executable = getenv("ADB");
-        if (!adb_executable)
-            adb_executable = "adb";
-    }
     return adb_executable;
 }
 

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -31,6 +31,7 @@ bool
 sc_adb_init(void) {
     adb_executable = sc_get_env("ADB");
     if (adb_executable) {
+        LOGD("Using adb: %s", adb_executable);
         return true;
     }
 
@@ -49,6 +50,8 @@ sc_adb_init(void) {
         // Error already logged
         return false;
     }
+
+    LOGD("Using adb (portable): %s", adb_executable);
 #endif
 
     return true;

--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -34,11 +34,22 @@ sc_adb_init(void) {
         return true;
     }
 
+#if !defined(PORTABLE) || defined(_WIN32)
     adb_executable = strdup("adb");
     if (!adb_executable) {
         LOG_OOM();
         return false;
     }
+#else
+    // For portable builds, use the absolute path to the adb executable
+    // in the same directory as scrcpy (except on Windows, where "adb"
+    // is sufficient)
+    adb_executable = sc_file_get_local_path("adb");
+    if (!adb_executable) {
+        // Error already logged
+        return false;
+    }
+#endif
 
     return true;
 }

--- a/app/src/adb/adb.h
+++ b/app/src/adb/adb.h
@@ -15,6 +15,12 @@
 
 #define SC_ADB_SILENT (SC_ADB_NO_STDOUT | SC_ADB_NO_STDERR | SC_ADB_NO_LOGERR)
 
+bool
+sc_adb_init(void);
+
+void
+sc_adb_destroy(void);
+
 const char *
 sc_adb_get_executable(void);
 

--- a/app/src/icon.c
+++ b/app/src/icon.c
@@ -9,6 +9,7 @@
 
 #include "config.h"
 #include "compat.h"
+#include "util/env.h"
 #include "util/file.h"
 #include "util/log.h"
 #include "util/str.h"
@@ -19,35 +20,22 @@
 
 static char *
 get_icon_path(void) {
-#ifdef __WINDOWS__
-    const wchar_t *icon_path_env = _wgetenv(L"SCRCPY_ICON_PATH");
-#else
-    const char *icon_path_env = getenv("SCRCPY_ICON_PATH");
-#endif
-    if (icon_path_env) {
+    char *icon_path = sc_get_env("SCRCPY_ICON_PATH");
+    if (icon_path) {
         // if the envvar is set, use it
-#ifdef __WINDOWS__
-        char *icon_path = sc_str_from_wchars(icon_path_env);
-#else
-        char *icon_path = strdup(icon_path_env);
-#endif
-        if (!icon_path) {
-            LOG_OOM();
-            return NULL;
-        }
         LOGD("Using SCRCPY_ICON_PATH: %s", icon_path);
         return icon_path;
     }
 
 #ifndef PORTABLE
     LOGD("Using icon: " SCRCPY_DEFAULT_ICON_PATH);
-    char *icon_path = strdup(SCRCPY_DEFAULT_ICON_PATH);
+    icon_path = strdup(SCRCPY_DEFAULT_ICON_PATH);
     if (!icon_path) {
         LOG_OOM();
         return NULL;
     }
 #else
-    char *icon_path = sc_file_get_local_path(SCRCPY_PORTABLE_ICON_FILENAME);
+    icon_path = sc_file_get_local_path(SCRCPY_PORTABLE_ICON_FILENAME);
     if (!icon_path) {
         LOGE("Could not get icon path");
         return NULL;

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -9,6 +9,7 @@
 
 #include "adb/adb.h"
 #include "util/binary.h"
+#include "util/env.h"
 #include "util/file.h"
 #include "util/log.h"
 #include "util/net_intr.h"
@@ -25,35 +26,22 @@
 
 static char *
 get_server_path(void) {
-#ifdef __WINDOWS__
-    const wchar_t *server_path_env = _wgetenv(L"SCRCPY_SERVER_PATH");
-#else
-    const char *server_path_env = getenv("SCRCPY_SERVER_PATH");
-#endif
-    if (server_path_env) {
+    char *server_path = sc_get_env("SCRCPY_SERVER_PATH");
+    if (server_path) {
         // if the envvar is set, use it
-#ifdef __WINDOWS__
-        char *server_path = sc_str_from_wchars(server_path_env);
-#else
-        char *server_path = strdup(server_path_env);
-#endif
-        if (!server_path) {
-            LOG_OOM();
-            return NULL;
-        }
         LOGD("Using SCRCPY_SERVER_PATH: %s", server_path);
         return server_path;
     }
 
 #ifndef PORTABLE
     LOGD("Using server: " SC_SERVER_PATH_DEFAULT);
-    char *server_path = strdup(SC_SERVER_PATH_DEFAULT);
+    server_path = strdup(SC_SERVER_PATH_DEFAULT);
     if (!server_path) {
         LOG_OOM();
         return NULL;
     }
 #else
-    char *server_path = sc_file_get_local_path(SC_SERVER_FILENAME);
+    server_path = sc_file_get_local_path(SC_SERVER_FILENAME);
     if (!server_path) {
         LOGE("Could not get local file path, "
              "using " SC_SERVER_FILENAME " from current directory");

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -485,14 +485,21 @@ sc_server_init(struct sc_server *server, const struct sc_server_params *params,
     // end of the program
     server->params = *params;
 
-    bool ok = sc_mutex_init(&server->mutex);
+    bool ok = sc_adb_init();
     if (!ok) {
+        return false;
+    }
+
+    ok = sc_mutex_init(&server->mutex);
+    if (!ok) {
+        sc_adb_destroy();
         return false;
     }
 
     ok = sc_cond_init(&server->cond_stopped);
     if (!ok) {
         sc_mutex_destroy(&server->mutex);
+        sc_adb_destroy();
         return false;
     }
 
@@ -500,6 +507,7 @@ sc_server_init(struct sc_server *server, const struct sc_server_params *params,
     if (!ok) {
         sc_cond_destroy(&server->cond_stopped);
         sc_mutex_destroy(&server->mutex);
+        sc_adb_destroy();
         return false;
     }
 
@@ -1141,4 +1149,6 @@ sc_server_destroy(struct sc_server *server) {
     sc_intr_destroy(&server->intr);
     sc_cond_destroy(&server->cond_stopped);
     sc_mutex_destroy(&server->mutex);
+
+    sc_adb_destroy();
 }

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -95,9 +95,14 @@ scrcpy_otg(struct scrcpy_options *options) {
     // On Windows, only one process could open a USB device
     // <https://github.com/Genymobile/scrcpy/issues/2773>
     LOGI("Killing adb server (if any)...");
-    unsigned flags = SC_ADB_NO_STDOUT | SC_ADB_NO_STDERR | SC_ADB_NO_LOGERR;
-    // uninterruptible (intr == NULL), but in practice it's very quick
-    sc_adb_kill_server(NULL, flags);
+    if (sc_adb_init()) {
+        unsigned flags = SC_ADB_NO_STDOUT | SC_ADB_NO_STDERR | SC_ADB_NO_LOGERR;
+        // uninterruptible (intr == NULL), but in practice it's very quick
+        sc_adb_kill_server(NULL, flags);
+        sc_adb_destroy();
+    } else {
+        LOGW("Could not call adb executable, adb server not killed");
+    }
 #endif
 
     static const struct sc_usb_callbacks cbs = {

--- a/app/src/util/env.c
+++ b/app/src/util/env.c
@@ -1,0 +1,29 @@
+#include "env.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include "util/str.h"
+
+char *
+sc_get_env(const char *varname) {
+#ifdef _WIN32
+    wchar_t *w_varname = sc_str_to_wchars(varname);
+    if (!w_varname) {
+         return NULL;
+    }
+    const wchar_t *value = _wgetenv(w_varname);
+    free(w_varname);
+    if (!value) {
+        return NULL;
+    }
+
+    return sc_str_from_wchars(value);
+#else
+    const char *value = getenv(varname);
+    if (!value) {
+        return NULL;
+    }
+
+    return strdup(value);
+#endif
+}

--- a/app/src/util/env.h
+++ b/app/src/util/env.h
@@ -1,0 +1,12 @@
+#ifndef SC_ENV_H
+#define SC_ENV_H
+
+#include "common.h"
+
+// Return the value of the environment variable (may be NULL).
+//
+// The returned value must be freed by the caller.
+char *
+sc_get_env(const char *varname);
+
+#endif

--- a/release/build_linux.sh
+++ b/release/build_linux.sh
@@ -36,8 +36,7 @@ ninja -C "$LINUX_BUILD_DIR"
 
 # Group intermediate outputs into a 'dist' directory
 mkdir -p "$LINUX_BUILD_DIR/dist"
-cp "$LINUX_BUILD_DIR"/app/scrcpy "$LINUX_BUILD_DIR/dist/scrcpy_bin"
+cp "$LINUX_BUILD_DIR"/app/scrcpy "$LINUX_BUILD_DIR/dist/"
 cp app/data/icon.png "$LINUX_BUILD_DIR/dist/"
-cp app/data/scrcpy_static_wrapper.sh "$LINUX_BUILD_DIR/dist/scrcpy"
 cp app/scrcpy.1 "$LINUX_BUILD_DIR/dist/"
 cp -r "$ADB_INSTALL_DIR"/. "$LINUX_BUILD_DIR/dist/"

--- a/release/build_macos.sh
+++ b/release/build_macos.sh
@@ -36,8 +36,7 @@ ninja -C "$MACOS_BUILD_DIR"
 
 # Group intermediate outputs into a 'dist' directory
 mkdir -p "$MACOS_BUILD_DIR/dist"
-cp "$MACOS_BUILD_DIR"/app/scrcpy "$MACOS_BUILD_DIR/dist/scrcpy_bin"
+cp "$MACOS_BUILD_DIR"/app/scrcpy "$MACOS_BUILD_DIR/dist/"
 cp app/data/icon.png "$MACOS_BUILD_DIR/dist/"
-cp app/data/scrcpy_static_wrapper.sh "$MACOS_BUILD_DIR/dist/scrcpy"
 cp app/scrcpy.1 "$MACOS_BUILD_DIR/dist/"
 cp -r "$ADB_INSTALL_DIR"/. "$MACOS_BUILD_DIR/dist/"


### PR DESCRIPTION
Implement the function to get the executable path on macOS, so that enabling `-Dportable=true` works on all platforms to find `scrcpy-server` and `icon.png` in the same directory as the executable.

@Genxster1998 I stole this from your branch. Thank you :wink:

Please review/test on macOS.