### PR TITLE
fall back to dumpsys output when we can't get the display info

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -116,7 +116,12 @@ public final class DisplayManager {
 
     public DisplayInfo getDisplayInfo(int displayId) {
         try {
-            Object displayInfo = manager.getClass().getMethod("getDisplayInfo", int.class).invoke(manager, displayId);
+            Object displayInfo = null;
+            try {
+                displayInfo = manager.getClass().getMethod("getDisplayInfo", int.class).invoke(manager, displayId);
+            } catch (Exception e) {
+                // do nothing and continue to the fallback
+            }
             if (displayInfo == null) {
                 // fallback when displayInfo is null
                 return getDisplayInfoFromDumpsysDisplay(displayId);


### PR DESCRIPTION
Sometimes `getDisplayInfo` will throw an `NullPointerException` and scrcpy will exit. However, after falling back to the dumpsys implementation we did not observe this anymore. 