### PR TITLE
Add option to enforce window aspect ratio to always match video

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -32,6 +32,7 @@ enum {
     OPT_WINDOW_WIDTH,
     OPT_WINDOW_HEIGHT,
     OPT_WINDOW_BORDERLESS,
+    OPT_WINDOW_PRESERVE_ASPECT_RATIO,
     OPT_MAX_FPS,
     OPT_LOCK_VIDEO_ORIENTATION,
     OPT_DISPLAY,
@@ -1053,6 +1054,11 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_WINDOW_BORDERLESS,
         .longopt = "window-borderless",
         .text = "Disable window decorations (display borderless window)."
+    },
+    {
+        .longopt_id = OPT_WINDOW_PRESERVE_ASPECT_RATIO,
+        .longopt = "window-preserve-aspect-ratio",
+        .text = "Preserve the aspect ratio of the video source when resizing the window."
     },
     {
         .longopt_id = OPT_WINDOW_TITLE,
@@ -2596,6 +2602,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_WINDOW_BORDERLESS:
                 opts->window_borderless = true;
+                break;
+            case OPT_WINDOW_PRESERVE_ASPECT_RATIO:
+                opts->window_preserve_aspect_ratio = true;
                 break;
             case OPT_PUSH_TARGET:
                 opts->push_target = optarg;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -85,6 +85,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .turn_screen_off = false,
     .key_inject_mode = SC_KEY_INJECT_MODE_MIXED,
     .window_borderless = false,
+    .window_preserve_aspect_ratio = false,
     .mipmaps = true,
     .stay_awake = false,
     .force_adb_forward = false,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -295,6 +295,7 @@ struct scrcpy_options {
     bool turn_screen_off;
     enum sc_key_inject_mode key_inject_mode;
     bool window_borderless;
+    bool window_preserve_aspect_ratio;
     bool mipmaps;
     bool stay_awake;
     bool force_adb_forward;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -814,6 +814,7 @@ aoa_complete:
             .window_width = options->window_width,
             .window_height = options->window_height,
             .window_borderless = options->window_borderless,
+            .window_preserve_aspect_ratio = options->window_preserve_aspect_ratio,
             .orientation = options->display_orientation,
             .mipmaps = options->mipmaps,
             .fullscreen = options->fullscreen,

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -377,6 +377,7 @@ sc_screen_init(struct sc_screen *screen,
     screen->req.width = params->window_width;
     screen->req.height = params->window_height;
     screen->req.fullscreen = params->fullscreen;
+    screen->req.preserve_aspect_ratio = params->window_preserve_aspect_ratio;
     screen->req.start_fps_counter = params->start_fps_counter;
 
     bool ok = sc_frame_buffer_init(&screen->fb);
@@ -604,10 +605,14 @@ sc_screen_show_initial_window(struct sc_screen *screen) {
     sc_sdl_set_window_size(screen->window, window_size);
     sc_sdl_set_window_position(screen->window, position);
 
+    if (screen->req.preserve_aspect_ratio) {
+        float aspect_ratio = (float) screen->content_size.width / screen->content_size.height;
+        sc_sdl_set_window_aspect_ratio(screen->window, aspect_ratio, aspect_ratio);
+    }
+
     if (screen->req.fullscreen) {
         sc_screen_toggle_fullscreen(screen);
     }
-
     if (screen->req.start_fps_counter) {
         sc_fps_counter_start(&screen->fps_counter);
     }
@@ -687,6 +692,10 @@ resize_for_content(struct sc_screen *screen, struct sc_size old_content_size,
     };
     target_size = get_optimal_size(target_size, new_content_size, true);
     assert(is_windowed(screen));
+    if(screen->req.preserve_aspect_ratio){
+        float aspect_ratio = (float) new_content_size.width / new_content_size.height;
+        sc_sdl_set_window_aspect_ratio(screen->window, aspect_ratio, aspect_ratio);
+    }
     sc_sdl_set_window_size(screen->window, target_size);
 }
 
@@ -845,6 +854,9 @@ sc_screen_resize_to_fit(struct sc_screen *screen) {
     assert(screen->video);
 
     if (!is_windowed(screen)) {
+        return;
+    }
+    if(screen->req.preserve_aspect_ratio){
         return;
     }
 

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -602,17 +602,19 @@ sc_screen_show_initial_window(struct sc_screen *screen) {
                                                        screen->req.height);
 
     assert(is_windowed(screen));
-    sc_sdl_set_window_size(screen->window, window_size);
-    sc_sdl_set_window_position(screen->window, position);
 
     if (screen->req.preserve_aspect_ratio) {
         float aspect_ratio = (float) screen->content_size.width / screen->content_size.height;
         sc_sdl_set_window_aspect_ratio(screen->window, aspect_ratio, aspect_ratio);
     }
 
+    sc_sdl_set_window_size(screen->window, window_size);
+    sc_sdl_set_window_position(screen->window, position);
+
     if (screen->req.fullscreen) {
         sc_screen_toggle_fullscreen(screen);
     }
+
     if (screen->req.start_fps_counter) {
         sc_fps_counter_start(&screen->fps_counter);
     }

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -50,6 +50,7 @@ struct sc_screen {
         uint16_t width;
         uint16_t height;
         bool fullscreen;
+        bool preserve_aspect_ratio;
         bool start_fps_counter;
     } req;
 
@@ -107,6 +108,7 @@ struct sc_screen_params {
     uint16_t window_height;
 
     bool window_borderless;
+    bool window_preserve_aspect_ratio;
 
     enum sc_orientation orientation;
     bool mipmaps;

--- a/app/src/util/sdl.c
+++ b/app/src/util/sdl.c
@@ -84,6 +84,15 @@ sc_sdl_set_window_size(SDL_Window *window, struct sc_size size) {
     }
 }
 
+void
+sc_sdl_set_window_aspect_ratio(SDL_Window *window, float min_aspect, float max_aspect) {
+    bool ok = SDL_SetWindowAspectRatio(window, min_aspect, max_aspect);
+    if (!ok) {
+        LOGE("Could not set window aspect ratio: %s", SDL_GetError());
+        assert(!"unexpected");
+    }
+}
+
 struct sc_point
 sc_sdl_get_window_position(SDL_Window *window) {
     int x;

--- a/app/src/util/sdl.h
+++ b/app/src/util/sdl.h
@@ -29,6 +29,9 @@ void
 sc_sdl_set_window_position(SDL_Window *window, struct sc_point point);
 
 void
+sc_sdl_set_window_aspect_ratio(SDL_Window *window, float min_aspect, float max_aspect);
+
+void
 sc_sdl_show_window(SDL_Window *window);
 
 void

--- a/doc/window.md
+++ b/doc/window.md
@@ -25,6 +25,14 @@ The initial window position and size may be specified:
 scrcpy --window-x=100 --window-y=100 --window-width=800 --window-height=600
 ```
 
+## Preserve aspect ratio
+
+The window aspect ratio can be enforced to always fit the video source on platforms that support it:
+
+```bash
+scrcpy --window-preserve-aspect-ratio
+```
+
 ## Borderless
 
 To disable window decorations:


### PR DESCRIPTION
Adds a `--window-preserve-aspect-ratio` CLI option (defaults to false) that uses SDL3's new [SDL_SetWindowAspectRatio](https://wiki.libsdl.org/SDL3/SDL_SetWindowAspectRatio) functionality to preserve the window's aspect ratio when resized so that it always matches the content, eliminating the black bars.

Tested on KWin Wayland compositor version 6.6.4