### PR TITLE
Check headers for reallocarray

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -139,14 +139,28 @@ check_functions = [
     'vasprintf',
     'nrand48',
     'jrand48',
-    'reallocarray',
 ]
+
+check_functions_in_headers = {
+    'stdlib.h': [
+        'reallocarray'
+    ],
+}
 
 foreach f : check_functions
   if cc.has_function(f)
     define = 'HAVE_' + f.underscorify().to_upper()
     conf.set(define, true)
   endif
+endforeach
+
+foreach header, f_list : check_functions_in_headers
+    foreach f : f_list
+        if cc.has_function(f) and cc.has_header_symbol(header, f, args: ['-D_GNU_SOURCE'])
+            define = 'HAVE_' + f.underscorify().to_upper()
+            conf.set(define, true)
+        endif
+    endforeach
 endforeach
 
 conf.set('HAVE_SOCK_CLOEXEC', host_machine.system() != 'windows' and


### PR DESCRIPTION
meson's `cc.has_function(f)` only does a link check (faster)
on Android's bionic libc, `reallocarray` links, but the headers don't define `reallocarray`

older malloc.h (on termux):
```c
/**
 * [reallocarray(3)](https://man7.org/linux/man-pages/man3/reallocarray.3.html)
 * resizes allocated memory on the heap.
 *
 * Equivalent to `realloc(__ptr, __item_count * __item_size)` but fails if the
 * multiplication overflows.
 *
 * Returns a pointer (which may be different from `__ptr`) to the resized
 * memory on success and returns a null pointer and sets `errno` on failure
 * (but see the notes for malloc()).
 */
#if __ANDROID_API__ >= 29
__nodiscard void* _Nullable reallocarray(void* _Nullable __ptr, size_t __item_count, size_t __item_size) __BIONIC_ALLOC_SIZE(2, 3) __INTRODUCED_IN(29);
#elif defined(__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__)
#include <errno.h>
static __inline __nodiscard void* _Nullable reallocarray(void* _Nullable __ptr, size_t __item_count, size_t __item_size) __BIONIC_ALLOC_SIZE(2, 3) {
  size_t __new_size;
  if (__builtin_mul_overflow(__item_count, __item_size, &__new_size)) {
    errno = ENOMEM;
    return NULL;
  }
  return realloc(__ptr, __new_size);
}
#endif
```
if the header does not define it, (`__ANDROID_API__`  too low), then use `compat.c` fallback ?

```c
cc.has_header_symbol(header, f, args: ['-D_GNU_SOURCE'])
```
symbol check is not a function check, but I don't know how to do a function check
`-D_GNU_SOURCE` is needed because this is the command used by meson:
```
... -D_FILE_OFFSET_BITS=64 -O0 -Werror=implicit-function-declaration -std=c11
```
without `-std=c11`, it'd work,

```c
#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
#include <alloca.h>
...
void *reallocarray (void *, size_t, size_t);
void qsort_r (void *, size_t, size_t, int (*)(const void *, const void *, void *), void *);
#endif
```
somewhere above:
```meson
conf.set('_GNU_SOURCE', true)
```
defines `_GNU_SOURCE`, but I found no way of passing `conf` to `cc.has_header_symbol` to not have to do
```meson
args: ['-D_GNU_SOURCE']
```

<details>
<summary>extras:</summary>

`cc.has_function()`
```c
#define reallocarray meson_disable_define_of_reallocarray

#include <limits.h>
#undef reallocarray

#ifdef __cplusplus
extern "C"
#endif
char reallocarray (void);

#if defined __stub_reallocarray || defined __stub___reallocarray
fail fail fail this function is not going to work
#endif

int main(void) {
    return reallocarray ();
}
```
`cc.has_header_symbol()`
```c
#include <stdlib.h>
int main(void) {
    /* If it's not defined as a macro, try to use as a symbol */
    #ifndef reallocarray
        reallocarray;
    #endif
    return 0;
}
```

</details>