### PR TITLE
Keep Windows terminal open on error by default

### DIFF
--- a/app/data/scrcpy-console.bat
+++ b/app/data/scrcpy-console.bat
@@ -1,2 +1,0 @@
-@echo off
-scrcpy.exe --pause-on-exit=if-error %*

--- a/app/src/cli.h
+++ b/app/src/cli.h
@@ -8,6 +8,7 @@
 #include "options.h"
 
 enum sc_pause_on_exit {
+    SC_PAUSE_ON_EXIT_UNDEFINED,
     SC_PAUSE_ON_EXIT_TRUE,
     SC_PAUSE_ON_EXIT_FALSE,
     SC_PAUSE_ON_EXIT_IF_ERROR,

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -39,7 +39,7 @@ main_scrcpy(int argc, char *argv[]) {
         .opts = scrcpy_options_default,
         .help = false,
         .version = false,
-        .pause_on_exit = SC_PAUSE_ON_EXIT_FALSE,
+        .pause_on_exit = SC_PAUSE_ON_EXIT_UNDEFINED,
     };
 
 #ifndef NDEBUG

--- a/doc/windows.md
+++ b/doc/windows.md
@@ -72,18 +72,6 @@ Documentation for command line arguments is available:
  - `scrcpy --help`
  - on [github](/README.md)
 
-To start scrcpy directly without opening a terminal, double-click on one of
-these files:
- - `scrcpy-console.bat`: start with a terminal open (it will close when scrcpy
-   terminates, unless an error occurs);
- - `scrcpy-noconsole.vbs`: start without a terminal (but you won't see any error
-   message).
-
-_Avoid double-clicking on `scrcpy.exe` directly: on error, the terminal would
-close immediately and you won't have time to read any error message (this
-executable is intended to be run from the terminal). Use `scrcpy-console.bat`
-instead._
-
 If you plan to always use the same arguments, create a file `myscrcpy.bat`
 (enable [show file extensions] to avoid confusion) containing your command, For
 example:
@@ -92,9 +80,17 @@ example:
 scrcpy --prefer-text --turn-screen-off --stay-awake
 ```
 
+Add `--pause-on-exit=if-error` if you want the console to remain open when
+scrcpy fails:
+
+```bash
+scrcpy --prefer-text --turn-screen-off --stay-awake --pause-on-exit=if-error
+```
+
 [show file extensions]: https://www.howtogeek.com/205086/beginner-how-to-make-windows-show-file-extensions/
 
-Then just double-click on that file.
+Then just double-click on that file to run it.
 
-You could also edit (a copy of) `scrcpy-console.bat` or `scrcpy-noconsole.vbs`
-to add some arguments.
+To start scrcpy without opening a terminal, double-click `scrcpy-noconsole.vbs`
+(note that errors won't be shown). To pass arguments, edit (a copy of)
+`scrcpy-noconsole.vbs` add and the desired arguments.

--- a/release/build_windows.sh
+++ b/release/build_windows.sh
@@ -45,7 +45,6 @@ ninja -C "$WINXX_BUILD_DIR"
 # Group intermediate outputs into a 'dist' directory
 mkdir -p "$WINXX_BUILD_DIR/dist"
 cp "$WINXX_BUILD_DIR"/app/scrcpy.exe "$WINXX_BUILD_DIR/dist/"
-cp app/data/scrcpy-console.bat "$WINXX_BUILD_DIR/dist/"
 cp app/data/scrcpy-noconsole.vbs "$WINXX_BUILD_DIR/dist/"
 cp app/data/icon.png "$WINXX_BUILD_DIR/dist/"
 cp app/data/open_a_terminal_here.bat "$WINXX_BUILD_DIR/dist/"


### PR DESCRIPTION
If scrcpy is launched by double-clicking `scrcpy.exe` in Windows Explorer, automatically set `--pause-on-exit=if-error`.

Without this, the terminal would close immediately, preventing the user from seeing the error.

Also remove `scrcpy-console.bat`, which is now useless.

---

Detecting whether it is launched by double-clicking relies on a heuristic (it is not 100% reliable). Basically it checks how many processes share the console. If there is only one, then it's probably launched by double-clicking from Windows Explorer. In practice, it works:
 - running by double-clicking on `scrcpy.exe` implicitly sets `--pause-on-exit=if-error`
 - running from a terminal or a `.bat` does not implicit pause on exit.

Like #6662, the goal is to avoid getting a window that disappears without knowing why, which could suggest that a crash occurred (even though there is no crash).