### PR TITLE
Made windows build instructions more clear in build.md

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -154,6 +154,8 @@ install it manually and make it available from the `PATH`:
 export PATH="$JAVA_HOME/bin:$PATH"
 ```
 
+When following the rest of the build instructions mentioned below, ensure you're using the MINGW terminal within MSYS2.
+
 ### Mac OS
 
 Install the packages with [Homebrew]:


### PR DESCRIPTION
This pull request updates the build documentation to clarify the terminal requirements for Windows users.

* [`doc/build.md`](diffhunk://#diff-0ea7c2ec5c45d47502051b4a185cc68ace0b8a560f60742b9017b3f517e9fa8fR157-R158): Added a note to specify that the MINGW terminal within MSYS2 should be used when following the build instructions on Windows.