### PR TITLE
Fix incorrect icon filename in build documentation

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -271,7 +271,7 @@ This installs several files:
  - `/usr/local/bin/scrcpy` (main app)
  - `/usr/local/share/scrcpy/scrcpy-server` (server to push to the device)
  - `/usr/local/share/man/man1/scrcpy.1` (manpage)
- - `/usr/local/share/icons/hicolor/256x256/apps/icon.png` (app icon)
+ - `/usr/local/share/icons/hicolor/256x256/apps/scrcpy.png` (app icon)
  - `/usr/local/share/zsh/site-functions/_scrcpy` (zsh completion)
  - `/usr/local/share/bash-completion/completions/scrcpy` (bash completion)
 


### PR DESCRIPTION
The installed icon was listed as `icon.png`, but the actual filename is `scrcpy.png`.