### PR TITLE
Get camera list from camera service directly

### DIFF
--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -57,6 +57,7 @@ cd "$SERVER_DIR/src/main/aidl"
 # Fake sources to expose hidden Android types to the project
 FAKE_SRC=( \
     android/content/*java \
+    android/hardware/*java \
 )
 
 SRC=( \

--- a/server/src/main/java/android/hardware/ICameraServiceListener.java
+++ b/server/src/main/java/android/hardware/ICameraServiceListener.java
@@ -1,0 +1,14 @@
+package android.hardware;
+
+import android.os.IBinder;
+
+public interface ICameraServiceListener {
+    int STATUS_NOT_PRESENT = 0;
+    int STATUS_ENUMERATING = 2;
+
+    class Default implements ICameraServiceListener {
+        public IBinder asBinder() {
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/CameraService.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/CameraService.java
@@ -1,0 +1,110 @@
+package com.genymobile.scrcpy.wrappers;
+
+import android.annotation.SuppressLint;
+import android.hardware.ICameraServiceListener;
+import android.os.Binder;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.util.Log;
+
+import com.genymobile.scrcpy.util.Ln;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CameraService {
+    private final IInterface service;
+
+    private Method addListenerMethod;
+    private Method removeListenerMethod;
+
+    public CameraService(IInterface service) {
+        this.service = service;
+    }
+
+    private Method getAddListenerMethod() throws NoSuchMethodException {
+        if (addListenerMethod == null) {
+            addListenerMethod = service.getClass().getDeclaredMethod("addListener", ICameraServiceListener.class);
+        }
+        return addListenerMethod;
+    }
+
+    public CameraStatus[] addListener(ICameraServiceListener listener) {
+        try {
+            Object[] rawStatuses = (Object[]) getAddListenerMethod().invoke(service, listener);
+            if (rawStatuses == null) {
+                return null;
+            }
+            CameraStatus[] cameraStatuses = new CameraStatus[rawStatuses.length];
+            for (int i = 0; i < rawStatuses.length; i++) {
+                cameraStatuses[i] = new CameraStatus(rawStatuses[i]);
+            }
+            return cameraStatuses;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Method getRemoveListenerMethod() throws NoSuchMethodException {
+        if (removeListenerMethod == null) {
+            removeListenerMethod = service.getClass().getDeclaredMethod("removeListener", ICameraServiceListener.class);
+        }
+        return removeListenerMethod;
+    }
+
+    public void removeListener(ICameraServiceListener listener) {
+        try {
+            getRemoveListenerMethod().invoke(service, listener);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // Simulate `CameraManager.getCameraIdList()`
+    // <https://android.googlesource.com/platform/frameworks/base/+/af274a1b252752b385bceb14f1f88e361e2c91e5/core/java/android/hardware/camera2/CameraManager.java#2351>
+    public String[] getCameraIdList() {
+        Binder binder = new Binder() {
+            @Override
+            protected boolean onTransact(int code, Parcel data, Parcel reply, int flags) {
+                return true;
+            }
+        };
+        ICameraServiceListener listener = new ICameraServiceListener.Default() {
+            // To immune from future changes to `ICameraServiceListener`,
+            // we use an empty `Binder` that ignores all transactions.
+            @Override
+            public IBinder asBinder() {
+                return binder;
+            }
+        };
+
+        CameraStatus[] cameraStatuses = addListener(listener);
+        removeListener(listener);
+
+        if (cameraStatuses == null) {
+            return null;
+        }
+
+        List<String> cameraIds = new ArrayList<>();
+        for (CameraStatus cameraStatus : cameraStatuses) {
+            if (cameraStatus.status != ICameraServiceListener.STATUS_NOT_PRESENT && cameraStatus.status != ICameraServiceListener.STATUS_ENUMERATING) {
+                cameraIds.add(cameraStatus.cameraId);
+            }
+        }
+
+        return cameraIds.toArray(new String[0]);
+    }
+
+    @SuppressLint({"SoonBlockedPrivateApi", "PrivateApi"})
+    public static class CameraStatus {
+        public int status;
+        public String cameraId;
+
+        public CameraStatus(Object raw) throws NoSuchFieldException, IllegalAccessException {
+            status = raw.getClass().getDeclaredField("status").getInt(raw);
+            cameraId = (String) raw.getClass().getDeclaredField("cameraId").get(raw);
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
@@ -31,6 +31,7 @@ public final class ServiceManager {
     private static StatusBarManager statusBarManager;
     private static ClipboardManager clipboardManager;
     private static ActivityManager activityManager;
+    private static CameraService cameraService;
     private static CameraManager cameraManager;
 
     private ServiceManager() {
@@ -95,6 +96,18 @@ public final class ServiceManager {
             activityManager = ActivityManager.create();
         }
         return activityManager;
+    }
+
+    public static CameraService getCameraService() {
+        if (cameraService == null) {
+            try {
+                IInterface camera = getService("media.camera", "android.hardware.ICameraService");
+                cameraService = new CameraService(camera);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+        return cameraService;
     }
 
     public static CameraManager getCameraManager() {


### PR DESCRIPTION
This is a cleaned-up version of https://github.com/Genymobile/scrcpy/issues/4392#issuecomment-1807165007.

I'm using similar code in my project to enumerate cameras, then use Scrcpy to mirror them, but recently 2337f524d167e210a2985d691e5695e5b7e3249f broke this usage.

I think it should rather list and accept non-functional camera IDs, than rejecting functional ones.

This doesn't include the code to handle logical vs. physical cameras.