### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       GRADLE: gradle  # use native gradle instead of ./gradlew in scripts
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -34,10 +34,10 @@ jobs:
       GRADLE: gradle  # use native gradle instead of ./gradlew in scripts
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -46,7 +46,7 @@ jobs:
         run: release/build_server.sh
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: scrcpy-server
           path: release/work/build-server/server/scrcpy-server
@@ -55,10 +55,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -96,7 +96,7 @@ jobs:
             fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -118,7 +118,7 @@ jobs:
             tar -C .. -cvf dist.tar.gz dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-linux-x86_64-intermediate
           path: release/work/build-linux-x86_64/dist-tar/
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -149,7 +149,7 @@ jobs:
             tar -C .. -cvf dist.tar.gz dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-win32-intermediate
           path: release/work/build-win32/dist-tar/
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -180,7 +180,7 @@ jobs:
             tar -C .. -cvf dist.tar.gz dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-win64-intermediate
           path: release/work/build-win64/dist-tar/
@@ -198,7 +198,7 @@ jobs:
             fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: |
@@ -223,7 +223,7 @@ jobs:
             tar -C .. -cvf dist.tar.gz dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-macos-aarch64-intermediate
           path: release/work/build-macos-aarch64/dist-tar/
@@ -241,7 +241,7 @@ jobs:
             fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install dependencies
         run: brew install meson nasm libiconv zlib automake
@@ -266,7 +266,7 @@ jobs:
             tar -C .. -cvf dist.tar.gz dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-macos-x86_64-intermediate
           path: release/work/build-macos-x86_64/dist-tar/
@@ -278,16 +278,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrcpy-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
 
       - name: Download build-linux-x86_64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-linux-x86_64-intermediate
           path: release/work/build-linux-x86_64/dist-tar/
@@ -302,7 +302,7 @@ jobs:
         run: release/package_client.sh linux-x86_64 tar.gz
 
       - name: Upload release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-linux-x86_64
           path: release/output/
@@ -314,16 +314,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrcpy-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
 
       - name: Download build-win32
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-win32-intermediate
           path: release/work/build-win32/dist-tar/
@@ -338,7 +338,7 @@ jobs:
         run: release/package_client.sh win32 zip
 
       - name: Upload release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-win32
           path: release/output/
@@ -350,16 +350,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrcpy-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
 
       - name: Download build-win64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-win64-intermediate
           path: release/work/build-win64/dist-tar/
@@ -374,7 +374,7 @@ jobs:
         run: release/package_client.sh win64 zip
 
       - name: Upload release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-win64
           path: release/output
@@ -386,16 +386,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrcpy-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
 
       - name: Download build-macos-aarch64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-macos-aarch64-intermediate
           path: release/work/build-macos-aarch64/dist-tar/
@@ -410,7 +410,7 @@ jobs:
         run: release/package_client.sh macos-aarch64 tar.gz
 
       - name: Upload release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-macos-aarch64
           path: release/output/
@@ -422,16 +422,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrcpy-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
 
       - name: Download build-macos
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: build-macos-x86_64-intermediate
           path: release/work/build-macos-x86_64/dist-tar/
@@ -446,7 +446,7 @@ jobs:
         run: release/package_client.sh macos-x86_64 tar.gz
 
       - name: Upload release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-macos-x86_64
           path: release/output/
@@ -462,40 +462,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download scrcpy-server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: scrcpy-server
           path: release/work/build-server/server/
 
       - name: Download release-linux-x86_64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-linux-x86_64
           path: release/output/
 
       - name: Download release-win32
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-win32
           path: release/output/
 
       - name: Download release-win64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-win64
           path: release/output/
 
       - name: Download release-macos-aarch64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-macos-aarch64
           path: release/output/
 
       - name: Download release-macos-x86_64
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: release-macos-x86_64
           path: release/output/
@@ -507,7 +507,7 @@ jobs:
         run: release/generate_checksums.sh
 
       - name: Upload release artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: scrcpy-release-${{ env.VERSION }}
           path: release/output


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/setup-java` from `v4` to `v5` in `.github/workflows/release.yml`
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/release.yml`
- Updated `actions/download-artifact` from `v4` to `v7` in `.github/workflows/release.yml`
