### PR TITLE
Prevent division-by-zero when mouse moves at start

### DIFF
--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -867,7 +867,9 @@ sc_screen_handle_event(struct sc_screen *screen, const SDL_Event *event) {
         return true;
     }
 
-    sc_input_manager_handle_event(&screen->im, event);
+    if (screen->has_frame) {
+        sc_input_manager_handle_event(&screen->im, event);
+    }
     return true;
 }
 


### PR DESCRIPTION
A simple solution by checking that the frame is created before handling input events.