### PR TITLE
Add --no-vd-destroy-content

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -57,6 +57,7 @@ _scrcpy() {
         --no-mipmaps
         --no-mouse-hover
         --no-power-on
+        --no-vd-destroy-content
         --no-vd-system-decorations
         --no-video
         --no-video-playback

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -63,6 +63,7 @@ arguments=(
     '--no-mipmaps[Disable the generation of mipmaps]'
     '--no-mouse-hover[Do not forward mouse hover events]'
     '--no-power-on[Do not power on the device on start]'
+    '--no-vd-destroy-content[Disable virtual display "destroy content on removal" flag]'
     '--no-vd-system-decorations[Disable virtual display system decorations flag]'
     '--no-video[Disable video forwarding]'
     '--no-video-playback[Disable video playback]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -370,6 +370,12 @@ Do not forward mouse hover (mouse motion without any clicks) events.
 Do not power on the device on start.
 
 .TP
+.B \-\-no\-vd\-destroy\-content
+Disable virtual display "destroy content on removal" flag.
+
+With this option, when the virtual display is closed, the running apps are moved to the main display rather than being destroyed.
+
+.TP
 .B \-\-no\-vd\-system\-decorations
 Disable virtual display system decorations flag.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -2706,7 +2706,7 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 opts->angle = optarg;
                 break;
             case OPT_NO_VD_SYSTEM_DECORATIONS:
-                opts->vd_system_decorations = optarg;
+                opts->vd_system_decorations = false;
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -110,6 +110,7 @@ enum {
     OPT_CAPTURE_ORIENTATION,
     OPT_ANGLE,
     OPT_NO_VD_SYSTEM_DECORATIONS,
+    OPT_NO_VD_DESTROY_CONTENT,
 };
 
 struct sc_option {
@@ -658,6 +659,15 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_NO_POWER_ON,
         .longopt = "no-power-on",
         .text = "Do not power on the device on start.",
+    },
+    {
+        .longopt_id = OPT_NO_VD_DESTROY_CONTENT,
+        .longopt = "no-vd-destroy-content",
+        .text = "Disable virtual display \"destroy content on removal\" "
+                "flag.\n"
+                "With this option, when the virtual display is closed, the "
+                "running apps are moved to the main display rather than being "
+                "destroyed.",
     },
     {
         .longopt_id = OPT_NO_VD_SYSTEM_DECORATIONS,
@@ -2704,6 +2714,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_ANGLE:
                 opts->angle = optarg;
+                break;
+            case OPT_NO_VD_DESTROY_CONTENT:
+                opts->vd_destroy_content = false;
                 break;
             case OPT_NO_VD_SYSTEM_DECORATIONS:
                 opts->vd_system_decorations = false;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -108,6 +108,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .new_display = NULL,
     .start_app = NULL,
     .angle = NULL,
+    .vd_destroy_content = true,
     .vd_system_decorations = true,
 };
 

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -310,6 +310,7 @@ struct scrcpy_options {
     bool audio_dup;
     const char *new_display; // [<width>x<height>][/<dpi>] parsed by the server
     const char *start_app;
+    bool vd_destroy_content;
     bool vd_system_decorations;
 };
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -458,6 +458,7 @@ scrcpy(struct scrcpy_options *options) {
         .power_on = options->power_on,
         .kill_adb_on_close = options->kill_adb_on_close,
         .camera_high_speed = options->camera_high_speed,
+        .vd_destroy_content = options->vd_destroy_content,
         .vd_system_decorations = options->vd_system_decorations,
         .list = options->list,
     };

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -377,6 +377,9 @@ execute_server(struct sc_server *server,
         VALIDATE_STRING(params->new_display);
         ADD_PARAM("new_display=%s", params->new_display);
     }
+    if (!params->vd_destroy_content) {
+        ADD_PARAM("vd_destroy_content=false");
+    }
     if (!params->vd_system_decorations) {
         ADD_PARAM("vd_system_decorations=false");
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -69,6 +69,7 @@ struct sc_server_params {
     bool power_on;
     bool kill_adb_on_close;
     bool camera_high_speed;
+    bool vd_destroy_content;
     bool vd_system_decorations;
     uint8_t list;
 };

--- a/doc/virtual_display.md
+++ b/doc/virtual_display.md
@@ -50,3 +50,14 @@ any default launcher UI available in virtual displays.
 
 Note that if no app is started, no content will be rendered, so no video frame
 will be produced at all.
+
+
+## Destroy on close
+
+By default, when the virtual display is closed, the running apps are destroyed.
+
+To move them to the main display instead, use:
+
+```
+scrcpy --new-display --no-vd-destroy-content
+```

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -60,6 +60,7 @@ public class Options {
     private boolean powerOn = true;
 
     private NewDisplay newDisplay;
+    private boolean vdDestroyContent = true;
     private boolean vdSystemDecorations = true;
 
     private Orientation.Lock captureOrientationLock = Orientation.Lock.Unlocked;
@@ -231,6 +232,10 @@ public class Options {
 
     public Orientation.Lock getCaptureOrientationLock() {
         return captureOrientationLock;
+    }
+
+    public boolean getVDDestroyContent() {
+        return vdDestroyContent;
     }
 
     public boolean getVDSystemDecorations() {
@@ -465,6 +470,9 @@ public class Options {
                     break;
                 case "new_display":
                     options.newDisplay = parseNewDisplay(value);
+                    break;
+                case "vd_destroy_content":
+                    options.vdDestroyContent = Boolean.parseBoolean(value);
                     break;
                 case "vd_system_decorations":
                     options.vdSystemDecorations = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -53,6 +53,7 @@ public class NewDisplayCapture extends SurfaceCapture {
     private final boolean captureOrientationLocked;
     private final Orientation captureOrientation;
     private final float angle;
+    private final boolean vdDestroyContent;
     private final boolean vdSystemDecorations;
 
     private VirtualDisplay virtualDisplay;
@@ -73,6 +74,7 @@ public class NewDisplayCapture extends SurfaceCapture {
         this.captureOrientation = options.getCaptureOrientation();
         assert captureOrientation != null;
         this.angle = options.getAngle();
+        this.vdDestroyContent = options.getVDDestroyContent();
         this.vdSystemDecorations = options.getVDSystemDecorations();
     }
 
@@ -167,8 +169,10 @@ public class NewDisplayCapture extends SurfaceCapture {
             int flags = VIRTUAL_DISPLAY_FLAG_PUBLIC
                     | VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY
                     | VIRTUAL_DISPLAY_FLAG_SUPPORTS_TOUCH
-                    | VIRTUAL_DISPLAY_FLAG_ROTATES_WITH_CONTENT
-                    | VIRTUAL_DISPLAY_FLAG_DESTROY_CONTENT_ON_REMOVAL;
+                    | VIRTUAL_DISPLAY_FLAG_ROTATES_WITH_CONTENT;
+            if (vdDestroyContent) {
+                flags |= VIRTUAL_DISPLAY_FLAG_DESTROY_CONTENT_ON_REMOVAL;
+            }
             if (vdSystemDecorations) {
                 flags |= VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS;
             }


### PR DESCRIPTION
Add an option to disable the following flag for virtual displays:

    DisplayManager.VIRTUAL_DISPLAY_FLAG_DESTROY_CONTENT_ON_REMOVAL
   
With this option, when the virtual display is closd, the running apps are moved to the main display rather than being destroyed.