### PR TITLE
fix: the server in server.c

### DIFF
--- a/app/src/server.c
+++ b/app/src/server.c
@@ -578,9 +578,10 @@ device_read_info(struct sc_intr *intr, sc_socket device_socket,
         LOGE("Could not retrieve device information");
         return false;
     }
-    // in case the client sends garbage
+    // in case the client sends garbage, ensure null-termination
     buf[SC_DEVICE_NAME_FIELD_LENGTH - 1] = '\0';
-    memcpy(info->device_name, (char *) buf, sizeof(info->device_name));
+    strncpy(info->device_name, (char *) buf, sizeof(info->device_name) - 1);
+    info->device_name[sizeof(info->device_name) - 1] = '\0';
 
     return true;
 }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `app/src/server.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `app/src/server.c:583` |

**Description**: The server.c file copies device name data from a network buffer directly into a fixed-size buffer using memcpy without validating the source buffer size. The code copies exactly sizeof(info->device_name) bytes from the network buffer 'buf' without verifying that 'buf' actually contains that many bytes or that the data is properly bounded. This allows an attacker to send a malformed packet with insufficient data or oversized data that could overflow adjacent memory regions.

## Changes
- `app/src/server.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] Code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
