### PR TITLE
Improve cleanup reliability

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -10,6 +10,8 @@ import android.os.BatteryManager;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Handle the cleanup of scrcpy, even if the main process is killed.
@@ -107,16 +109,22 @@ public final class CleanUp {
 
     private void run(int displayId, int restoreStayOn, boolean disableShowTouches, boolean powerOffScreen, int restoreScreenOffTimeout)
             throws IOException {
-        String[] cmd = {
-                "app_process",
-                "/",
-                CleanUp.class.getName(),
-                String.valueOf(displayId),
-                String.valueOf(restoreStayOn),
-                String.valueOf(disableShowTouches),
-                String.valueOf(powerOffScreen),
-                String.valueOf(restoreScreenOffTimeout),
-        };
+
+        List<String> cmd = new ArrayList<>();
+        if (new File("/system/bin/setsid").exists()) {
+            cmd.add("/system/bin/setsid");
+        } else if (new File("/system/bin/nohup").exists()) {
+            cmd.add("/system/bin/nohup");
+        }
+
+        cmd.add("app_process");
+        cmd.add("/");
+        cmd.add(CleanUp.class.getName());
+        cmd.add(String.valueOf(displayId));
+        cmd.add(String.valueOf(restoreStayOn));
+        cmd.add(String.valueOf(disableShowTouches));
+        cmd.add(String.valueOf(powerOffScreen));
+        cmd.add(String.valueOf(restoreScreenOffTimeout));
 
         ProcessBuilder builder = new ProcessBuilder(cmd);
         builder.environment().put("CLASSPATH", Server.SERVER_PATH);


### PR DESCRIPTION
Currently, if scrcpy terminates before the cleanup process is started (race condition), e.g. due to an early error, the initial state is not restored. This can be easily reproduced by forcing scrcpy to fail:

```bash
scrcpy --show-touches --video-encoder=fail
```

In addition, starting the cleanup process with `setsid` or `nohup` reduces the likelihood of it being killed along with the scrcpy server process on some devices (but not all).

Refs #5601.

Here is a binary to replace in scrcpy 3.0.2:

- [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/5613/1/scrcpy-server) <sub>`SHA-256: e925077940dbe82ab8375aca06bf471d88a7c775096b6747eac810f074481b9`</sub>