### PR TITLE
 Activity launches when Android desktop mode is active (Android 16 QPR1+ / Android 17)

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -13,6 +13,7 @@ import com.genymobile.scrcpy.opengl.OpenGLRunner;
 import com.genymobile.scrcpy.util.AffineMatrix;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
+import com.genymobile.scrcpy.wrappers.WindowManager;
 
 import android.graphics.Rect;
 import android.hardware.display.VirtualDisplay;
@@ -187,7 +188,8 @@ public class NewDisplayCapture extends SurfaceCapture {
                         | VIRTUAL_DISPLAY_FLAG_TOUCH_FEEDBACK_DISABLED;
                 if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
                     flags |= VIRTUAL_DISPLAY_FLAG_OWN_FOCUS
-                            | VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP;
+                            | VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP
+                            | VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS;
                 }
             }
             virtualDisplay = ServiceManager.getDisplayManager()
@@ -197,6 +199,10 @@ public class NewDisplayCapture extends SurfaceCapture {
 
             if (displayImePolicy != -1) {
                 ServiceManager.getWindowManager().setDisplayImePolicy(virtualDisplayId, displayImePolicy);
+            }
+
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
+                ServiceManager.getWindowManager().setDisplayWindowingMode(virtualDisplayId, WindowManager.WINDOWING_MODE_FREEFORM);
             }
 
             displaySizeMonitor.start(virtualDisplayId, this::invalidate);

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -188,8 +188,7 @@ public class NewDisplayCapture extends SurfaceCapture {
                         | VIRTUAL_DISPLAY_FLAG_TOUCH_FEEDBACK_DISABLED;
                 if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
                     flags |= VIRTUAL_DISPLAY_FLAG_OWN_FOCUS
-                            | VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP
-                            | VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS;
+                            | VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP;
                 }
             }
             virtualDisplay = ServiceManager.getDisplayManager()

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -283,22 +283,33 @@ public final class WindowManager {
     @TargetApi(AndroidVersions.API_34_ANDROID_14)
     @SuppressWarnings("unchecked")
     public void setDisplayWindowingMode(int displayId, int windowingMode) {
-        // A Binder token used to identify this organizer during registration/unregistration with the system server
-        IBinder organizerBinder = new Binder();
+        // A Binder token with the correct AIDL interface descriptor, so that any system server
+        // callbacks during registration are properly identified and silently handled
+        IBinder organizerBinder = new Binder() {
+            {
+                attachInterface(null, "android.window.IDisplayAreaOrganizer");
+            }
+
+            @Override
+            protected boolean onTransact(int code, android.os.Parcel data, android.os.Parcel reply, int flags)
+                    throws android.os.RemoteException {
+                if (super.onTransact(code, data, reply, flags)) {
+                    return true;
+                }
+                // Silently accept any organizer callback transactions
+                return true;
+            }
+        };
         Object organizerProxy = null;
         Object daoController = null;
         try {
-            // Get the IWindowOrganizerController
-            Class<?> serviceManagerClass = Class.forName("android.os.ServiceManager");
-            Method getServiceMethod = serviceManagerClass.getDeclaredMethod("getService", String.class);
-            IBinder wocBinder = (IBinder) getServiceMethod.invoke(null, "window_organizer");
-            if (wocBinder == null) {
+            // Get the IWindowOrganizerController via ServiceManager
+            IInterface windowOrganizerController = ServiceManager.getService("window_organizer",
+                    "android.window.IWindowOrganizerController");
+            if (windowOrganizerController == null) {
                 Ln.w("window_organizer service not available");
                 return;
             }
-
-            Class<?> iWocStubClass = Class.forName("android.window.IWindowOrganizerController$Stub");
-            Object windowOrganizerController = iWocStubClass.getDeclaredMethod("asInterface", IBinder.class).invoke(null, wocBinder);
 
             // Get the IDisplayAreaOrganizerController
             daoController = windowOrganizerController.getClass().getMethod("getDisplayAreaOrganizerController").invoke(windowOrganizerController);

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -4,11 +4,15 @@ import com.genymobile.scrcpy.AndroidVersions;
 import com.genymobile.scrcpy.util.Ln;
 
 import android.annotation.TargetApi;
+import android.os.Binder;
 import android.os.Build;
+import android.os.IBinder;
 import android.os.IInterface;
 import android.view.IDisplayWindowListener;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
 
 public final class WindowManager {
 
@@ -17,6 +21,9 @@ public final class WindowManager {
     public static final int DISPLAY_IME_POLICY_LOCAL = 0;
     public static final int DISPLAY_IME_POLICY_FALLBACK_DISPLAY = 1;
     public static final int DISPLAY_IME_POLICY_HIDE = 2;
+
+    // android.app.WindowConfiguration.WINDOWING_MODE_FREEFORM
+    public static final int WINDOWING_MODE_FREEFORM = 5;
 
     private final IInterface manager;
     private Method getRotationMethod;
@@ -262,6 +269,93 @@ public final class WindowManager {
             }
         } catch (ReflectiveOperationException e) {
             Ln.e("Could not invoke method", e);
+        }
+    }
+
+    /**
+     * Set the windowing mode of a display's default task area via WindowContainerTransaction.
+     *
+     * This is required for Android desktop mode to operate in freeform windowing mode on virtual displays.
+     */
+    @TargetApi(AndroidVersions.API_34_ANDROID_14)
+    @SuppressWarnings("unchecked")
+    public void setDisplayWindowingMode(int displayId, int windowingMode) {
+        IBinder organizerBinder = new Binder();
+        Object organizerProxy = null;
+        Object daoController = null;
+        try {
+            // Get the IWindowOrganizerController
+            Class<?> serviceManagerClass = Class.forName("android.os.ServiceManager");
+            Method getServiceMethod = serviceManagerClass.getDeclaredMethod("getService", String.class);
+            IBinder wocBinder = (IBinder) getServiceMethod.invoke(null, "window_organizer");
+            if (wocBinder == null) {
+                Ln.w("window_organizer service not available");
+                return;
+            }
+
+            Class<?> iWocStubClass = Class.forName("android.window.IWindowOrganizerController$Stub");
+            Object windowOrganizerController = iWocStubClass.getDeclaredMethod("asInterface", IBinder.class).invoke(null, wocBinder);
+
+            // Get the IDisplayAreaOrganizerController
+            daoController = windowOrganizerController.getClass().getMethod("getDisplayAreaOrganizerController").invoke(windowOrganizerController);
+
+            // Create a no-op IDisplayAreaOrganizer proxy for registration
+            Class<?> idaoClass = Class.forName("android.window.IDisplayAreaOrganizer");
+            organizerProxy = Proxy.newProxyInstance(
+                    ClassLoader.getSystemClassLoader(),
+                    new Class[]{idaoClass},
+                    (proxy, method, args) -> {
+                        if ("asBinder".equals(method.getName())) {
+                            return organizerBinder;
+                        }
+                        return null;
+                    }
+            );
+
+            // Register the organizer for FEATURE_DEFAULT_TASK_CONTAINER (1) to get display area tokens
+            int featureDefaultTaskContainer = 1;
+            Object parceledList = daoController.getClass()
+                    .getMethod("registerOrganizer", idaoClass, int.class)
+                    .invoke(daoController, organizerProxy, featureDefaultTaskContainer);
+
+            List<Object> displayAreaInfos = (List<Object>) parceledList.getClass().getMethod("getList").invoke(parceledList);
+
+            // Find the display area token matching our virtual display
+            Object targetToken = null;
+            for (Object info : displayAreaInfos) {
+                Object displayAreaInfo = info.getClass().getMethod("getDisplayAreaInfo").invoke(info);
+                int daDisplayId = displayAreaInfo.getClass().getDeclaredField("displayId").getInt(displayAreaInfo);
+                if (daDisplayId == displayId) {
+                    targetToken = displayAreaInfo.getClass().getDeclaredField("token").get(displayAreaInfo);
+                    break;
+                }
+            }
+
+            if (targetToken != null) {
+                // Create a WindowContainerTransaction to set the windowing mode
+                Class<?> wctClass = Class.forName("android.window.WindowContainerTransaction");
+                Object wct = wctClass.getDeclaredConstructor().newInstance();
+
+                Class<?> tokenClass = Class.forName("android.window.WindowContainerToken");
+                wctClass.getMethod("setWindowingMode", tokenClass, int.class).invoke(wct, targetToken, windowingMode);
+
+                // Apply the transaction
+                windowOrganizerController.getClass().getMethod("applyTransaction", wctClass).invoke(windowOrganizerController, wct);
+            } else {
+                Ln.w("Could not find display area for display " + displayId);
+            }
+        } catch (Exception e) {
+            Ln.w("Could not set windowing mode for display " + displayId, e);
+        } finally {
+            // Always unregister the organizer
+            if (organizerProxy != null && daoController != null) {
+                try {
+                    Class<?> idaoClass = Class.forName("android.window.IDisplayAreaOrganizer");
+                    daoController.getClass().getMethod("unregisterOrganizer", idaoClass).invoke(daoController, organizerProxy);
+                } catch (Exception e) {
+                    Ln.w("Could not unregister display area organizer", e);
+                }
+            }
         }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/WindowManager.java
@@ -25,6 +25,9 @@ public final class WindowManager {
     // android.app.WindowConfiguration.WINDOWING_MODE_FREEFORM
     public static final int WINDOWING_MODE_FREEFORM = 5;
 
+    // android.window.DisplayAreaOrganizer.FEATURE_DEFAULT_TASK_CONTAINER
+    private static final int FEATURE_DEFAULT_TASK_CONTAINER = 1;
+
     private final IInterface manager;
     private Method getRotationMethod;
 
@@ -280,6 +283,7 @@ public final class WindowManager {
     @TargetApi(AndroidVersions.API_34_ANDROID_14)
     @SuppressWarnings("unchecked")
     public void setDisplayWindowingMode(int displayId, int windowingMode) {
+        // A Binder token used to identify this organizer during registration/unregistration with the system server
         IBinder organizerBinder = new Binder();
         Object organizerProxy = null;
         Object daoController = null;
@@ -299,7 +303,7 @@ public final class WindowManager {
             // Get the IDisplayAreaOrganizerController
             daoController = windowOrganizerController.getClass().getMethod("getDisplayAreaOrganizerController").invoke(windowOrganizerController);
 
-            // Create a no-op IDisplayAreaOrganizer proxy for registration
+            // Create a no-op IDisplayAreaOrganizer proxy for registration; callbacks are ignored since we unregister immediately
             Class<?> idaoClass = Class.forName("android.window.IDisplayAreaOrganizer");
             organizerProxy = Proxy.newProxyInstance(
                     ClassLoader.getSystemClassLoader(),
@@ -312,11 +316,10 @@ public final class WindowManager {
                     }
             );
 
-            // Register the organizer for FEATURE_DEFAULT_TASK_CONTAINER (1) to get display area tokens
-            int featureDefaultTaskContainer = 1;
+            // Register the organizer to get display area tokens
             Object parceledList = daoController.getClass()
                     .getMethod("registerOrganizer", idaoClass, int.class)
-                    .invoke(daoController, organizerProxy, featureDefaultTaskContainer);
+                    .invoke(daoController, organizerProxy, FEATURE_DEFAULT_TASK_CONTAINER);
 
             List<Object> displayAreaInfos = (List<Object>) parceledList.getClass().getMethod("getList").invoke(parceledList);
 


### PR DESCRIPTION
Summary of Changes
Problem
Virtual displays created by scrcpy don't correctly route activity launches when Android desktop mode is active (Android 16 QPR1+ / Android 17). Apps launched from the virtual display's desktop launcher open on the phone's main screen instead of the virtual display.

Root Cause
VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS was only set conditionally (via user option), not guaranteed on API 34+
The virtual display area was never assigned WINDOWING_MODE_FREEFORM via WindowContainerTransaction, which is required for freeform windowing in desktop mode
Changes Made
NewDisplayCapture.java (2 changes):

Added VIRTUAL_DISPLAY_FLAG_SHOULD_SHOW_SYSTEM_DECORATIONS to the unconditional API 34+ flag block — ensures the display is always treated as a full windowing environment on modern Android
Added call to setDisplayWindowingMode() after virtual display creation to set freeform windowing mode
WindowManager.java (1 new method + 2 constants):

Added WINDOWING_MODE_FREEFORM constant (= 5, from android.app.WindowConfiguration)
Added FEATURE_DEFAULT_TASK_CONTAINER constant (= 1, from android.window.DisplayAreaOrganizer)
Added setDisplayWindowingMode(int displayId, int windowingMode) method that:
Gets the IWindowOrganizerController service via reflection
Temporarily registers a no-op DisplayAreaOrganizer to obtain the display area's WindowContainerToken
Creates and applies a WindowContainerTransaction to set the windowing mode
Properly unregisters the organizer in a finally block
Gracefully handles failures with warning logs