### PR TITLE
allow requesting IDR frames through the control channel

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -188,7 +188,7 @@
       identification within third-party archives.
 
    Copyright (C) 2018 Genymobile
-   Copyright (C) 2018-2024 Romain Vimont
+   Copyright (C) 2018-2025 Romain Vimont
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ work][donate]:
 ## Licence
 
     Copyright (C) 2018 Genymobile
-    Copyright (C) 2018-2024 Romain Vimont
+    Copyright (C) 2018-2025 Romain Vimont
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ Note that USB debugging is not required to run scrcpy in [OTG mode](doc/otg.md).
  - [macOS](doc/macos.md)
 
 
+## Must-know tips
+
+ - [Reducing resolution](doc/video.md#size) may greatly improve performance
+   (`scrcpy -m1024`)
+ - [_Right-click_](doc/mouse.md#mouse-bindings) triggers `BACK`
+ - [_Middle-click_](doc/mouse.md#mouse-bindings) triggers `HOME`
+ - <kbd>Alt</kbd>+<kbd>f</kbd> toggles [fullscreen](doc/window.md#fullscreen)
+ - There are many other [shortcuts](doc/shortcuts.md)
+
+
 ## Usage examples
 
 There are a lot of options, [documented](#user-documentation) in separate pages.

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -829,7 +829,7 @@ Report bugs to <https://github.com/Genymobile/scrcpy/issues>.
 .SH COPYRIGHT
 Copyright \(co 2018 Genymobile <https://www.genymobile.com>
 
-Copyright \(co 2018\-2024 Romain Vimont <rom@rom1v.com>
+Copyright \(co 2018\-2025 Romain Vimont <rom@rom1v.com>
 
 Licensed under the Apache License, Version 2.0.
 

--- a/doc/connection.md
+++ b/doc/connection.md
@@ -113,16 +113,17 @@ with the device IP address you found)_.
 7. Run `scrcpy` as usual.
 8. Run `adb disconnect` once you're done.
 
-Since Android 11, a [wireless debugging option][adb-wireless] allows to bypass
-having to physically connect your device directly to your computer.
+Since Android 11, a [wireless debugging option][adb-wireless] allows you to
+bypass having to physically connect your device to your computer.
 
 [adb-wireless]: https://developer.android.com/studio/command-line/adb#wireless-android11-command-line
 
 
 ## Autostart
 
-A small tool (by the scrcpy author) allows to run arbitrary commands whenever a
-new Android device is connected: [AutoAdb]. It can be used to start scrcpy:
+A small tool (by the scrcpy author) allows you to run arbitrary commands
+whenever a new Android device is connected: [AutoAdb]. It can be used to start
+scrcpy:
 
 ```bash
 autoadb scrcpy -s '{}'

--- a/doc/device.md
+++ b/doc/device.md
@@ -34,6 +34,31 @@ adb shell settings put global stay_on_while_plugged_in 0
 ```
 
 
+## Screen off timeout
+
+The Android screen automatically turns off after some delay.
+
+To change this delay while scrcpy is running:
+
+```bash
+scrcpy --screen-off-timeout=300  # 300 seconds (5 minutes)
+```
+
+The initial value is restored on exit.
+
+It is possible to change this setting manually:
+
+```bash
+# get the current screen_off_timeout value
+adb shell settings get system screen_off_timeout
+# set a new value (in milliseconds)
+adb shell settings put system screen_off_timeout 30000
+```
+
+Note that the Android value is in milliseconds, but the scrcpy command line
+argument is in seconds.
+
+
 ## Turn screen off
 
 It is possible to turn the device screen off while mirroring on start with a
@@ -69,31 +94,6 @@ adb shell cmd display power-off 0
 # turn screen on
 adb shell cmd display power-on 0
 ```
-
-
-## Screen off timeout
-
-The Android screen automatically turns off after some delay.
-
-To change this delay while scrcpy is running:
-
-```bash
-scrcpy --screen-off-timeout=300  # 300 seconds (5 minutes)
-```
-
-The initial value is restored on exit.
-
-It is possible to change this setting manually:
-
-```bash
-# get the current screen_off_timeout value
-adb shell settings get system screen_off_timeout
-# set a new value (in milliseconds)
-adb shell settings put system screen_off_timeout 30000
-```
-
-Note that the Android value is in milliseconds, but the scrcpy command line
-argument is in seconds.
 
 
 ## Show touches

--- a/doc/mouse.md
+++ b/doc/mouse.md
@@ -83,9 +83,9 @@ process like the _adb daemon_).
 ## Mouse bindings
 
 By default, with SDK mouse:
- - right-click triggers BACK (or POWER on)
- - middle-click triggers HOME
- - the 4th click triggers APP_SWITCH
+ - right-click triggers `BACK` (or `POWER` on)
+ - middle-click triggers `HOME`
+ - the 4th click triggers `APP_SWITCH`
  - the 5th click expands the notification panel
 
 The secondary clicks may be forwarded to the device instead by pressing the
@@ -121,9 +121,9 @@ Each character must be one of the following:
 
  - `+`: forward the click to the device
  - `-`: ignore the click
- - `b`: trigger shortcut BACK (or turn screen on if off)
- - `h`: trigger shortcut HOME
- - `s`: trigger shortcut APP_SWITCH
+ - `b`: trigger shortcut `BACK` (or turn screen on if off)
+ - `h`: trigger shortcut `HOME`
+ - `s`: trigger shortcut `APP_SWITCH`
  - `n`: trigger shortcut "expand notification panel"
 
 For example:

--- a/doc/virtual_display.md
+++ b/doc/virtual_display.md
@@ -11,6 +11,8 @@ scrcpy --new-display         # use the main display size and density
 scrcpy --new-display=/240    # use the main display size and 240 dpi
 ```
 
+The new virtual display is destroyed on exit.
+
 ## Start app
 
 On some devices, a launcher is available in the virtual display.

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -20,6 +20,12 @@ and extract it.
 
 ### From a package manager
 
+From [WinGet] (ADB and other dependencies will be installed alongside scrcpy):
+
+```bash
+winget install --exact Genymobile.scrcpy
+```
+
 From [Chocolatey]:
 
 ```bash
@@ -29,12 +35,12 @@ choco install adb    # if you don't have it yet
 
 From [Scoop]:
 
-
 ```bash
 scoop install scrcpy
 scoop install adb    # if you don't have it yet
 ```
 
+[WinGet]: https://github.com/microsoft/winget-cli
 [Chocolatey]: https://chocolatey.org/
 [Scoop]: https://scoop.sh
 

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -156,6 +156,7 @@ public final class Server {
 
                 if (controller != null) {
                     controller.setSurfaceCapture(surfaceCapture);
+                    controller.setSurfaceEncoder(surfaceEncoder);
                 }
             }
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
@@ -25,6 +25,7 @@ public final class ControlMessage {
     public static final int TYPE_OPEN_HARD_KEYBOARD_SETTINGS = 15;
     public static final int TYPE_START_APP = 16;
     public static final int TYPE_RESET_VIDEO = 17;
+    public static final int TYPE_REQUEST_IDR = 18;
 
     public static final long SEQUENCE_INVALID = 0;
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
@@ -56,6 +56,8 @@ public class ControlMessageReader {
                 return parseUhidDestroy();
             case ControlMessage.TYPE_START_APP:
                 return parseStartApp();
+            case ControlMessage.TYPE_REQUEST_IDR:
+                return ControlMessage.createEmpty(type);
             default:
                 throw new ControlProtocolException("Unknown event type: " + type);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -12,6 +12,7 @@ import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.SurfaceCapture;
+import com.genymobile.scrcpy.video.SurfaceEncoder;
 import com.genymobile.scrcpy.video.VirtualDisplayListener;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.InputManager;
@@ -99,6 +100,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     // Used for resetting video encoding on RESET_VIDEO message
     private SurfaceCapture surfaceCapture;
+    private SurfaceEncoder surfaceEncoder;
 
     public Controller(ControlChannel controlChannel, CleanUp cleanUp, Options options) {
         this.displayId = options.getDisplayId();
@@ -152,6 +154,10 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     public void setSurfaceCapture(SurfaceCapture surfaceCapture) {
         this.surfaceCapture = surfaceCapture;
+    }
+
+    public void setSurfaceEncoder(SurfaceEncoder surfaceEncoder) {
+        this.surfaceEncoder = surfaceEncoder;
     }
 
     private UhidManager getUhidManager() {
@@ -306,6 +312,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 break;
             case ControlMessage.TYPE_RESET_VIDEO:
                 resetVideo();
+                break;
+            case ControlMessage.TYPE_REQUEST_IDR:
+                requestIdr();
                 break;
             default:
                 // do nothing
@@ -726,6 +735,13 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
         if (surfaceCapture != null) {
             Ln.i("Video capture reset");
             surfaceCapture.requestInvalidate();
+        }
+    }
+
+    public void requestIdr() {
+        if (surfaceEncoder != null) {
+            Ln.i("Requesting IDR");
+            surfaceEncoder.requestIdr();
         }
     }
 }


### PR DESCRIPTION
I am using scrcpy server to capture the screen and then broadcast the stream to multiple web clients. Todo so i need an new IDR frame whenever a new client connects.