### PR TITLE
Prevent build from falling back to system libs

### DIFF
--- a/release/build_linux.sh
+++ b/release/build_linux.sh
@@ -22,9 +22,12 @@ app/deps/libusb.sh linux native static
 DEPS_INSTALL_DIR="$PWD/app/deps/work/install/linux-native-static"
 ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-linux"
 
+# Never fall back to system libs
+unset PKG_CONFIG_PATH
+export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig"
+
 rm -rf "$LINUX_BUILD_DIR"
 meson setup "$LINUX_BUILD_DIR" \
-    --pkg-config-path="$DEPS_INSTALL_DIR/lib/pkgconfig" \
     -Dc_args="-I$DEPS_INSTALL_DIR/include" \
     -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
     --buildtype=release \

--- a/release/build_macos.sh
+++ b/release/build_macos.sh
@@ -22,9 +22,12 @@ app/deps/libusb.sh macos native static
 DEPS_INSTALL_DIR="$PWD/app/deps/work/install/macos-native-static"
 ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-macos"
 
+# Never fall back to system libs
+unset PKG_CONFIG_PATH
+export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig"
+
 rm -rf "$MACOS_BUILD_DIR"
 meson setup "$MACOS_BUILD_DIR" \
-    --pkg-config-path="$DEPS_INSTALL_DIR/lib/pkgconfig" \
     -Dc_args="-I$DEPS_INSTALL_DIR/include" \
     -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
     --buildtype=release \

--- a/release/build_windows.sh
+++ b/release/build_windows.sh
@@ -29,9 +29,12 @@ app/deps/libusb.sh $WINXX cross shared
 DEPS_INSTALL_DIR="$PWD/app/deps/work/install/$WINXX-cross-shared"
 ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-windows"
 
+# Never fall back to system libs
+unset PKG_CONFIG_PATH
+export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig"
+
 rm -rf "$WINXX_BUILD_DIR"
 meson setup "$WINXX_BUILD_DIR" \
-    --pkg-config-path="$DEPS_INSTALL_DIR/lib/pkgconfig" \
     -Dc_args="-I$DEPS_INSTALL_DIR/include" \
     -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
     --cross-file=cross_$WINXX.txt \


### PR DESCRIPTION
Ensure that if a file or function is not found, the build does not attempt to use system libraries. Falling back could introduce incompatible versions or libraries compiles with different features.