### PR TITLE
Correct output information

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -1700,7 +1700,7 @@ parse_orientation(const char *s, enum sc_orientation *orientation) {
         return true;
     }
     LOGE("Unsupported orientation: %s (expected 0, 90, 180, 270, flip0, "
-         "flip90, flip180 or flip270)", optarg);
+         "flip90, flip180 or flip270)", s);
     return false;
 }
 


### PR DESCRIPTION
scrcpy --capture-orientation=@100
scrcpy 3.3.4 <https://github.com/Genymobile/scrcpy>
2026-02-28 10:59:22.537 scrcpy[91098:1428736] ERROR: Unsupported orientation: @100 (expected 0, 90, 180, 270, flip0, flip90, flip180 or flip270)

We should tell the user that the error is 100, not @100.