### PR TITLE
Inject main display events to the original display

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -124,23 +124,9 @@ public class ScreenCapture extends SurfaceCapture {
             inputSize = videoSize;
         }
 
-        int virtualDisplayId;
-        PositionMapper positionMapper;
         try {
             virtualDisplay = ServiceManager.getDisplayManager()
                     .createVirtualDisplay("scrcpy", inputSize.getWidth(), inputSize.getHeight(), displayId, surface);
-
-
-            if (displayId == 0) {
-                // Main display: send all events to the original display, relative to the device size
-                Size deviceSize = displayInfo.getSize();
-                positionMapper = PositionMapper.create(videoSize, transform, deviceSize);
-                virtualDisplayId = 0;
-            } else {
-                // The positions are relative to the virtual display, not the original display (so use inputSize, not deviceSize!)
-                positionMapper = PositionMapper.create(videoSize, transform, inputSize);
-                virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
-            }
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
             try {
@@ -148,11 +134,7 @@ public class ScreenCapture extends SurfaceCapture {
 
                 Size deviceSize = displayInfo.getSize();
                 int layerStack = displayInfo.getLayerStack();
-
                 setDisplaySurface(display, surface, deviceSize.toRect(), inputSize.toRect(), layerStack);
-                virtualDisplayId = displayId;
-
-                positionMapper = PositionMapper.create(videoSize, transform, deviceSize);
                 Ln.d("Display: using SurfaceControl API");
             } catch (Exception surfaceControlException) {
                 Ln.e("Could not create display using DisplayManager", displayManagerException);
@@ -162,6 +144,18 @@ public class ScreenCapture extends SurfaceCapture {
         }
 
         if (vdListener != null) {
+            int virtualDisplayId;
+            PositionMapper positionMapper;
+            if (virtualDisplay == null || displayId == 0) {
+                // Surface control or main display: send all events to the original display, relative to the device size
+                Size deviceSize = displayInfo.getSize();
+                positionMapper = PositionMapper.create(videoSize, transform, deviceSize);
+                virtualDisplayId = displayId;
+            } else {
+                // The positions are relative to the virtual display, not the original display (so use inputSize, not deviceSize!)
+                positionMapper = PositionMapper.create(videoSize, transform, inputSize);
+                virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
+            }
             vdListener.onNewVirtualDisplay(virtualDisplayId, positionMapper);
         }
     }

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -129,10 +129,18 @@ public class ScreenCapture extends SurfaceCapture {
         try {
             virtualDisplay = ServiceManager.getDisplayManager()
                     .createVirtualDisplay("scrcpy", inputSize.getWidth(), inputSize.getHeight(), displayId, surface);
-            virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
 
-            // The positions are relative to the virtual display, not the original display (so use inputSize, not deviceSize!)
-            positionMapper = PositionMapper.create(videoSize, transform, inputSize);
+
+            if (displayId == 0) {
+                // Main display: send all events to the original display, relative to the device size
+                Size deviceSize = displayInfo.getSize();
+                positionMapper = PositionMapper.create(videoSize, transform, deviceSize);
+                virtualDisplayId = 0;
+            } else {
+                // The positions are relative to the virtual display, not the original display (so use inputSize, not deviceSize!)
+                positionMapper = PositionMapper.create(videoSize, transform, inputSize);
+                virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
+            }
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
             try {


### PR DESCRIPTION
When mirroring a secondary display, touch and scroll events must be sent to the mirroring virtual display id (with coordinates relative to the virtual display size), rather than to the original display (with coordinates relative to the original display size). (see #4598 #5137)

This behavior, introduced by d19396718ee0c0ba7fb578f595a6553c0458da59 (#5370), was also applied for the main display for consistency. However, it has been found to cause some UI elements to become unclickable.
    
To minimize inconveniences, restore the previous behavior when mirroring the main display: send all events to the original display id (0) with coordinates relative to the original display size.

Fixes #5545
Fixes #5605

Here is a binary to replace in scrcpy 3.0.2:

- [`scrcpy-server`](https://tmp.rom1v.com/scrcpy/5614/1/scrcpy-server) <sub>`SHA-256: 350f96085b68f1bf5fd33cbf521ecec0c1b697048728a55d5ca402ab804a48b`</sub>