### PR TITLE
Update JDK17 installation on Mac

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -172,8 +172,7 @@ Additionally, if you want to build the server, install Java 17 from Caskroom, an
 make it available from the `PATH`:
 
 ```bash
-brew tap homebrew/cask-versions
-brew install adoptopenjdk/openjdk/adoptopenjdk17
+brew install --cask temurin@17
 export JAVA_HOME="$(/usr/libexec/java_home --version 1.17)"
 export PATH="$JAVA_HOME/bin:$PATH"
 ```

--- a/doc/build.md
+++ b/doc/build.md
@@ -172,7 +172,7 @@ Additionally, if you want to build the server, install Java 17 from Caskroom, an
 make it available from the `PATH`:
 
 ```bash
-brew install --cask temurin@17
+brew install openjdk@17
 export JAVA_HOME="$(/usr/libexec/java_home --version 1.17)"
 export PATH="$JAVA_HOME/bin:$PATH"
 ```


### PR DESCRIPTION
The JDK17 cask is now deprecated. The project has moved to Adoptium and can be installed through https://formulae.brew.sh/cask/temurin