### PR TITLE
Associate UHID devices to displays on Android 15

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -148,6 +148,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                 displayDataAvailable.notify();
             }
         }
+        UhidManager.setDisplayId(virtualDisplayId);
     }
 
     public void setSurfaceCapture(SurfaceCapture surfaceCapture) {

--- a/server/src/main/java/com/genymobile/scrcpy/control/UhidManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/UhidManager.java
@@ -53,7 +53,7 @@ public final class UhidManager {
     }
 
     public static void setDisplayId(int displayId) {
-        if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14 && displayId != 0) {
+        if (Build.VERSION.SDK_INT >= AndroidVersions.API_35_ANDROID_15 && displayId != 0) {
             DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
             ServiceManager.getInputManager().addUniqueIdAssociationByPort(inputPort, displayInfo.getUniqueId());
         }
@@ -241,6 +241,10 @@ public final class UhidManager {
     }
 
     public void closeAll() {
+        if (Build.VERSION.SDK_INT >= AndroidVersions.API_35_ANDROID_15) {
+            ServiceManager.getInputManager().removeUniqueIdAssociationByPort(inputPort);
+        }
+
         for (FileDescriptor fd : fds.values()) {
             close(fd);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/device/DisplayInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/DisplayInfo.java
@@ -7,16 +7,18 @@ public final class DisplayInfo {
     private final int layerStack;
     private final int flags;
     private final int dpi;
+    private final String uniqueId;
 
     public static final int FLAG_SUPPORTS_PROTECTED_BUFFERS = 0x00000001;
 
-    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags, int dpi) {
+    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags, int dpi, String uniqueId) {
         this.displayId = displayId;
         this.size = size;
         this.rotation = rotation;
         this.layerStack = layerStack;
         this.flags = flags;
         this.dpi = dpi;
+        this.uniqueId = uniqueId;
     }
 
     public int getDisplayId() {
@@ -41,6 +43,10 @@ public final class DisplayInfo {
 
     public int getDpi() {
         return dpi;
+    }
+
+    public String getUniqueId() {
+        return uniqueId;
     }
 }
 

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -81,7 +81,7 @@ public final class DisplayManager {
         int density = Integer.parseInt(m.group(5));
         int layerStack = Integer.parseInt(m.group(6));
 
-        return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, density);
+        return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, density, "");
     }
 
     private static DisplayInfo getDisplayInfoFromDumpsysDisplay(int displayId) {
@@ -129,7 +129,8 @@ public final class DisplayManager {
             int layerStack = cls.getDeclaredField("layerStack").getInt(displayInfo);
             int flags = cls.getDeclaredField("flags").getInt(displayInfo);
             int dpi = cls.getDeclaredField("logicalDensityDpi").getInt(displayInfo);
-            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, dpi);
+            String uniqueId = (String)cls.getDeclaredField("uniqueId").get(displayInfo);
+            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, dpi, uniqueId);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
@@ -89,13 +89,7 @@ public final class InputManager {
 
     private static Method getAddUniqueIdAssociationByPortMethod() throws NoSuchMethodException {
         if (addUniqueIdAssociationByPortMethod == null) {
-            try {
-                // Android 15
-                addUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("addUniqueIdAssociationByPort", String.class, String.class);
-            } catch (NoSuchMethodException ignored) {
-                // Android 12 to 14
-                addUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("addUniqueIdAssociation", String.class, String.class);
-            }
+            addUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("addUniqueIdAssociationByPort", String.class, String.class);
         }
         return addUniqueIdAssociationByPortMethod;
     }
@@ -111,13 +105,7 @@ public final class InputManager {
 
     private static Method getRemoveUniqueIdAssociationByPortMethod() throws NoSuchMethodException {
         if (removeUniqueIdAssociationByPortMethod == null) {
-            try {
-                // Android 15
-                removeUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("removeUniqueIdAssociationByPort", String.class);
-            } catch (NoSuchMethodException ignored) {
-                // Android 12 to 14
-                removeUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("removeUniqueIdAssociation", String.class);
-            }
+            removeUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("removeUniqueIdAssociationByPort", String.class);
         }
         return removeUniqueIdAssociationByPortMethod;
     }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/InputManager.java
@@ -1,8 +1,10 @@
 package com.genymobile.scrcpy.wrappers;
 
+import com.genymobile.scrcpy.FakeContext;
 import com.genymobile.scrcpy.util.Ln;
 
 import android.annotation.SuppressLint;
+import android.content.Context;
 import android.view.InputEvent;
 import android.view.MotionEvent;
 
@@ -16,38 +18,25 @@ public final class InputManager {
     public static final int INJECT_INPUT_EVENT_MODE_WAIT_FOR_FINISH = 2;
 
     private final Object manager;
-    private Method injectInputEventMethod;
 
+    private static Method injectInputEventMethod;
     private static Method setDisplayIdMethod;
     private static Method setActionButtonMethod;
+    private static Method addUniqueIdAssociationByPortMethod;
+    private static Method removeUniqueIdAssociationByPortMethod;
 
     static InputManager create() {
-        try {
-            Class<?> inputManagerClass = getInputManagerClass();
-            Method getInstanceMethod = inputManagerClass.getDeclaredMethod("getInstance");
-            Object im = getInstanceMethod.invoke(null);
-            return new InputManager(im);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
-        }
-    }
-
-    private static Class<?> getInputManagerClass() {
-        try {
-            // Parts of the InputManager class have been moved to a new InputManagerGlobal class in Android 14 preview
-            return Class.forName("android.hardware.input.InputManagerGlobal");
-        } catch (ClassNotFoundException e) {
-            return android.hardware.input.InputManager.class;
-        }
+        Object im = FakeContext.get().getSystemService(Context.INPUT_SERVICE);
+        return new InputManager(im);
     }
 
     private InputManager(Object manager) {
         this.manager = manager;
     }
 
-    private Method getInjectInputEventMethod() throws NoSuchMethodException {
+    private static Method getInjectInputEventMethod() throws NoSuchMethodException {
         if (injectInputEventMethod == null) {
-            injectInputEventMethod = manager.getClass().getMethod("injectInputEvent", InputEvent.class, int.class);
+            injectInputEventMethod = android.hardware.input.InputManager.class.getMethod("injectInputEvent", InputEvent.class, int.class);
         }
         return injectInputEventMethod;
     }
@@ -95,6 +84,50 @@ public final class InputManager {
         } catch (ReflectiveOperationException e) {
             Ln.e("Cannot set action button on MotionEvent", e);
             return false;
+        }
+    }
+
+    private static Method getAddUniqueIdAssociationByPortMethod() throws NoSuchMethodException {
+        if (addUniqueIdAssociationByPortMethod == null) {
+            try {
+                // Android 15
+                addUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("addUniqueIdAssociationByPort", String.class, String.class);
+            } catch (NoSuchMethodException ignored) {
+                // Android 12 to 14
+                addUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("addUniqueIdAssociation", String.class, String.class);
+            }
+        }
+        return addUniqueIdAssociationByPortMethod;
+    }
+
+    public void addUniqueIdAssociationByPort(String inputPort, String uniqueId) {
+        try {
+            Method method = getAddUniqueIdAssociationByPortMethod();
+            method.invoke(manager, inputPort, uniqueId);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Cannot add unique id association by port", e);
+        }
+    }
+
+    private static Method getRemoveUniqueIdAssociationByPortMethod() throws NoSuchMethodException {
+        if (removeUniqueIdAssociationByPortMethod == null) {
+            try {
+                // Android 15
+                removeUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("removeUniqueIdAssociationByPort", String.class);
+            } catch (NoSuchMethodException ignored) {
+                // Android 12 to 14
+                removeUniqueIdAssociationByPortMethod = android.hardware.input.InputManager.class.getMethod("removeUniqueIdAssociation", String.class);
+            }
+        }
+        return removeUniqueIdAssociationByPortMethod;
+    }
+
+    public void removeUniqueIdAssociationByPort(String inputPort) {
+        try {
+            Method method = getRemoveUniqueIdAssociationByPortMethod();
+            method.invoke(manager, inputPort);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Cannot remove unique id association by port", e);
         }
     }
 }


### PR DESCRIPTION
Fixes #4829
Fixes #5547
Fixes #5557

Only works on Android 15 and newer because it requires `ASSOCIATE_INPUT_DEVICE_TO_DISPLAY` permission.

When running multiple instances of `scrcpy --display-id` or `scrcpy --new-display`, each display will have its own mouse pointer.

Has no effect on keyboard, the whole system still only has one input focus.

I used `FakeContext.get().getSystemService(Context.INPUT_SERVICE)` to get `InputManager`, because initially I was testing `addPortAssociation`, which doesn't exist on `InputManagerGlobal`. This simplifies the code, especially for `ClipboardManager`, where we can use the stable public API (https://github.com/yume-chan/leap-scrcpy/blob/f9aaf1b05118261d75b82ba88b462f08e37eecdc/server/app/src/main/java/leap/scrcpy/server/FakeContext.kt#L62-L72)