### PR TITLE
Clean handling of ANDROID_PLATFORM containing decimal, like 36.1

### DIFF
--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -86,7 +86,7 @@ javac -encoding UTF-8 -bootclasspath "$ANDROID_JAR" \
 echo "Dexing..."
 cd "$CLASSES_DIR"
 
-if [[ $PLATFORM -lt 31 ]]
+if [[ ${PLATFORM%.*} -lt 31 ]]
 then
     # use dx
     "$BUILD_TOOLS_DIR/dx" --dex --output "$BUILD_DIR/classes.dex" \


### PR DESCRIPTION
Removes the following error:
./server/build_without_gradle.sh: line 89:
[[: 36.1: syntax error: invalid arithmetic operator (error token is ".1")

Tested with
```sh
ANDROID_PLATFORM=36.1 ANDROID_BUILD_TOOLS=36.1.0 ./server/build_without_gradle.sh
```