### PR TITLE
Add session metadata for video stream

### DIFF
--- a/app/src/audio_player.c
+++ b/app/src/audio_player.c
@@ -30,7 +30,10 @@ sc_audio_player_frame_sink_push(struct sc_frame_sink *sink,
 
 static bool
 sc_audio_player_frame_sink_open(struct sc_frame_sink *sink,
-                                const AVCodecContext *ctx) {
+                                const AVCodecContext *ctx,
+                                const struct sc_stream_session *session) {
+    (void) session;
+
     struct sc_audio_player *ap = DOWNCAST(sink);
 
 #ifdef SCRCPY_LAVU_HAS_CHLAYOUT

--- a/app/src/decoder.h
+++ b/app/src/decoder.h
@@ -5,6 +5,7 @@
 
 #include <libavcodec/avcodec.h>
 
+#include "coords.h"
 #include "trait/frame_source.h"
 #include "trait/packet_sink.h"
 
@@ -16,6 +17,9 @@ struct sc_decoder {
 
     AVCodecContext *ctx;
     AVFrame *frame;
+
+    struct sc_stream_session session; // only initialized for video stream
+    struct sc_size frame_size;
 };
 
 // The name must be statically allocated (e.g. a string literal)

--- a/app/src/delay_buffer.c
+++ b/app/src/delay_buffer.c
@@ -109,7 +109,8 @@ stopped:
 
 static bool
 sc_delay_buffer_frame_sink_open(struct sc_frame_sink *sink,
-                                const AVCodecContext *ctx) {
+                                const AVCodecContext *ctx,
+                                const struct sc_stream_session *session) {
     struct sc_delay_buffer *db = DOWNCAST(sink);
     (void) ctx;
 
@@ -132,7 +133,7 @@ sc_delay_buffer_frame_sink_open(struct sc_frame_sink *sink,
     sc_vecdeque_init(&db->queue);
     db->stopped = false;
 
-    if (!sc_frame_source_sinks_open(&db->frame_source, ctx)) {
+    if (!sc_frame_source_sinks_open(&db->frame_source, ctx, session)) {
         goto error_destroy_wait_cond;
     }
 

--- a/app/src/delay_buffer.h
+++ b/app/src/delay_buffer.h
@@ -18,14 +18,23 @@
 // forward declarations
 typedef struct AVFrame AVFrame;
 
-struct sc_delayed_frame {
-    AVFrame *frame;
+enum sc_delayed_packet_type {
+    SC_DELAYED_PACKET_TYPE_FRAME,
+    SC_DELAYED_PACKET_TYPE_SESSION,
+};
+
+struct sc_delayed_packet {
+    enum sc_delayed_packet_type type;
+    union {
+        AVFrame *frame;
+        struct sc_stream_session session;
+    };
 #ifdef SC_BUFFERING_DEBUG
     sc_tick push_date;
 #endif
 };
 
-struct sc_delayed_frame_queue SC_VECDEQUE(struct sc_delayed_frame);
+struct sc_delayed_packet_queue SC_VECDEQUE(struct sc_delayed_packet);
 
 struct sc_delay_buffer {
     struct sc_frame_source frame_source; // frame source trait
@@ -40,7 +49,7 @@ struct sc_delay_buffer {
     sc_cond wait_cond;
 
     struct sc_clock clock;
-    struct sc_delayed_frame_queue queue;
+    struct sc_delayed_packet_queue queue;
     bool stopped;
 };
 

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -541,7 +541,10 @@ sc_recorder_set_orientation(AVStream *stream, enum sc_orientation orientation) {
 
 static bool
 sc_recorder_video_packet_sink_open(struct sc_packet_sink *sink,
-                                   AVCodecContext *ctx) {
+                                   AVCodecContext *ctx,
+                                   const struct sc_stream_session *session) {
+    (void) session;
+
     struct sc_recorder *recorder = DOWNCAST_VIDEO(sink);
     // only written from this thread, no need to lock
     assert(!recorder->video_init);
@@ -635,7 +638,10 @@ sc_recorder_video_packet_sink_push(struct sc_packet_sink *sink,
 
 static bool
 sc_recorder_audio_packet_sink_open(struct sc_packet_sink *sink,
-                                   AVCodecContext *ctx) {
+                                   AVCodecContext *ctx,
+                                   const struct sc_stream_session *session) {
+    (void) session;
+
     struct sc_recorder *recorder = DOWNCAST_AUDIO(sink);
     assert(recorder->audio);
     // only written from this thread, no need to lock

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -252,9 +252,11 @@ event_watcher(void *data, SDL_Event *event) {
 
 static bool
 sc_screen_frame_sink_open(struct sc_frame_sink *sink,
-                          const AVCodecContext *ctx) {
+                          const AVCodecContext *ctx,
+                          const struct sc_stream_session *session) {
     assert(ctx->pix_fmt == AV_PIX_FMT_YUV420P);
     (void) ctx;
+    (void) session;
 
     struct sc_screen *screen = DOWNCAST(sink);
 

--- a/app/src/trait/frame_sink.h
+++ b/app/src/trait/frame_sink.h
@@ -6,6 +6,8 @@
 #include <stdbool.h>
 #include <libavcodec/avcodec.h>
 
+#include "trait/packet_sink.h"
+
 /**
  * Frame sink trait.
  *
@@ -17,9 +19,16 @@ struct sc_frame_sink {
 
 struct sc_frame_sink_ops {
     /* The codec context is valid until the sink is closed */
-    bool (*open)(struct sc_frame_sink *sink, const AVCodecContext *ctx);
+    bool (*open)(struct sc_frame_sink *sink, const AVCodecContext *ctx,
+                 const struct sc_stream_session *session);
     void (*close)(struct sc_frame_sink *sink);
     bool (*push)(struct sc_frame_sink *sink, const AVFrame *frame);
+
+    /**
+     * Optional callback to be notified of a new stream session.
+     */
+    bool (*push_session)(struct sc_frame_sink *sink,
+                         const struct sc_stream_session *session);
 };
 
 #endif

--- a/app/src/trait/frame_source.h
+++ b/app/src/trait/frame_source.h
@@ -28,7 +28,8 @@ sc_frame_source_add_sink(struct sc_frame_source *source,
 
 bool
 sc_frame_source_sinks_open(struct sc_frame_source *source,
-                           const AVCodecContext *ctx);
+                           const AVCodecContext *ctx,
+                           const struct sc_stream_session *session);
 
 void
 sc_frame_source_sinks_close(struct sc_frame_source *source);
@@ -36,5 +37,9 @@ sc_frame_source_sinks_close(struct sc_frame_source *source);
 bool
 sc_frame_source_sinks_push(struct sc_frame_source *source,
                            const AVFrame *frame);
+
+bool
+sc_frame_source_sinks_push_session(struct sc_frame_source *source,
+                                   const struct sc_stream_session *session);
 
 #endif

--- a/app/src/trait/packet_sink.h
+++ b/app/src/trait/packet_sink.h
@@ -15,11 +15,27 @@ struct sc_packet_sink {
     const struct sc_packet_sink_ops *ops;
 };
 
+struct sc_stream_session_video {
+    uint32_t width;
+    uint32_t height;
+};
+
+struct sc_stream_session {
+    struct sc_stream_session_video video;
+};
+
 struct sc_packet_sink_ops {
     /* The codec context is valid until the sink is closed */
-    bool (*open)(struct sc_packet_sink *sink, AVCodecContext *ctx);
+    bool (*open)(struct sc_packet_sink *sink, AVCodecContext *ctx,
+                 const struct sc_stream_session *session);
     void (*close)(struct sc_packet_sink *sink);
     bool (*push)(struct sc_packet_sink *sink, const AVPacket *packet);
+
+    /**
+     * Optional callback to be notified of a new stream session.
+     */
+    bool (*push_session)(struct sc_packet_sink *sink,
+                         const struct sc_stream_session *session);
 
     /*/
      * Called when the input stream has been disabled at runtime.

--- a/app/src/trait/packet_source.c
+++ b/app/src/trait/packet_source.c
@@ -27,11 +27,12 @@ sc_packet_source_sinks_close_firsts(struct sc_packet_source *source,
 
 bool
 sc_packet_source_sinks_open(struct sc_packet_source *source,
-                            AVCodecContext *ctx) {
+                            AVCodecContext *ctx,
+                            const struct sc_stream_session *session) {
     assert(source->sink_count);
     for (unsigned i = 0; i < source->sink_count; ++i) {
         struct sc_packet_sink *sink = source->sinks[i];
-        if (!sink->ops->open(sink, ctx)) {
+        if (!sink->ops->open(sink, ctx, session)) {
             sc_packet_source_sinks_close_firsts(source, i);
             return false;
         }
@@ -53,6 +54,20 @@ sc_packet_source_sinks_push(struct sc_packet_source *source,
     for (unsigned i = 0; i < source->sink_count; ++i) {
         struct sc_packet_sink *sink = source->sinks[i];
         if (!sink->ops->push(sink, packet)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool
+sc_packet_source_sinks_push_session(struct sc_packet_source *source,
+                                    const struct sc_stream_session *session) {
+    assert(source->sink_count);
+    for (unsigned i = 0; i < source->sink_count; ++i) {
+        struct sc_packet_sink *sink = source->sinks[i];
+        if (!sink->ops->push_session(sink, session)) {
             return false;
         }
     }

--- a/app/src/trait/packet_source.h
+++ b/app/src/trait/packet_source.h
@@ -28,7 +28,8 @@ sc_packet_source_add_sink(struct sc_packet_source *source,
 
 bool
 sc_packet_source_sinks_open(struct sc_packet_source *source,
-                            AVCodecContext *ctx);
+                            AVCodecContext *ctx,
+                            const struct sc_stream_session *session);
 
 void
 sc_packet_source_sinks_close(struct sc_packet_source *source);
@@ -36,6 +37,10 @@ sc_packet_source_sinks_close(struct sc_packet_source *source);
 bool
 sc_packet_source_sinks_push(struct sc_packet_source *source,
                             const AVPacket *packet);
+
+bool
+sc_packet_source_sinks_push_session(struct sc_packet_source *source,
+                                    const struct sc_stream_session *session);
 
 void
 sc_packet_source_sinks_disable(struct sc_packet_source *source);

--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -146,9 +146,11 @@ run_v4l2_sink(void *data) {
 }
 
 static bool
-sc_v4l2_sink_open(struct sc_v4l2_sink *vs, const AVCodecContext *ctx) {
+sc_v4l2_sink_open(struct sc_v4l2_sink *vs, const AVCodecContext *ctx,
+                  const struct sc_stream_session *session) {
     assert(ctx->pix_fmt == AV_PIX_FMT_YUV420P);
     (void) ctx;
+    (void) session;
 
     bool ok = sc_frame_buffer_init(&vs->fb);
     if (!ok) {
@@ -326,9 +328,10 @@ sc_v4l2_sink_push(struct sc_v4l2_sink *vs, const AVFrame *frame) {
 }
 
 static bool
-sc_v4l2_frame_sink_open(struct sc_frame_sink *sink, const AVCodecContext *ctx) {
+sc_v4l2_frame_sink_open(struct sc_frame_sink *sink, const AVCodecContext *ctx,
+                        const struct sc_stream_session *session) {
     struct sc_v4l2_sink *vs = DOWNCAST(sink);
-    return sc_v4l2_sink_open(vs, ctx);
+    return sc_v4l2_sink_open(vs, ctx, session);
 }
 
 static void

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -409,12 +409,11 @@ with any client which uses the same protocol.
 
 For simplicity, some [server-specific options] have been added to produce raw
 streams easily:
- - `send_device_meta=false`: disable the device metata (in practice, the device
+ - `send_device_meta=false`: disable device metadata (in practice, the device
    name) sent on the _first_ socket
  - `send_frame_meta=false`: disable the 12-byte header for each packet
  - `send_dummy_byte`: disable the dummy byte sent on forward connections
- - `send_codec_meta`: disable the codec information (and initial device size for
-   video)
+ - `send_stream_meta`: disable codec and video size metadata
  - `raw_stream`: disable all the above
 
 [server-specific options]: https://github.com/Genymobile/scrcpy/blob/a3cdf1a6b86ea22786e1f7d09b9c202feabc6949/server/src/main/java/com/genymobile/scrcpy/Options.java#L309-L329

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -78,7 +78,7 @@ public class Options {
     private boolean sendDeviceMeta = true; // send device name and size
     private boolean sendFrameMeta = true; // send PTS so that the client may record properly
     private boolean sendDummyByte = true; // write a byte on start to detect connection issues
-    private boolean sendCodecMeta = true; // write the codec metadata before the stream
+    private boolean sendStreamMeta = true; // write the stream metadata (codec and session)
 
     public Ln.Level getLogLevel() {
         return logLevel;
@@ -284,8 +284,8 @@ public class Options {
         return sendDummyByte;
     }
 
-    public boolean getSendCodecMeta() {
-        return sendCodecMeta;
+    public boolean getSendStreamMeta() {
+        return sendStreamMeta;
     }
 
     @SuppressWarnings("MethodLength")
@@ -500,8 +500,8 @@ public class Options {
                 case "send_dummy_byte":
                     options.sendDummyByte = Boolean.parseBoolean(value);
                     break;
-                case "send_codec_meta":
-                    options.sendCodecMeta = Boolean.parseBoolean(value);
+                case "send_stream_meta":
+                    options.sendStreamMeta = Boolean.parseBoolean(value);
                     break;
                 case "raw_stream":
                     boolean rawStream = Boolean.parseBoolean(value);
@@ -509,7 +509,7 @@ public class Options {
                         options.sendDeviceMeta = false;
                         options.sendFrameMeta = false;
                         options.sendDummyByte = false;
-                        options.sendCodecMeta = false;
+                        options.sendStreamMeta = false;
                     }
                     break;
                 default:

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -126,7 +126,7 @@ public final class Server {
                     audioCapture = new AudioPlaybackCapture(options.getAudioDup());
                 }
 
-                Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendCodecMeta(), options.getSendFrameMeta());
+                Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendStreamMeta(), options.getSendFrameMeta());
                 AsyncProcessor audioRecorder;
                 if (audioCodec == AudioCodec.RAW) {
                     audioRecorder = new AudioRawRecorder(audioCapture, audioStreamer);
@@ -137,7 +137,7 @@ public final class Server {
             }
 
             if (video) {
-                Streamer videoStreamer = new Streamer(connection.getVideoFd(), options.getVideoCodec(), options.getSendCodecMeta(),
+                Streamer videoStreamer = new Streamer(connection.getVideoFd(), options.getVideoCodec(), options.getSendStreamMeta(),
                         options.getSendFrameMeta());
                 SurfaceCapture surfaceCapture;
                 if (options.getVideoSource() == VideoSource.DISPLAY) {

--- a/server/src/main/java/com/genymobile/scrcpy/device/Streamer.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Streamer.java
@@ -19,7 +19,7 @@ public final class Streamer {
 
     private final FileDescriptor fd;
     private final Codec codec;
-    private final boolean sendCodecMeta;
+    private final boolean sendStreamMeta;
     private final boolean sendFrameMeta;
 
     private final ByteBuffer headerBuffer = ByteBuffer.allocate(12);
@@ -27,7 +27,7 @@ public final class Streamer {
     public Streamer(FileDescriptor fd, Codec codec, boolean sendCodecMeta, boolean sendFrameMeta) {
         this.fd = fd;
         this.codec = codec;
-        this.sendCodecMeta = sendCodecMeta;
+        this.sendStreamMeta = sendCodecMeta;
         this.sendFrameMeta = sendFrameMeta;
     }
 
@@ -36,7 +36,7 @@ public final class Streamer {
     }
 
     public void writeAudioHeader() throws IOException {
-        if (sendCodecMeta) {
+        if (sendStreamMeta) {
             ByteBuffer buffer = ByteBuffer.allocate(4);
             buffer.putInt(codec.getId());
             buffer.flip();
@@ -45,7 +45,7 @@ public final class Streamer {
     }
 
     public void writeVideoHeader(Size videoSize) throws IOException {
-        if (sendCodecMeta) {
+        if (sendStreamMeta) {
             ByteBuffer buffer = ByteBuffer.allocate(12);
             buffer.putInt(codec.getId());
             buffer.putInt(videoSize.getWidth());

--- a/server/src/main/java/com/genymobile/scrcpy/device/Streamer.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Streamer.java
@@ -3,6 +3,7 @@ package com.genymobile.scrcpy.device;
 import com.genymobile.scrcpy.audio.AudioCodec;
 import com.genymobile.scrcpy.util.Codec;
 import com.genymobile.scrcpy.util.IO;
+import com.genymobile.scrcpy.util.Ln;
 
 import android.media.MediaCodec;
 
@@ -14,8 +15,9 @@ import java.util.Arrays;
 
 public final class Streamer {
 
-    private static final long PACKET_FLAG_CONFIG = 1L << 63;
-    private static final long PACKET_FLAG_KEY_FRAME = 1L << 62;
+    private static final long PACKET_FLAG_SESSION = 1L << 63;
+    private static final long PACKET_FLAG_CONFIG = 1L << 62;
+    private static final long PACKET_FLAG_KEY_FRAME = 1L << 61;
 
     private final FileDescriptor fd;
     private final Codec codec;
@@ -44,12 +46,10 @@ public final class Streamer {
         }
     }
 
-    public void writeVideoHeader(Size videoSize) throws IOException {
+    public void writeVideoHeader() throws IOException {
         if (sendStreamMeta) {
-            ByteBuffer buffer = ByteBuffer.allocate(12);
+            ByteBuffer buffer = ByteBuffer.allocate(4);
             buffer.putInt(codec.getId());
-            buffer.putInt(videoSize.getWidth());
-            buffer.putInt(videoSize.getHeight());
             buffer.flip();
             IO.writeFully(fd, buffer);
         }
@@ -87,6 +87,18 @@ public final class Streamer {
         boolean config = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0;
         boolean keyFrame = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0;
         writePacket(codecBuffer, pts, config, keyFrame);
+    }
+
+    public void writeSessionMeta(int width, int height) throws IOException {
+        if (sendStreamMeta) {
+            headerBuffer.clear();
+
+            headerBuffer.putInt((int) (PACKET_FLAG_SESSION >> 32)); // Set the first bit to 1
+            headerBuffer.putInt(width);
+            headerBuffer.putInt(height);
+            headerBuffer.flip();
+            IO.writeFully(fd, headerBuffer);
+        }
     }
 
     private void writeFrameMeta(FileDescriptor fd, int packetSize, long pts, boolean config, boolean keyFrame) throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -71,16 +71,13 @@ public class SurfaceEncoder implements AsyncProcessor {
 
         try {
             boolean alive;
-            boolean headerWritten = false;
+
+            streamer.writeVideoHeader();
 
             do {
                 reset.consumeReset(); // If a capture reset was requested, it is implicitly fulfilled
                 capture.prepare();
                 Size size = capture.getSize();
-                if (!headerWritten) {
-                    streamer.writeVideoHeader(size);
-                    headerWritten = true;
-                }
 
                 format.setInteger(MediaFormat.KEY_WIDTH, size.getWidth());
                 format.setInteger(MediaFormat.KEY_HEIGHT, size.getHeight());
@@ -107,6 +104,7 @@ public class SurfaceEncoder implements AsyncProcessor {
                         boolean resetRequested = reset.consumeReset();
                         if (!resetRequested) {
                             // If a reset is requested during encode(), it will interrupt the encoding by an EOS
+                            streamer.writeSessionMeta(size.getWidth(), size.getHeight());
                             encode(mediaCodec, streamer);
                         }
                         // The capture might have been closed internally (for example if the camera is disconnected)


### PR DESCRIPTION
Introduce a new packet type, a "session" packet, containing metadata about the encoding session. It is used only for the video stream, and currently includes the video resolution.

For illustration, here is a sequence of packets on the video stream:

                                        device rotation
                                        v
    CODEC | SESSION | MEDIA | MEDIA | … | SESSION | MEDIA | MEDIA | …
           1920x1080 <-----------------> 1080x1920 <------------------
                      encoding session 1            encoding session 2

This metadata is not strictly necessary, since the video resolution can be determined after decoding. However, it allows detection of cases where the encoder does not respect the requested size (and logs a warning), even without decoding (e.g., when there is no video playback).

Additional metadata could be added later if necessary, for example the actual device rotation.
    
Refs #5918
Refs #5984