### PR TITLE
Set low-latency high-priority encoder hints by default

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -264,6 +264,8 @@ public class SurfaceEncoder implements AsyncProcessor {
         format.setInteger(MediaFormat.KEY_I_FRAME_INTERVAL, DEFAULT_I_FRAME_INTERVAL);
         // display the very first frame, and recover from bad quality when no new frames
         format.setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, REPEAT_FRAME_DELAY_US); // µs
+        // real-time priority
+        format.setInteger(MediaFormat.KEY_PRIORITY, 0);
         if (maxFps > 0) {
             // The key existed privately before Android 10:
             // <https://android.googlesource.com/platform/frameworks/base/+/625f0aad9f7a259b6881006ad8710adce57d1384%5E%21/>

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -266,6 +266,8 @@ public class SurfaceEncoder implements AsyncProcessor {
         format.setLong(MediaFormat.KEY_REPEAT_PREVIOUS_FRAME_AFTER, REPEAT_FRAME_DELAY_US); // µs
         // real-time priority
         format.setInteger(MediaFormat.KEY_PRIORITY, 0);
+        // output 1 frame as soon as 1 frame is queued
+        format.setInteger(MediaFormat.KEY_LATENCY, 1);
         if (maxFps > 0) {
             // The key existed privately before Android 10:
             // <https://android.googlesource.com/platform/frameworks/base/+/625f0aad9f7a259b6881006ad8710adce57d1384%5E%21/>


### PR DESCRIPTION
See https://github.com/Genymobile/scrcpy/issues/6238#issuecomment-3828402687

Doc:
- https://developer.android.com/reference/android/media/MediaFormat#KEY_PRIORITY
- https://developer.android.com/reference/android/media/MediaFormat#KEY_LATENCY