### PR TITLE
Enable Presentation API on virtual display so apps with dual-screen support can use it as extended display

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -36,7 +36,7 @@ public class NewDisplayCapture extends SurfaceCapture {
     private static final int VIRTUAL_DISPLAY_FLAG_TOUCH_FEEDBACK_DISABLED = 1 << 13;
     private static final int VIRTUAL_DISPLAY_FLAG_OWN_FOCUS = 1 << 14;
     private static final int VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP = 1 << 15;
-
+    private static final int VIRTUAL_DISPLAY_FLAG_PRESENTATION = 1 << 1;
     private final VirtualDisplayListener vdListener;
     private final NewDisplay newDisplay;
 
@@ -171,7 +171,8 @@ public class NewDisplayCapture extends SurfaceCapture {
             int flags = VIRTUAL_DISPLAY_FLAG_PUBLIC
                     | VIRTUAL_DISPLAY_FLAG_OWN_CONTENT_ONLY
                     | VIRTUAL_DISPLAY_FLAG_SUPPORTS_TOUCH
-                    | VIRTUAL_DISPLAY_FLAG_ROTATES_WITH_CONTENT;
+                    | VIRTUAL_DISPLAY_FLAG_ROTATES_WITH_CONTENT
+                    | VIRTUAL_DISPLAY_FLAG_PRESENTATION;
             if (vdDestroyContent) {
                 flags |= VIRTUAL_DISPLAY_FLAG_DESTROY_CONTENT_ON_REMOVAL;
             }

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -36,7 +36,7 @@ public class NewDisplayCapture extends SurfaceCapture {
     private static final int VIRTUAL_DISPLAY_FLAG_TOUCH_FEEDBACK_DISABLED = 1 << 13;
     private static final int VIRTUAL_DISPLAY_FLAG_OWN_FOCUS = 1 << 14;
     private static final int VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP = 1 << 15;
-    private static final int VIRTUAL_DISPLAY_FLAG_PRESENTATION = 1 << 1;
+    private static final int VIRTUAL_DISPLAY_FLAG_PRESENTATION = android.hardware.display.DisplayManager.VIRTUAL_DISPLAY_FLAG_PRESENTATION;
     private final VirtualDisplayListener vdListener;
     private final NewDisplay newDisplay;
 


### PR DESCRIPTION
This two-line addition to the server makes it so that apps with baked in two-screen support, such as DS and 3DS emulator apps (including MelonDS, Drastic, and Azahar), can see the scrcpy virtual display as an external display they can present to. This allows one to plug a phone into their computer, run `./scrcpy --new-display=1920x1080 --no-vd-system-decorations` (for example)then launch azahar or other emulators with support for this on their main display, and the app will treat the scrcpy virtual display the same way it would treat a real plugged-in display or a chromecast/miracast-connected display.

I have not tested this extensively, but it works well on my Galaxy S23 with Azahar, as pictured below. Occasionally the screen goes black for some reason I don't fully understand, but killing it, relaunching scrcpy, and forcing a refresh by rotating the screen on my phone brings it back with no problem. 

It is possible this feature should be behind a command-line flag or limited to certain versions of android; I am not an expert in scrcpy itself and present this primarily as proof of concept. There appear to be several feature requests ranging back to 2019 that are essentially asking for this feature in various ways, including #4708 and #886 

![WhatsApp Image 2025-09-11 at 15 50 45](https://github.com/user-attachments/assets/21b0cf1e-8cbc-4717-a52f-78cd916e26c5)
