### PR TITLE
Only disable control for no-window if we also don't do any other video operations

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -687,8 +687,7 @@ static const struct sc_option options[] = {
     {
         .longopt_id = OPT_NO_WINDOW,
         .longopt = "no-window",
-        .text = "Disable scrcpy window. Implies --no-video-playback and "
-                "--no-control.",
+        .text = "Disable scrcpy window. Implies --no-video-playback",
     },
     {
         .longopt_id = OPT_ORIENTATION,
@@ -2759,9 +2758,12 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
 #endif
 
     if (!opts->window) {
-        // Without window, there cannot be any video playback or control
+        // Without window, there cannot be any video playback
         opts->video_playback = false;
-        opts->control = false;
+        // Without any other video output control doesn't make sense 
+        if(!opts->record_filename && !v4l2){
+            opts->control = false;
+        }
     }
 
     if (!opts->video) {


### PR DESCRIPTION
To allow the cli options that require control to work when we are recording or sinking to v4l2 control shouldn't be forced off just because we have no window.

This should close issue #5803 