### PR TITLE
Add catching of CTRL_BREAK_EVENT signal on Windows OS

### DIFF
--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -93,7 +93,7 @@ struct scrcpy {
 
 #ifdef _WIN32
 static BOOL WINAPI windows_ctrl_handler(DWORD ctrl_type) {
-    if (ctrl_type == CTRL_C_EVENT) {
+    if (ctrl_type == CTRL_C_EVENT || ctrl_type == CTRL_BREAK_EVENT) {
         sc_push_event(SDL_QUIT);
         return TRUE;
     }


### PR DESCRIPTION
If a scrcpy process is spawned using **Python 3.8.10** with **scrcpy v3.3.1**  on **Windows 10 OS** as follows:

```python
proc = subprocess.Popen(
        "scrcpy --no-window --record=file.mp4",
        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
    )
```

and the process is terminated as follows:

```python
proc.send_signal(signal.CTRL_BREAK_EVENT)
```

Then the process will not terminate gracefully and the recording file will be corrupted.

This can be fixed by adding the catching of the CTRL_BREAK_EVENT signal to the `windows_ctrl_handler` function in scrcpy.c
The fix was tested on a Samsung Galaxy S6 Edge+. The following script:

```python
import signal
import subprocess
import time


if __name__ == "__main__":
    proc = subprocess.Popen(
        "scrcpy --no-window --record=file.mp4",
        creationflags=subprocess.CREATE_NEW_PROCESS_GROUP
    )
    time.sleep(10)
    proc.send_signal(signal.CTRL_BREAK_EVENT)
    proc.wait()
```
was run using **scrcpy v3.3.1** and the resulting recording file was corrupted. The same script was run using the PR build and the resulting recording file was not corrupted.

Possibly fixes the below issue:
https://github.com/Genymobile/scrcpy/issues/5195


