### PR TITLE
Feature: Do not disturb

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -25,6 +25,7 @@ _scrcpy() {
         --display-id=
         --display-ime-policy=
         --display-orientation=
+        --do-not-disturb
         -e --select-tcpip
         -f --fullscreen
         --force-adb-forward

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -32,6 +32,7 @@ arguments=(
     '--display-id=[Specify the display id to mirror]'
     '--display-ime-policy[Set the policy for selecting where the IME should be displayed]'
     '--display-orientation=[Set the initial display orientation]:orientation values:(0 90 180 270 flip0 flip90 flip180 flip270)'
+    '--do-not-disturb[Enable Do Not Disturb]'
     {-e,--select-tcpip}'[Use TCP/IP device]'
     {-f,--fullscreen}'[Start in fullscreen]'
     '--force-adb-forward[Do not attempt to use \"adb reverse\" to connect to the device]'

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -114,6 +114,7 @@ enum {
     OPT_NO_VD_SYSTEM_DECORATIONS,
     OPT_NO_VD_DESTROY_CONTENT,
     OPT_DISPLAY_IME_POLICY,
+    OPT_DO_NOT_DISTURB,
 };
 
 struct sc_option {
@@ -408,6 +409,11 @@ static const struct sc_option options[] = {
                 "in degrees; the \"flip\" keyword applies a horizontal flip "
                 "before the rotation.\n"
                 "Default is 0.",
+    },
+    {
+        .longopt_id = OPT_DO_NOT_DISTURB,
+        .longopt = "do-not-disturb",
+        .text = "Enable Do Not Disturb",
     },
     {
         .shortopt = 'e',
@@ -2820,6 +2826,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                                               &opts->display_ime_policy)) {
                     return false;
                 }
+                break;
+            case OPT_DO_NOT_DISTURB:
+                opts->do_not_disturb = true;
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -113,6 +113,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .angle = NULL,
     .vd_destroy_content = true,
     .vd_system_decorations = true,
+    .do_not_disturb = false,
 };
 
 enum sc_orientation

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -314,6 +314,7 @@ struct scrcpy_options {
     bool require_audio;
     bool kill_adb_on_close;
     bool camera_high_speed;
+    bool do_not_disturb;
 #define SC_OPTION_LIST_ENCODERS 0x1
 #define SC_OPTION_LIST_DISPLAYS 0x2
 #define SC_OPTION_LIST_CAMERAS 0x4

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -453,6 +453,7 @@ scrcpy(struct scrcpy_options *options) {
         .audio_dup = options->audio_dup,
         .show_touches = options->show_touches,
         .stay_awake = options->stay_awake,
+        .do_not_disturb = options->do_not_disturb,
         .video_codec_options = options->video_codec_options,
         .audio_codec_options = options->audio_codec_options,
         .video_encoder = options->video_encoder,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -360,6 +360,9 @@ execute_server(struct sc_server *server,
     if (params->show_touches) {
         ADD_PARAM("show_touches=true");
     }
+    if (params->do_not_disturb) {
+        ADD_PARAM("do_not_disturb=true");
+    }
     if (params->stay_awake) {
         ADD_PARAM("stay_awake=true");
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -56,6 +56,7 @@ struct sc_server_params {
     bool audio_dup;
     bool show_touches;
     bool stay_awake;
+    bool do_not_disturb;
     bool force_adb_forward;
     bool power_off_on_close;
     bool clipboard_autosync;

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -6,6 +6,8 @@ import com.genymobile.scrcpy.util.Settings;
 import com.genymobile.scrcpy.util.SettingsException;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
+import android.app.NotificationManager;
+import android.content.Context;
 import android.os.BatteryManager;
 import android.os.Looper;
 import android.system.ErrnoException;
@@ -80,6 +82,19 @@ public final class CleanUp {
             }
         }
 
+        int previousDoNotDisturbMode = NotificationManager.INTERRUPTION_FILTER_NONE;
+        if (options.getDoNotDisturb()) {
+            try {
+                FakeContext context = FakeContext.get();
+                NotificationManager notificationManager = (NotificationManager) context
+                        .getSystemService(Context.NOTIFICATION_SERVICE);
+                previousDoNotDisturbMode = notificationManager.getCurrentInterruptionFilter();
+                notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALARMS);
+            } catch (Exception e) {
+                Ln.e("Could not set dnd mode", e);
+            }
+        }
+
         int restoreScreenOffTimeout = -1;
         int screenOffTimeout = options.getScreenOffTimeout();
         if (screenOffTimeout != -1) {
@@ -116,14 +131,15 @@ public final class CleanUp {
         boolean powerOffScreen = options.getPowerOffScreenOnClose();
 
         try {
-            run(displayId, restoreStayOn, disableShowTouches, powerOffScreen, restoreScreenOffTimeout, restoreDisplayImePolicy);
+            run(displayId, restoreStayOn, disableShowTouches, powerOffScreen, restoreScreenOffTimeout, restoreDisplayImePolicy, previousDoNotDisturbMode);
         } catch (IOException e) {
             Ln.e("Clean up I/O exception", e);
         }
     }
 
     private void run(int displayId, int restoreStayOn, boolean disableShowTouches, boolean powerOffScreen, int restoreScreenOffTimeout,
-            int restoreDisplayImePolicy) throws IOException {
+            int restoreDisplayImePolicy,
+            int previousDoNotDisturbMode) throws IOException {
         String[] cmd = {
                 "app_process",
                 "/",
@@ -134,6 +150,7 @@ public final class CleanUp {
                 String.valueOf(powerOffScreen),
                 String.valueOf(restoreScreenOffTimeout),
                 String.valueOf(restoreDisplayImePolicy),
+                String.valueOf(previousDoNotDisturbMode),
         };
 
         ProcessBuilder builder = new ProcessBuilder(cmd);
@@ -204,6 +221,7 @@ public final class CleanUp {
         boolean powerOffScreen = Boolean.parseBoolean(args[3]);
         int restoreScreenOffTimeout = Integer.parseInt(args[4]);
         int restoreDisplayImePolicy = Integer.parseInt(args[5]);
+        int previousDoNotDisturbMode = Integer.parseInt(args[6]);
 
         // Dynamic option
         boolean restoreDisplayPower = false;

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -7,7 +7,6 @@ import com.genymobile.scrcpy.util.SettingsException;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
 import android.app.NotificationManager;
-import android.content.Context;
 import android.os.BatteryManager;
 import android.os.Looper;
 import android.system.ErrnoException;
@@ -82,14 +81,13 @@ public final class CleanUp {
             }
         }
 
-        int previousDoNotDisturbMode = NotificationManager.INTERRUPTION_FILTER_NONE;
+        int previousDoNotDisturbMode = -1;
         if (options.getDoNotDisturb()) {
             try {
-                FakeContext context = FakeContext.get();
-                NotificationManager notificationManager = (NotificationManager) context
-                        .getSystemService(Context.NOTIFICATION_SERVICE);
+                NotificationManager notificationManager = ServiceManager.getNotificationManager();
                 previousDoNotDisturbMode = notificationManager.getCurrentInterruptionFilter();
                 notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALARMS);
+
             } catch (Exception e) {
                 Ln.e("Could not set dnd mode", e);
             }
@@ -282,6 +280,11 @@ public final class CleanUp {
                 Ln.i("Restoring display power");
                 Device.setDisplayPower(targetDisplayId, true);
             }
+        }
+
+        if(previousDoNotDisturbMode != -1) {
+            Ln.i("Restoring DoNotDisturbMode");
+            ServiceManager.getNotificationManager().setInterruptionFilter(previousDoNotDisturbMode);
         }
 
         System.exit(0);

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -48,6 +48,7 @@ public class Options {
     private boolean cameraHighSpeed;
     private boolean showTouches;
     private boolean stayAwake;
+    private boolean doNotDisturb;
     private int screenOffTimeout = -1;
     private int displayImePolicy = -1;
     private List<CodecOption> videoCodecOptions;
@@ -182,6 +183,10 @@ public class Options {
 
     public boolean getStayAwake() {
         return stayAwake;
+    }
+
+    public boolean getDoNotDisturb() {
+        return doNotDisturb;
     }
 
     public int getScreenOffTimeout() {
@@ -392,6 +397,9 @@ public class Options {
                     break;
                 case "stay_awake":
                     options.stayAwake = Boolean.parseBoolean(value);
+                    break;
+                case "do_not_disturb":
+                    options.doNotDisturb = Boolean.parseBoolean(value);
                     break;
                 case "screen_off_timeout":
                     options.screenOffTimeout = Integer.parseInt(value);

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ServiceManager.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy.wrappers;
 
 import com.genymobile.scrcpy.FakeContext;
 
+import android.app.NotificationManager;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.hardware.camera2.CameraManager;
@@ -32,6 +33,7 @@ public final class ServiceManager {
     private static ClipboardManager clipboardManager;
     private static ActivityManager activityManager;
     private static CameraManager cameraManager;
+    private static NotificationManager notificationManager;
 
     private ServiceManager() {
         /* not instantiable */
@@ -108,5 +110,18 @@ public final class ServiceManager {
             }
         }
         return cameraManager;
+    }
+
+    public static NotificationManager getNotificationManager() {
+        if (notificationManager == null) {
+            try {
+                // a similar method like CameraManager is only available for Android >= 16
+                // https://android.googlesource.com/platform/frameworks/base/+blame/refs/tags/android-16.0.0_r4/core/java/android/app/NotificationManager.java#718
+                notificationManager = (NotificationManager) FakeContext.get().getSystemService(Context.NOTIFICATION_SERVICE);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        }
+        return notificationManager;
     }
 }


### PR DESCRIPTION
This PR adds the commandline flag `--do-not-disturb` which automatically enables it on the android device.
It is mainly useful for when you need to demo an app from a device that can receive sensitive notifications.