### PR TITLE
Fix Android 16 crash: add missing IDisplayWindowListener methods

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayWindowListener.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayWindowListener.java
@@ -23,6 +23,17 @@ public class DisplayWindowListener extends IDisplayWindowListener.Stub {
         // empty default implementation
     }
 
+    // Android 16 added these methods to IDisplayWindowListener.
+    // They are not in the SDK stubs, so no @Override, but they must exist
+    // to prevent AbstractMethodError when the binder dispatches to them.
+    public void onDisplayAnimationsDisabledChanged(int displayId, boolean animationsDisabled) {
+        // empty default implementation
+    }
+
+    public void onDisplayAddSystemDecorations(int displayId) {
+        // empty default implementation
+    }
+
     @Override
     public boolean onTransact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
         try {


### PR DESCRIPTION
## Summary\n\nFixes #6362 — scrcpy crashes immediately on Android 16 with:\n\n```\njava.lang.AbstractMethodError: abstract method \"void android.view.IDisplayWindowListener.onDisplayAnimationsDisabledChanged(int, boolean)\"\n```\n\nAndroid 16 added two new methods to `IDisplayWindowListener`:\n- `onDisplayAnimationsDisabledChanged(int, boolean)`\n- `onDisplayAddSystemDecorations(int)`\n\nWithout stub implementations, the binder throws `AbstractMethodError` when dispatching to them. The existing `onTransact()` catch does not prevent this because the error occurs during binder dispatch before `onTransact()` is reached.\n\n## Changes\n\nAdded no-op stub implementations for both methods in `DisplayWindowListener.java`. `@Override` is omitted because these methods are not present in the current SDK stubs — they exist only at runtime on Android 16+.\n\n## Testing\n\n- Tested on Pixel 9 Pro XL running GrapheneOS (Android 16, build 2026030700)\n- scrcpy now connects and stays connected (previously crashed within 1-2 seconds)\n- Screen mirroring, input, rotation all working