### PR TITLE
Set icon and server env paths for meson devenv

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -279,3 +279,9 @@ if get_option('buildtype') == 'debug'
         test(t[0], exe)
     endforeach
 endif
+
+if meson.version().version_compare('>= 0.58.0')
+       devenv = environment()
+       devenv.set('SCRCPY_ICON_PATH', join_paths(meson.current_source_dir(), 'data/icon.png'))
+       meson.add_devenv(devenv)
+endif

--- a/server/meson.build
+++ b/server/meson.build
@@ -23,3 +23,9 @@ else
                   install: true,
                   install_dir: 'share/scrcpy')
 endif
+
+if meson.version().version_compare('>= 0.58.0')
+       devenv = environment()
+       devenv.set('SCRCPY_SERVER_PATH', join_paths(meson.current_build_dir(), 'scrcpy-server'))
+       meson.add_devenv(devenv)
+endif


### PR DESCRIPTION
This allows users to compile and run the project without root.

```sh
meson setup x
meson compile -C x
meson devenv -C x
scrcpy
```