### PR TITLE
Add AV1 decoder in release builds

### DIFF
--- a/app/deps/dav1d.sh
+++ b/app/deps/dav1d.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -ex
+DEPS_DIR=$(dirname ${BASH_SOURCE[0]})
+cd "$DEPS_DIR"
+. common
+process_args "$@"
+
+VERSION=1.5.0
+FILENAME=dav1d-$VERSION.tar.gz
+PROJECT_DIR=dav1d-$VERSION
+SHA256SUM=78b15d9954b513ea92d27f39362535ded2243e1b0924fde39f37a31ebed5f76b
+
+cd "$SOURCES_DIR"
+
+if [[ -d "$PROJECT_DIR" ]]
+then
+    echo "$PWD/$PROJECT_DIR" found
+else
+    get_file "https://code.videolan.org/videolan/dav1d/-/archive/$VERSION/$FILENAME" "$FILENAME" "$SHA256SUM"
+    tar xf "$FILENAME"  # First level directory is "$PROJECT_DIR"
+fi
+
+mkdir -p "$BUILD_DIR/$PROJECT_DIR"
+cd "$BUILD_DIR/$PROJECT_DIR"
+
+if [[ -d "$DIRNAME" ]]
+then
+    echo "'$PWD/$DIRNAME' already exists, not reconfigured"
+    cd "$DIRNAME"
+else
+    mkdir "$DIRNAME"
+    cd "$DIRNAME"
+
+    conf=(
+        --prefix="$INSTALL_DIR/$DIRNAME"
+        --libdir=lib
+        -Denable_tests=false
+        -Denable_tools=false
+        # Always build dav1d statically
+        --default-library=static
+    )
+
+    if [[ "$BUILD_TYPE" == cross ]]
+    then
+        case "$HOST" in
+            win32)
+                conf+=(
+                    --cross-file="$SOURCES_DIR/$PROJECT_DIR/package/crossfiles/i686-w64-mingw32.meson"
+                )
+                ;;
+
+            win64)
+                conf+=(
+                    --cross-file="$SOURCES_DIR/$PROJECT_DIR/package/crossfiles/x86_64-w64-mingw32.meson"
+                )
+                ;;
+
+            *)
+                echo "Unsupported host: $HOST" >&2
+                exit 1
+        esac
+    fi
+
+    meson setup . "$SOURCES_DIR/$PROJECT_DIR" "${conf[@]}"
+fi
+
+ninja
+ninja install

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -40,11 +40,6 @@ else
         export LDFLAGS='-static-libgcc -static'
     elif [[ "$HOST" == "macos" ]]
     then
-        export LDFLAGS="$LDFLAGS -L/opt/homebrew/opt/zlib/lib"
-        export CPPFLAGS="$CPPFLAGS -I/opt/homebrew/opt/zlib/include"
-
-        export LDFLAGS="$LDFLAGS-L/opt/homebrew/opt/libiconv/lib"
-        export CPPFLAGS="$CPPFLAGS -I/opt/homebrew/opt/libiconv/include"
         export PKG_CONFIG_PATH="/opt/homebrew/opt/zlib/lib/pkgconfig"
     fi
 

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -43,8 +43,11 @@ else
         export PKG_CONFIG_PATH="/opt/homebrew/opt/zlib/lib/pkgconfig"
     fi
 
+    export PKG_CONFIG_PATH="$INSTALL_DIR/$DIRNAME/lib/pkgconfig:$PKG_CONFIG_PATH"
+
     conf=(
         --prefix="$INSTALL_DIR/$DIRNAME"
+        --pkg-config-flags="--static"
         --extra-cflags="-O2 -fPIC"
         --disable-programs
         --disable-doc
@@ -57,9 +60,11 @@ else
         --disable-vaapi
         --disable-vdpau
         --enable-swresample
+        --enable-libdav1d
         --enable-decoder=h264
         --enable-decoder=hevc
         --enable-decoder=av1
+        --enable-decoder=libdav1d
         --enable-decoder=pcm_s16le
         --enable-decoder=opus
         --enable-decoder=aac

--- a/release/build_linux.sh
+++ b/release/build_linux.sh
@@ -15,6 +15,7 @@ LINUX_BUILD_DIR="$WORK_DIR/build-linux-$ARCH"
 
 app/deps/adb_linux.sh
 app/deps/sdl.sh linux native static
+app/deps/dav1d.sh linux native static
 app/deps/ffmpeg.sh linux native static
 app/deps/libusb.sh linux native static
 

--- a/release/build_macos.sh
+++ b/release/build_macos.sh
@@ -15,6 +15,7 @@ MACOS_BUILD_DIR="$WORK_DIR/build-macos-$ARCH"
 
 app/deps/adb_macos.sh
 app/deps/sdl.sh macos native static
+app/deps/dav1d.sh macos native static
 app/deps/ffmpeg.sh macos native static
 app/deps/libusb.sh macos native static
 

--- a/release/build_windows.sh
+++ b/release/build_windows.sh
@@ -22,6 +22,7 @@ WINXX_BUILD_DIR="$WORK_DIR/build-$WINXX"
 
 app/deps/adb_windows.sh
 app/deps/sdl.sh $WINXX cross shared
+app/deps/dav1d.sh $WINXX cross shared
 app/deps/ffmpeg.sh $WINXX cross shared
 app/deps/libusb.sh $WINXX cross shared
 


### PR DESCRIPTION
Recent devices have an AV1 encoder (and it works quite well).

On Linux, when building using system libraries, it was already working. But no AV1 decoder was included in release builds.

This PR adds [dav1d](https://www.videolan.org/projects/dav1d.html) support to decode AV1 streams.

With my Pixel 8, I can run:

```
scrcpy --video-codec=av1
```

I only tested on Linux. Please test on Windows and macOS.

Fixes #4744

---

Note: @muvaf, could you please check the first commit `Remove broken macOS flags` related to https://github.com/Genymobile/scrcpy/pull/5517#issuecomment-2495522201.

---

Binaries:
- [`scrcpy-linux-x86_64-dav1d.tar.gz`](https://tmp.rom1v.com/scrcpy/5644/1/scrcpy-linux-x86_64-dav1d.tar.gz) <sub>`SHA-256: aaf74723c8a93705937c0461d1cc4fbf6af411ac9f40502c0ddeea00f5a4403`</sub>
- [`scrcpy-win64-dav1d.zip`](https://tmp.rom1v.com/scrcpy/5644/1/scrcpy-win64-dav1d.zip) <sub>`SHA-256: c413db1271e29695561168ee43723ac082369043f85e8dc0b3ce6e4c6fd12d5`</sub>
- [`scrcpy-macos-aarch64-dav1d.tar.gz`](https://tmp.rom1v.com/scrcpy/5644/1/scrcpy-macos-aarch64-dav1d.tar.gz) <sub>`SHA-256: 103f95ce4c6e01f51b5135a668334215d8182569b1c1022c2892e523dff8005`</sub>
- [`scrcpy-macos-x86_64-dav1d.tar.gz`](https://tmp.rom1v.com/scrcpy/5644/1/scrcpy-macos-x86_64-dav1d.tar.gz) <sub>`SHA-256: 56b86436afed29a2786c1d4d238830209b691fce69a95ffaeb89c316426a191`</sub>