### PR TITLE
allow requesting IDR frames through the control channel

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -156,6 +156,7 @@ public final class Server {
 
                 if (controller != null) {
                     controller.setSurfaceCapture(surfaceCapture);
+                    controller.setSurfaceEncoder(surfaceEncoder);
                 }
             }
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
@@ -25,6 +25,7 @@ public final class ControlMessage {
     public static final int TYPE_OPEN_HARD_KEYBOARD_SETTINGS = 15;
     public static final int TYPE_START_APP = 16;
     public static final int TYPE_RESET_VIDEO = 17;
+    public static final int TYPE_REQUEST_IDR = 18;
 
     public static final long SEQUENCE_INVALID = 0;
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
@@ -56,6 +56,8 @@ public class ControlMessageReader {
                 return parseUhidDestroy();
             case ControlMessage.TYPE_START_APP:
                 return parseStartApp();
+            case ControlMessage.TYPE_REQUEST_IDR:
+                return ControlMessage.createEmpty(type);
             default:
                 throw new ControlProtocolException("Unknown event type: " + type);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -12,6 +12,7 @@ import com.genymobile.scrcpy.device.Size;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.SurfaceCapture;
+import com.genymobile.scrcpy.video.SurfaceEncoder;
 import com.genymobile.scrcpy.video.VirtualDisplayListener;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.InputManager;
@@ -99,6 +100,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     // Used for resetting video encoding on RESET_VIDEO message
     private SurfaceCapture surfaceCapture;
+    private SurfaceEncoder surfaceEncoder;
 
     public Controller(ControlChannel controlChannel, CleanUp cleanUp, Options options) {
         this.displayId = options.getDisplayId();
@@ -152,6 +154,10 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     public void setSurfaceCapture(SurfaceCapture surfaceCapture) {
         this.surfaceCapture = surfaceCapture;
+    }
+
+    public void setSurfaceEncoder(SurfaceEncoder surfaceEncoder) {
+        this.surfaceEncoder = surfaceEncoder;
     }
 
     private UhidManager getUhidManager() {
@@ -306,6 +312,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 break;
             case ControlMessage.TYPE_RESET_VIDEO:
                 resetVideo();
+                break;
+            case ControlMessage.TYPE_REQUEST_IDR:
+                requestIdr();
                 break;
             default:
                 // do nothing
@@ -726,6 +735,13 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
         if (surfaceCapture != null) {
             Ln.i("Video capture reset");
             surfaceCapture.requestInvalidate();
+        }
+    }
+
+    public void requestIdr() {
+        if (surfaceEncoder != null) {
+            Ln.i("Requesting IDR");
+            surfaceEncoder.requestIdr();
         }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/CaptureIdr.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CaptureIdr.java
@@ -1,0 +1,21 @@
+package com.genymobile.scrcpy.video;
+
+import android.media.MediaCodec;
+import android.os.Bundle;
+
+public class CaptureIdr {
+
+    // Current instance of MediaCodec to "interrupt" on reset
+    private MediaCodec runningMediaCodec;
+
+    public synchronized void requestIdr() {
+        Bundle bundle = new Bundle();
+        bundle.putInt(MediaCodec.PARAMETER_KEY_REQUEST_SYNC_FRAME, 0);
+        this.runningMediaCodec.setParameters(bundle);
+    }
+
+    public synchronized void setRunningMediaCodec(MediaCodec runningMediaCodec) {
+        this.runningMediaCodec = runningMediaCodec;
+    }
+
+}

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -52,8 +52,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     private final AtomicBoolean stopped = new AtomicBoolean();
 
     private final CaptureReset reset = new CaptureReset();
-
-    private final AtomicBoolean idrRequested = new AtomicBoolean();
+    private final CaptureIdr requestIdr = new CaptureIdr();
 
     public SurfaceEncoder(SurfaceCapture capture, Streamer streamer, Options options) {
         this.capture = capture;
@@ -71,6 +70,7 @@ public class SurfaceEncoder implements AsyncProcessor {
         MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
 
         capture.init(reset);
+        requestIdr.setRunningMediaCodec(mediaCodec);
 
         try {
             boolean alive;
@@ -202,13 +202,6 @@ public class SurfaceEncoder implements AsyncProcessor {
 
         boolean eos;
         do {
-            if (idrRequested.get()) {
-                Bundle bundle = new Bundle();
-                bundle.putInt(MediaCodec.PARAMETER_KEY_REQUEST_SYNC_FRAME, 0);
-                codec.setParameters(bundle);
-                idrRequested.set(false);
-            }
-
             int outputBufferId = codec.dequeueOutputBuffer(bufferInfo, -1);
             try {
                 eos = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0;
@@ -335,6 +328,6 @@ public class SurfaceEncoder implements AsyncProcessor {
     }
 
     public void requestIdr() {
-        idrRequested.set(true);
+        requestIdr.requestIdr();
     }
 }


### PR DESCRIPTION
I am using scrcpy server to capture the screen and then broadcast the stream to multiple web clients. Todo so i need an new IDR frame whenever a new client connects.

The change has of course its flaws, as accessing the the MediaCodec isn't really possible from another thread atm. Thus an IDR gets only requested when a new frame was generated.