### PR TITLE
Improve/fix mouse scrolling support

### DIFF
--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -127,10 +127,14 @@ sc_control_msg_serialize(const struct sc_control_msg *msg, uint8_t *buf) {
             return 32;
         case SC_CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT:
             write_position(&buf[1], &msg->inject_scroll_event.position);
-            int16_t hscroll =
-                sc_float_to_i16fp(msg->inject_scroll_event.hscroll);
-            int16_t vscroll =
-                sc_float_to_i16fp(msg->inject_scroll_event.vscroll);
+            // Accept values in the range [-16, 16].
+            // Normalize to [-1, 1] in order to use sc_float_to_i16fp().
+            float hscroll_norm = msg->inject_scroll_event.hscroll / 16;
+            hscroll_norm = CLAMP(hscroll_norm, -1, 1);
+            float vscroll_norm = msg->inject_scroll_event.vscroll / 16;
+            vscroll_norm = CLAMP(vscroll_norm, -1, 1);
+            int16_t hscroll = sc_float_to_i16fp(hscroll_norm);
+            int16_t vscroll = sc_float_to_i16fp(vscroll_norm);
             sc_write16be(&buf[13], (uint16_t) hscroll);
             sc_write16be(&buf[15], (uint16_t) vscroll);
             sc_write32be(&buf[17], msg->inject_scroll_event.buttons);

--- a/app/src/hid/hid_mouse.c
+++ b/app/src/hid/hid_mouse.c
@@ -3,8 +3,8 @@
 #include <stdint.h>
 
 // 1 byte for buttons + padding, 1 byte for X position, 1 byte for Y position,
-// 1 byte for wheel motion
-#define SC_HID_MOUSE_INPUT_SIZE 4
+// 1 byte for wheel motion, 1 byte for hozizontal scrolling
+#define SC_HID_MOUSE_INPUT_SIZE 5
 
 /**
  * Mouse descriptor from the specification:
@@ -73,6 +73,21 @@ static const uint8_t SC_HID_MOUSE_REPORT_DESC[] = {
     // Report Count (3)
     0x95, 0x03,
     // Input (Data, Variable, Relative): 3 position bytes (X, Y, Wheel)
+    0x81, 0x06,
+
+    // Usage Page (Consumer Page)
+    0x05, 0x0C,
+    // Usage(AC Pan)
+    0x0A, 0x38, 0x02,
+    // Logical Minimum (-127)
+    0x15, 0x81,
+    // Logical Maximum (127)
+    0x25, 0x7F,
+    // Report Size (8)
+    0x75, 0x08,
+    // Report Count (1)
+    0x95, 0x01,
+    // Input (Data, Variable, Relative): 1 byte (AC Pan)
     0x81, 0x06,
 
     // End Collection
@@ -160,7 +175,8 @@ sc_hid_mouse_generate_input_from_motion(struct sc_hid_input *hid_input,
     data[0] = sc_hid_buttons_from_buttons_state(event->buttons_state);
     data[1] = CLAMP(event->xrel, -127, 127);
     data[2] = CLAMP(event->yrel, -127, 127);
-    data[3] = 0; // wheel coordinates only used for scrolling
+    data[3] = 0; // no vertical scrolling
+    data[4] = 0; // no horizontal scrolling
 }
 
 void
@@ -172,13 +188,14 @@ sc_hid_mouse_generate_input_from_click(struct sc_hid_input *hid_input,
     data[0] = sc_hid_buttons_from_buttons_state(event->buttons_state);
     data[1] = 0; // no x motion
     data[2] = 0; // no y motion
-    data[3] = 0; // wheel coordinates only used for scrolling
+    data[3] = 0; // no vertical scrolling
+    data[4] = 0; // no horizontal scrolling
 }
 
 bool
 sc_hid_mouse_generate_input_from_scroll(struct sc_hid_input *hid_input,
                                     const struct sc_mouse_scroll_event *event) {
-    if (!event->vscroll_int) {
+    if (!event->vscroll_int && !event->hscroll_int) {
         // Need a full integral value for HID
         return false;
     }
@@ -190,7 +207,7 @@ sc_hid_mouse_generate_input_from_scroll(struct sc_hid_input *hid_input,
     data[1] = 0; // no x motion
     data[2] = 0; // no y motion
     data[3] = CLAMP(event->vscroll_int, -127, 127);
-    // Horizontal scrolling ignored
+    data[4] = CLAMP(event->hscroll_int, -127, 127);
     return true;
 }
 

--- a/app/src/hid/hid_mouse.c
+++ b/app/src/hid/hid_mouse.c
@@ -175,19 +175,23 @@ sc_hid_mouse_generate_input_from_click(struct sc_hid_input *hid_input,
     data[3] = 0; // wheel coordinates only used for scrolling
 }
 
-void
+bool
 sc_hid_mouse_generate_input_from_scroll(struct sc_hid_input *hid_input,
                                     const struct sc_mouse_scroll_event *event) {
+    if (!event->vscroll_int) {
+        // Need a full integral value for HID
+        return false;
+    }
+
     sc_hid_mouse_input_init(hid_input);
 
     uint8_t *data = hid_input->data;
     data[0] = 0; // buttons state irrelevant (and unknown)
     data[1] = 0; // no x motion
     data[2] = 0; // no y motion
-    // In practice, vscroll is always -1, 0 or 1, but in theory other values
-    // are possible
-    data[3] = CLAMP(event->vscroll, -127, 127);
+    data[3] = CLAMP(event->vscroll_int, -127, 127);
     // Horizontal scrolling ignored
+    return true;
 }
 
 void sc_hid_mouse_generate_open(struct sc_hid_open *hid_open) {

--- a/app/src/hid/hid_mouse.h
+++ b/app/src/hid/hid_mouse.h
@@ -22,7 +22,7 @@ void
 sc_hid_mouse_generate_input_from_click(struct sc_hid_input *hid_input,
                                     const struct sc_mouse_click_event *event);
 
-void
+bool
 sc_hid_mouse_generate_input_from_scroll(struct sc_hid_input *hid_input,
                                     const struct sc_mouse_scroll_event *event);
 

--- a/app/src/input_events.h
+++ b/app/src/input_events.h
@@ -393,6 +393,8 @@ struct sc_mouse_scroll_event {
     struct sc_position position;
     float hscroll;
     float vscroll;
+    int32_t hscroll_int;
+    int32_t vscroll_int;
     uint8_t buttons_state; // bitwise-OR of sc_mouse_button values
 };
 

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -897,11 +897,11 @@ sc_input_manager_process_mouse_wheel(struct sc_input_manager *im,
     struct sc_mouse_scroll_event evt = {
         .position = sc_input_manager_get_position(im, mouse_x, mouse_y),
 #if SDL_VERSION_ATLEAST(2, 0, 18)
-        .hscroll = CLAMP(event->preciseX, -1.0f, 1.0f),
-        .vscroll = CLAMP(event->preciseY, -1.0f, 1.0f),
+        .hscroll = event->preciseX,
+        .vscroll = event->preciseY,
 #else
-        .hscroll = CLAMP(event->x, -1, 1),
-        .vscroll = CLAMP(event->y, -1, 1),
+        .hscroll = event->x,
+        .vscroll = event->y,
 #endif
         .buttons_state = im->mouse_buttons_state,
     };

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -903,6 +903,8 @@ sc_input_manager_process_mouse_wheel(struct sc_input_manager *im,
         .hscroll = event->x,
         .vscroll = event->y,
 #endif
+        .hscroll_int = event->x,
+        .vscroll_int = event->y,
         .buttons_state = im->mouse_buttons_state,
     };
 

--- a/app/src/mouse_sdk.c
+++ b/app/src/mouse_sdk.c
@@ -113,8 +113,8 @@ sc_mouse_processor_process_mouse_scroll(struct sc_mouse_processor *mp,
         .type = SC_CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT,
         .inject_scroll_event = {
             .position = event->position,
-            .hscroll = CLAMP(event->hscroll, -1, 1),
-            .vscroll = CLAMP(event->vscroll, -1, 1),
+            .hscroll = event->hscroll,
+            .vscroll = event->vscroll,
             .buttons = convert_mouse_buttons(event->buttons_state),
         },
     };

--- a/app/src/mouse_sdk.c
+++ b/app/src/mouse_sdk.c
@@ -113,8 +113,8 @@ sc_mouse_processor_process_mouse_scroll(struct sc_mouse_processor *mp,
         .type = SC_CONTROL_MSG_TYPE_INJECT_SCROLL_EVENT,
         .inject_scroll_event = {
             .position = event->position,
-            .hscroll = event->hscroll,
-            .vscroll = event->vscroll,
+            .hscroll = CLAMP(event->hscroll, -1, 1),
+            .vscroll = CLAMP(event->vscroll, -1, 1),
             .buttons = convert_mouse_buttons(event->buttons_state),
         },
     };

--- a/app/src/uhid/mouse_uhid.c
+++ b/app/src/uhid/mouse_uhid.c
@@ -55,7 +55,9 @@ sc_mouse_processor_process_mouse_scroll(struct sc_mouse_processor *mp,
     struct sc_mouse_uhid *mouse = DOWNCAST(mp);
 
     struct sc_hid_input hid_input;
-    sc_hid_mouse_generate_input_from_scroll(&hid_input, event);
+    if (!sc_hid_mouse_generate_input_from_scroll(&hid_input, event)) {
+        return;
+    }
 
     sc_mouse_uhid_send_input(mouse, &hid_input, "mouse scroll");
 }

--- a/app/src/usb/mouse_aoa.c
+++ b/app/src/usb/mouse_aoa.c
@@ -42,7 +42,9 @@ sc_mouse_processor_process_mouse_scroll(struct sc_mouse_processor *mp,
     struct sc_mouse_aoa *mouse = DOWNCAST(mp);
 
     struct sc_hid_input hid_input;
-    sc_hid_mouse_generate_input_from_scroll(&hid_input, event);
+    if (!sc_hid_mouse_generate_input_from_scroll(&hid_input, event)) {
+        return;
+    }
 
     if (!sc_aoa_push_input(mouse->aoa, &hid_input)) {
         LOGW("Could not push AOA HID input (mouse scroll)");

--- a/app/src/usb/screen_otg.c
+++ b/app/src/usb/screen_otg.c
@@ -164,8 +164,15 @@ sc_screen_otg_process_mouse_wheel(struct sc_screen_otg *screen,
 
     struct sc_mouse_scroll_event evt = {
         // .position not used for HID events
+#if SDL_VERSION_ATLEAST(2, 0, 18)
+        .hscroll = event->preciseX,
+        .vscroll = event->preciseY,
+#else
         .hscroll = event->x,
         .vscroll = event->y,
+#endif
+        .hscroll_int = event->x,
+        .vscroll_int = event->y,
         .buttons_state = sc_mouse_buttons_state_from_sdl(sdl_buttons_state),
     };
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
@@ -112,8 +112,9 @@ public class ControlMessageReader {
 
     private ControlMessage parseInjectScrollEvent() throws IOException {
         Position position = parsePosition();
-        float hScroll = Binary.i16FixedPointToFloat(dis.readShort());
-        float vScroll = Binary.i16FixedPointToFloat(dis.readShort());
+        // Binary.i16FixedPointToFloat() decodes values assuming the full range is [-1, 1], but the actual range is [-16, 16].
+        float hScroll = Binary.i16FixedPointToFloat(dis.readShort()) * 16;
+        float vScroll = Binary.i16FixedPointToFloat(dis.readShort()) * 16;
         int buttons = dis.readInt();
         return ControlMessage.createInjectScrollEvent(position, hScroll, vScroll, buttons);
     }


### PR DESCRIPTION
Scrolling values reported by SDL can produce fractional values (like 0.05, when precise scrolling is enabled), and also values greater than 1 or less than -1.

Currently, the reported value was clamped to [-1, 1]. To support larger values, extend the range to [-16, 16] for SDK mouse (the default mode).

Over HID, only integral scroll values can be sent. When receiving fractional values from SDL, scrolling was broken (#6156). To fix the problem, use the integral scroll value reported by SDL, which internally accumulates fractional deltas.

While I was at it, I also added horizontal scrolling support for HID (it was only implemented for SDK mouse).

Fixes #6156.