### PR TITLE
Allow macOS to get better OpenGL version again

### DIFF
--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -417,6 +417,31 @@ sc_screen_init(struct sc_screen *screen,
         goto error_destroy_window;
     }
 
+#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
+    screen->gl_context = NULL;
+    // starts with "opengl"
+    const char *renderer_name = SDL_GetRendererName(screen->renderer);
+    bool use_opengl = renderer_name && !strncmp(renderer_name, "opengl", 6);
+    if (use_opengl) {
+
+        LOGD("Attempting to get better OpenGL version");
+        // Persuade macOS to give us something better than OpenGL 2.1.
+        // If we create a Core Profile context, we get the best OpenGL version.
+        bool ok = SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
+				      SDL_GL_CONTEXT_PROFILE_CORE);
+	if (!ok) {
+	    LOGW("Could not set a GL Core Profile Context");
+	}
+
+	LOGD("Creating OpenGL Core Profile context");
+	screen->gl_context = SDL_GL_CreateContext(screen->window);
+	if (!screen->gl_context) {
+	    LOGE("Could not create OpenGL context: %s", SDL_GetError());
+	    goto error_destroy_window;
+	}
+    }
+#endif
+
     bool mipmaps = params->video;
     ok = sc_texture_init(&screen->tex, screen->renderer, mipmaps);
     if (!ok) {
@@ -522,6 +547,11 @@ error_destroy_texture:
 error_destroy_renderer:
     SDL_DestroyRenderer(screen->renderer);
 error_destroy_window:
+#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
+    if (!screen->gl_context) {
+        SDL_GL_DestroyContext(screen->gl_context);
+    }
+#endif
     SDL_DestroyWindow(screen->window);
 error_destroy_fps_counter:
     sc_fps_counter_destroy(&screen->fps_counter);

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -22,6 +22,10 @@
 #include "trait/frame_sink.h"
 #include "trait/mouse_processor.h"
 
+#ifdef __APPLE__
+# define SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
+#endif
+
 struct sc_screen {
     struct sc_frame_sink frame_sink; // frame sink trait
 
@@ -50,6 +54,9 @@ struct sc_screen {
 
     SDL_Window *window;
     SDL_Renderer *renderer;
+#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
+    SDL_GLContext gl_context;
+#endif
     struct sc_size frame_size;
     struct sc_size content_size; // rotated frame_size
 

--- a/app/src/texture.c
+++ b/app/src/texture.c
@@ -14,30 +14,9 @@ sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps) {
 
     tex->mipmaps = false;
 
-#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
-    display->gl_context = NULL;
-#endif
-
     // starts with "opengl"
     bool use_opengl = renderer_name && !strncmp(renderer_name, "opengl", 6);
     if (use_opengl) {
-
-#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
-        // Persuade macOS to give us something better than OpenGL 2.1.
-        // If we create a Core Profile context, we get the best OpenGL version.
-        bool ok = SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK,
-                                      SDL_GL_CONTEXT_PROFILE_CORE);
-        if (!ok) {
-            LOGW("Could not set a GL Core Profile Context");
-        }
-
-        LOGD("Creating OpenGL Core Profile context");
-        display->gl_context = SDL_GL_CreateContext(window);
-        if (!display->gl_context) {
-            LOGE("Could not create OpenGL context: %s", SDL_GetError());
-            return false;
-        }
-#endif
 
         struct sc_opengl *gl = &tex->gl;
         sc_opengl_init(gl);
@@ -69,9 +48,6 @@ sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps) {
 
 void
 sc_texture_destroy(struct sc_texture *tex) {
-#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
-    SDL_GL_DestroyContext(tex->gl_context);
-#endif
     if (tex->texture) {
         SDL_DestroyTexture(tex->texture);
     }

--- a/app/src/texture.h
+++ b/app/src/texture.h
@@ -11,10 +11,6 @@
 #include "coords.h"
 #include "opengl.h"
 
-#ifdef __APPLE__
-# define SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
-#endif
-
 enum sc_texture_type {
     SC_TEXTURE_TYPE_FRAME,
     SC_TEXTURE_TYPE_ICON,
@@ -28,9 +24,6 @@ struct sc_texture {
     enum sc_texture_type texture_type;
 
     struct sc_opengl gl;
-#ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
-    SDL_GLContext gl_context;
-#endif
 
     bool mipmaps;
     uint32_t texture_id; // only set if mipmaps is enabled


### PR DESCRIPTION
Figured out how to fix #6636 .
Getting OpenGL 4.1 instead of 2.1 again.
