### PR TITLE
Use optimal size alignment

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -45,6 +45,7 @@ _scrcpy() {
         -m --max-size=
         -M
         --max-fps=
+        --min-size-alignment=
         --mouse=
         --mouse-bind=
         -n --no-control
@@ -187,6 +188,10 @@ _scrcpy() {
         -s|--serial)
             # Use 'adb devices' to list serial numbers
             COMPREPLY=($(compgen -W "$("${ADB:-adb}" devices | awk '$2 == "device" {print $1}')" -- ${cur}))
+            return
+            ;;
+        --min-size-alignment)
+            COMPREPLY=($(compgen -> '1 2 4 8 16' -- "$cur"))
             return
             ;;
         --audio-bit-rate \

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -52,6 +52,7 @@ arguments=(
     {-m,--max-size=}'[Limit both the width and height of the video to value]'
     '-M[Use UHID/AOA mouse \(same as --mouse=uhid or --mouse=aoa, depending on OTG mode\)]'
     '--max-fps=[Limit the frame rate of screen capture]'
+    '--min-size-alignment=[Minimum video size alignment (1, 2, 4, 8 or 16)]'
     '--mouse=[Set the mouse input mode]:mode:(disabled sdk uhid aoa)'
     '--mouse-bind=[Configure bindings of secondary clicks]'
     {-n,--no-control}'[Disable device control \(mirror the device in read only\)]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -297,6 +297,16 @@ Same as \fB\-\-mouse=uhid\fR, or \fB\-\-mouse=aoa\fR if \fB\-\-otg\fR is set.
 Limit the framerate of screen capture (officially supported since Android 10, but may work on earlier versions).
 
 .TP
+.BI "\-\-min\-size\-alignment " alignment
+Configure the minimum video size alignment.
+
+This is a power-of-2 value (1, 2, 4, 8 or 16) that the video width and height must be multiples of.
+
+The actual alignment will be the maximum of this value and the video codec's alignment requirement.
+
+Default is 1.
+
+.TP
 .BI "\-\-mouse " mode
 Select how to send mouse inputs to the device.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -116,6 +116,7 @@ enum {
     OPT_DISPLAY_IME_POLICY,
     OPT_CAMERA_TORCH,
     OPT_CAMERA_ZOOM,
+    OPT_MIN_SIZE_ALIGNMENT,
 };
 
 struct sc_option {
@@ -575,6 +576,17 @@ static const struct sc_option options[] = {
         .argdesc = "value",
         .text = "Limit the frame rate of screen capture (officially supported "
                 "since Android 10, but may work on earlier versions).",
+    },
+    {
+        .longopt_id = OPT_MIN_SIZE_ALIGNMENT,
+        .longopt = "min-size-alignment",
+        .argdesc = "alignment",
+        .text = "Configure the minimum video size alignment.\n"
+                "This is a power-of-2 value (1, 2, 4, 8 or 16) that the video "
+                "width and height must be multiples of.\n"
+                "The actual alignment will be the maximum of this value and "
+                "the video codec's alignment requirement.\n"
+                "Default is 1.",
     },
     {
         .longopt_id = OPT_MOUSE,
@@ -1642,6 +1654,22 @@ parse_max_size(const char *s, uint16_t *max_size) {
     }
 
     *max_size = (uint16_t) value;
+    return true;
+}
+
+static bool
+parse_min_size_alignment(const char *s, uint8_t *min_size_alignment) {
+    long value;
+    bool ok = parse_integer_arg(s, &value, false, 1, 16, "min size alignment");
+    if (!ok) {
+        return false;
+    }
+    if (value & (value - 1)) {
+        LOGE("The minimum size alignment (%ld) must be a power-of-2", value);
+        return false;
+    }
+
+    *min_size_alignment = (uint8_t) value;
     return true;
 }
 
@@ -2853,6 +2881,12 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_DISPLAY_IME_POLICY:
                 if (!parse_display_ime_policy(optarg,
                                               &opts->display_ime_policy)) {
+                    return false;
+                }
+                break;
+            case OPT_MIN_SIZE_ALIGNMENT:
+                if (!parse_min_size_alignment(optarg,
+                                              &opts->min_size_alignment)) {
                     return false;
                 }
                 break;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -49,6 +49,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .tunnel_host = 0,
     .tunnel_port = 0,
     .shortcut_mods = SC_SHORTCUT_MOD_LALT | SC_SHORTCUT_MOD_LSUPER,
+    .min_size_alignment = 1,
     .max_size = 0,
     .video_bit_rate = 0,
     .audio_bit_rate = 0,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -258,6 +258,7 @@ struct scrcpy_options {
     uint32_t tunnel_host;
     uint16_t tunnel_port;
     uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
+    uint8_t min_size_alignment;
     uint16_t max_size;
     uint32_t video_bit_rate;
     uint32_t audio_bit_rate;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -439,6 +439,7 @@ scrcpy(struct scrcpy_options *options) {
         .port_range = options->port_range,
         .tunnel_host = options->tunnel_host,
         .tunnel_port = options->tunnel_port,
+        .min_size_alignment = options->min_size_alignment,
         .max_size = options->max_size,
         .video_bit_rate = options->video_bit_rate,
         .audio_bit_rate = options->audio_bit_rate,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -305,6 +305,9 @@ execute_server(struct sc_server *server,
         VALIDATE_STRING(params->max_fps);
         ADD_PARAM("max_fps=%s", params->max_fps);
     }
+    if (params->min_size_alignment != 1) {
+        ADD_PARAM("min_size_alignment=%" PRIu8, params->min_size_alignment);
+    }
     if (params->angle) {
         VALIDATE_STRING(params->angle);
         ADD_PARAM("angle=%s", params->angle);

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -41,6 +41,7 @@ struct sc_server_params {
     uint32_t tunnel_host;
     uint16_t tunnel_port;
     uint16_t max_size;
+    uint8_t min_size_alignment;
     uint32_t video_bit_rate;
     uint32_t audio_bit_rate;
     const char *max_fps; // float to be parsed by the server

--- a/doc/video.md
+++ b/doc/video.md
@@ -30,6 +30,17 @@ If encoding fails, scrcpy automatically tries again with a lower definition
 For camera mirroring, the `--max-size` value is used to select the camera source
 size instead (among the available resolutions).
 
+The size is rounded to a multiple of the _alignment_ required by the encoder, a
+power-of-2 value (1, 2, 4, 8 or 16) that the video width and height must be
+multiples of.
+
+The alignment can be forced to a minimum value. For instance, to force the width
+and height to be multiples of 8:
+
+```bash
+scrcpy --min-size-alignment=8
+```
+
 
 ## Bit rate
 

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -27,6 +27,7 @@ public class Options {
     private boolean video = true;
     private boolean audio = true;
     private int maxSize;
+    private int minSizeAlignment = 1;
     private VideoCodec videoCodec = VideoCodec.H264;
     private AudioCodec audioCodec = AudioCodec.OPUS;
     private VideoSource videoSource = VideoSource.DISPLAY;
@@ -100,6 +101,10 @@ public class Options {
 
     public int getMaxSize() {
         return maxSize;
+    }
+
+    public int getMinSizeAlignment() {
+        return minSizeAlignment;
     }
 
     public VideoCodec getVideoCodec() {
@@ -370,6 +375,13 @@ public class Options {
                     break;
                 case "max_size":
                     options.maxSize = Integer.parseInt(value);
+                    break;
+                case "min_size_alignment":
+                    int align = Integer.parseInt(value);
+                    if (align < 1 || align > 16 || (align & (align - 1)) != 0) {
+                        throw new IllegalArgumentException("min_size_alignment (" + align + ") must be 1, 2, 4, 8 or 16");
+                    }
+                    options.minSizeAlignment = align;
                     break;
                 case "video_bit_rate":
                     options.videoBitRate = Integer.parseInt(value);

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -369,7 +369,7 @@ public class Options {
                     options.audioDup = Boolean.parseBoolean(value);
                     break;
                 case "max_size":
-                    options.maxSize = Integer.parseInt(value) & ~7; // multiple of 8
+                    options.maxSize = Integer.parseInt(value);
                     break;
                 case "video_bit_rate":
                     options.videoBitRate = Integer.parseInt(value);

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -31,7 +31,6 @@ public final class Size {
 
     public Size limit(int maxSize) {
         assert maxSize >= 0 : "Max size may not be negative";
-        assert maxSize % 8 == 0 : "Max size must be a multiple of 8";
 
         if (maxSize == 0) {
             // No limit
@@ -55,13 +54,14 @@ public final class Size {
     }
 
     /**
-     * Round both dimensions of this size to be a multiple of 8 (as required by many encoders).
+     * Round both dimensions of this size to be multiples of {@code alignment}.
      *
-     * @return The current size rounded.
+     * @param alignment the required alignment
+     * @return the current size rounded
      */
-    public Size round8() {
-        if (isMultipleOf8()) {
-            // Already a multiple of 8
+    public Size round(int alignment) {
+        if (isMultipleOf(alignment)) {
+            // Already aligned
             return this;
         }
 
@@ -69,8 +69,8 @@ public final class Size {
         int major = portrait ? height : width;
         int minor = portrait ? width : height;
 
-        major &= ~7; // round down to not exceed the initial size
-        minor = (minor + 4) & ~7; // round to the nearest to minimize aspect ratio distortion
+        major = major / alignment * alignment; // round down to not exceed the initial size
+        minor = (minor + (alignment / 2)) / alignment * alignment; // round to the nearest to minimize aspect ratio distortion
         if (minor > major) {
             minor = major;
         }
@@ -80,8 +80,8 @@ public final class Size {
         return new Size(w, h);
     }
 
-    public boolean isMultipleOf8() {
-        return (width & 7) == 0 && (height & 7) == 0;
+    public boolean isMultipleOf(int alignment) {
+        return width % alignment == 0 && height % alignment == 0;
     }
 
     public Rect toRect() {

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -149,7 +149,7 @@ public class CameraCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().limit(maxSize).round8();
+        videoSize = filter.getOutputSize().limit(maxSize).round(getAlignment());
     }
 
     private static String selectCamera(String explicitCameraId, CameraFacing cameraFacing) throws CameraAccessException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -133,12 +133,13 @@ public class NewDisplayCapture extends SurfaceCapture {
         filter.addOrientation(displayRotation, captureOrientationLocked, captureOrientation);
         filter.addAngle(angle);
 
+        int alignment = getAlignment();
         Size filteredSize = filter.getOutputSize();
-        if (!filteredSize.isMultipleOf8() || (maxSize != 0 && filteredSize.getMax() > maxSize)) {
+        if (!filteredSize.isMultipleOf(alignment) || (maxSize != 0 && filteredSize.getMax() > maxSize)) {
             if (maxSize != 0) {
                 filteredSize = filteredSize.limit(maxSize);
             }
-            filteredSize = filteredSize.round8();
+            filteredSize = filteredSize.round(alignment);
             filter.addResize(filteredSize);
         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -97,7 +97,7 @@ public class ScreenCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().limit(maxSize).round8();
+        videoSize = filter.getOutputSize().limit(maxSize).round(getAlignment());
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -17,6 +17,7 @@ public abstract class SurfaceCapture {
     }
 
     private CaptureListener listener;
+    private int alignment;
 
     /**
      * Notify the listener that the capture has been invalidated (for example, because its size changed, or due to a manual user request).
@@ -28,8 +29,9 @@ public abstract class SurfaceCapture {
     /**
      * Called once before the first capture starts.
      */
-    public final void init(CaptureListener listener) throws ConfigurationException, IOException {
+    public final void init(CaptureListener listener, int alignment) throws ConfigurationException, IOException {
         this.listener = listener;
+        this.alignment = alignment;
         init();
     }
 
@@ -85,5 +87,16 @@ public abstract class SurfaceCapture {
      */
     public boolean isClosed() {
         return false;
+    }
+
+    /**
+     * Return the video alignment
+     * <p>
+     * This a power-of-2 value that the video width and height must be multiples of.
+     *
+     * @return the video alignment
+     */
+    protected int getAlignment() {
+        return alignment;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -43,6 +43,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     private final int videoBitRate;
     private final float maxFps;
     private final boolean downsizeOnError;
+    private final int minSizeAlignment;
 
     private boolean firstFrameSent;
     private int consecutiveErrors;
@@ -60,6 +61,7 @@ public class SurfaceEncoder implements AsyncProcessor {
         this.codecOptions = options.getVideoCodecOptions();
         this.encoderName = options.getVideoEncoder();
         this.downsizeOnError = options.getDownsizeOnError();
+        this.minSizeAlignment = options.getMinSizeAlignment();
     }
 
     private void streamCapture() throws IOException, ConfigurationException {
@@ -70,6 +72,10 @@ public class SurfaceEncoder implements AsyncProcessor {
                 .getVideoCapabilities();
         int alignment = caps != null ? Math.max(caps.getWidthAlignment(), caps.getHeightAlignment()) : 8;
         Ln.d("Video codec size alignment requirement: " + alignment + "px");
+        if (alignment < minSizeAlignment) {
+            alignment = minSizeAlignment;
+            Ln.d("Actual video size alignment: " + alignment + "px");
+        }
 
         MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -65,9 +65,15 @@ public class SurfaceEncoder implements AsyncProcessor {
     private void streamCapture() throws IOException, ConfigurationException {
         Codec codec = streamer.getCodec();
         MediaCodec mediaCodec = createMediaCodec(codec, encoderName);
+
+        MediaCodecInfo.VideoCapabilities caps = mediaCodec.getCodecInfo().getCapabilitiesForType(codec.getMimeType())
+                .getVideoCapabilities();
+        int alignment = caps != null ? Math.max(caps.getWidthAlignment(), caps.getHeightAlignment()) : 8;
+        Ln.d("Video codec size alignment requirement: " + alignment + "px");
+
         MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
 
-        capture.init(reset);
+        capture.init(reset, alignment);
 
         try {
             boolean alive;


### PR DESCRIPTION
The video was always constrained to use a size that is a multiple of 8.

This was sometimes not necessary (recent codecs only require a video size that is a multiple of 2 or even 1) and sometimes insufficient (some codecs require a size that is multiple of 16).

Use the size alignment required by the codec.

Also provide an option (`--min-size-alignment`) to force a minimal size alignment. This is a power-of-2 value (1, 2, 4, 8 or 16) that the video width and height must be a multiple of.

The actual alignment will be the maximum of this value and the video codec's alignment requirement.

---

Fixes #4949
Fixes #6236

This also fixes cases where the encoder has a multiple-of-16 alignment requirement, and avoids unnecessary constraints when the alignment requirements are lower.

_Spoiler: this will also be useful for resizable virtual displays._