### PR TITLE
Fix screensaver disabled unexpectedly

### DIFF
--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -140,7 +140,7 @@ sdl_set_hints(const char *render_driver) {
 }
 
 static void
-sdl_configure(bool video_playback, bool disable_screensaver) {
+sdl_configure(bool disable_screensaver) {
 #ifdef _WIN32
     // Clean up properly on Ctrl+C on Windows
     bool ok = SetConsoleCtrlHandler(windows_ctrl_handler, TRUE);
@@ -148,10 +148,6 @@ sdl_configure(bool video_playback, bool disable_screensaver) {
         LOGW("Could not set Ctrl+C handler");
     }
 #endif // _WIN32
-
-    if (!video_playback) {
-        return;
-    }
 
     if (disable_screensaver) {
         bool ok = SDL_DisableScreenSaver();
@@ -543,7 +539,7 @@ scrcpy(struct scrcpy_options *options) {
         }
     }
 
-    sdl_configure(options->video_playback, options->disable_screensaver);
+    sdl_configure(options->disable_screensaver);
 
     // Await for server without blocking Ctrl+C handling
     bool connected;


### PR DESCRIPTION
If the value of `video_playback` is `false` (e.g., when `--no-video`, `--no-window`, or `no-video-playback` is passed), the screensaver is disabled by default, according to [this ref](https://wiki.libsdl.org/SDL3/SDL_DisableScreenSaver).

By default, scrcpy does not prevent the screensaver from running on the computer unless the `--disable-screensaver` option is passed.

Related: #5099