### PR TITLE
Replace retry-with-lower-resolution mechanism with video capabilities constraints

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -56,7 +56,6 @@ _scrcpy() {
         --no-audio-playback
         --no-cleanup
         --no-clipboard-autosync
-        --no-downsize-on-error
         --no-key-repeat
         --no-mipmaps
         --no-mouse-hover

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -62,7 +62,6 @@ arguments=(
     '--no-audio-playback[Disable audio playback]'
     '--no-cleanup[Disable device cleanup actions on exit]'
     '--no-clipboard-autosync[Disable automatic clipboard synchronization]'
-    '--no-downsize-on-error[Disable lowering definition on MediaCodec error]'
     '--no-key-repeat[Do not forward repeated key events when a key is held down]'
     '--no-mipmaps[Disable the generation of mipmaps]'
     '--no-mouse-hover[Do not forward mouse hover events]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -385,12 +385,6 @@ By default, scrcpy automatically synchronizes the computer clipboard to the devi
 This option disables this automatic synchronization.
 
 .TP
-.B \-\-no\-downsize\-on\-error
-By default, on MediaCodec error, scrcpy automatically tries again with a lower definition.
-
-This option disables this behavior.
-
-.TP
 .B \-\-no\-key\-repeat
 Do not forward repeated key events when a key is held down.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -51,7 +51,6 @@ enum {
     OPT_NO_CLIPBOARD_AUTOSYNC,
     OPT_TCPIP,
     OPT_RAW_KEY_EVENTS,
-    OPT_NO_DOWNSIZE_ON_ERROR,
     OPT_OTG,
     OPT_NO_CLEANUP,
     OPT_PRINT_FPS,
@@ -610,13 +609,6 @@ static const struct sc_option options[] = {
                 "and the device clipboard to the computer clipboard whenever "
                 "it changes.\n"
                 "This option disables this automatic synchronization."
-    },
-    {
-        .longopt_id = OPT_NO_DOWNSIZE_ON_ERROR,
-        .longopt = "no-downsize-on-error",
-        .text = "By default, on MediaCodec error, scrcpy automatically tries "
-                "again with a lower definition.\n"
-                "This option disables this behavior.",
     },
     {
         .longopt_id = OPT_NO_KEY_REPEAT,
@@ -2581,9 +2573,6 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 opts->tcpip = true;
                 opts->tcpip_dst = optarg;
                 break;
-            case OPT_NO_DOWNSIZE_ON_ERROR:
-                opts->downsize_on_error = false;
-                break;
             case OPT_NO_VIDEO:
                 opts->video = false;
                 break;
@@ -2856,16 +2845,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     }
 
 #ifdef HAVE_V4L2
-    if (v4l2) {
-        if (!opts->video) {
-            LOGE("V4L2 sink requires video capture, but --no-video was set.");
-            return false;
-        }
-
-        // V4L2 could not handle size change.
-        // Do not log because downsizing on error is the default behavior,
-        // not an explicit request from the user.
-        opts->downsize_on_error = false;
+    if (v4l2 && !opts->video) {
+        LOGE("V4L2 sink requires video capture, but --no-video was set.");
+        return false;
     }
 
     if (opts->v4l2_buffer && !opts->v4l2_device) {

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -94,7 +94,6 @@ const struct scrcpy_options scrcpy_options_default = {
     .legacy_paste = false,
     .power_off_on_close = false,
     .clipboard_autosync = true,
-    .downsize_on_error = true,
     .tcpip = false,
     .tcpip_dst = NULL,
     .select_tcpip = false,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -304,7 +304,6 @@ struct scrcpy_options {
     bool legacy_paste;
     bool power_off_on_close;
     bool clipboard_autosync;
-    bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
     bool select_usb;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -455,7 +455,6 @@ scrcpy(struct scrcpy_options *options) {
         .force_adb_forward = options->force_adb_forward,
         .power_off_on_close = options->power_off_on_close,
         .clipboard_autosync = options->clipboard_autosync,
-        .downsize_on_error = options->downsize_on_error,
         .tcpip = options->tcpip,
         .tcpip_dst = options->tcpip_dst,
         .cleanup = options->cleanup,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -401,10 +401,6 @@ execute_server(struct sc_server *server,
         // By default, clipboard_autosync is true
         ADD_PARAM("clipboard_autosync=false");
     }
-    if (!params->downsize_on_error) {
-        // By default, downsize_on_error is true
-        ADD_PARAM("downsize_on_error=false");
-    }
     if (!params->cleanup) {
         // By default, cleanup is true
         ADD_PARAM("cleanup=false");

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -61,7 +61,6 @@ struct sc_server_params {
     bool force_adb_forward;
     bool power_off_on_close;
     bool clipboard_autosync;
-    bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
     bool select_usb;

--- a/doc/video.md
+++ b/doc/video.md
@@ -24,9 +24,6 @@ scrcpy -m 1024   # short version
 The other dimension is computed so that the Android device aspect ratio is
 preserved. That way, a device in 1920×1080 will be mirrored at 1024×576.
 
-If encoding fails, scrcpy automatically tries again with a lower definition
-(unless `--no-downsize-on-error` is enabled).
-
 For camera mirroring, the `--max-size` value is used to select the camera source
 size instead (among the available resolutions).
 

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -60,7 +60,6 @@ public class Options {
     private String audioEncoder;
     private boolean powerOffScreenOnClose;
     private boolean clipboardAutosync = true;
-    private boolean downsizeOnError = true;
     private boolean cleanup = true;
     private boolean powerOn = true;
 
@@ -229,10 +228,6 @@ public class Options {
 
     public boolean getClipboardAutosync() {
         return clipboardAutosync;
-    }
-
-    public boolean getDownsizeOnError() {
-        return downsizeOnError;
     }
 
     public boolean getCleanup() {
@@ -442,9 +437,6 @@ public class Options {
                     break;
                 case "clipboard_autosync":
                     options.clipboardAutosync = Boolean.parseBoolean(value);
-                    break;
-                case "downsize_on_error":
-                    options.downsizeOnError = Boolean.parseBoolean(value);
                     break;
                 case "cleanup":
                     options.cleanup = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -29,59 +29,35 @@ public final class Size {
         return new Size(height, width);
     }
 
-    public Size limit(int maxSize) {
+    public Size constrain(int maxSize, int alignment) {
         assert maxSize >= 0 : "Max size may not be negative";
+        assert alignment > 0 : "Alignment must be positive";
+        assert (alignment & (alignment - 1)) == 0 : "Alignment must be a power-of-two";
 
-        if (maxSize == 0) {
-            // No limit
-            return this;
+        int alignedMaxSize = maxSize / alignment * alignment; // round to a multiple of alignment
+        int w, h;
+
+        if (maxSize > 0 && (width > alignedMaxSize || height > alignedMaxSize)) {
+            if (width > height) {
+                w = alignedMaxSize;
+                h = round(height * alignedMaxSize / width, alignment);
+            } else {
+                w = round(width * alignedMaxSize / height, alignment);
+                h = alignedMaxSize;
+            }
+        } else {
+            w = round(width, alignment);
+            h = round(height, alignment);
         }
 
-        boolean portrait = height > width;
-        int major = portrait ? height : width;
-        if (major <= maxSize) {
-            return this;
-        }
+        assert maxSize == 0 || w <= maxSize : "The width cannot exceed maxSize if maxSize is aligned";
+        assert maxSize == 0 || h <= maxSize : "The height cannot exceed maxSize if maxSize is aligned";
 
-        int minor = portrait ? width : height;
-
-        int newMajor = maxSize;
-        int newMinor = maxSize * minor / major;
-
-        int w = portrait ? newMinor : newMajor;
-        int h = portrait ? newMajor : newMinor;
         return new Size(w, h);
     }
 
-    /**
-     * Round both dimensions of this size to be multiples of {@code alignment}.
-     *
-     * @param alignment the required alignment
-     * @return the current size rounded
-     */
-    public Size round(int alignment) {
-        if (isMultipleOf(alignment)) {
-            // Already aligned
-            return this;
-        }
-
-        boolean portrait = height > width;
-        int major = portrait ? height : width;
-        int minor = portrait ? width : height;
-
-        major = major / alignment * alignment; // round down to not exceed the initial size
-        minor = (minor + (alignment / 2)) / alignment * alignment; // round to the nearest to minimize aspect ratio distortion
-        if (minor > major) {
-            minor = major;
-        }
-
-        int w = portrait ? minor : major;
-        int h = portrait ? major : minor;
-        return new Size(w, h);
-    }
-
-    public boolean isMultipleOf(int alignment) {
-        return width % alignment == 0 && height % alignment == 0;
+    private static int round(int value, int alignment) {
+        return (value + (alignment / 2)) / alignment * alignment;
     }
 
     public Rect toRect() {

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -1,5 +1,7 @@
 package com.genymobile.scrcpy.device;
 
+import com.genymobile.scrcpy.video.VideoConstraints;
+
 import android.graphics.Rect;
 
 import java.util.Objects;
@@ -29,7 +31,9 @@ public final class Size {
         return new Size(height, width);
     }
 
-    public Size constrain(int maxSize, int alignment) {
+    public Size constrain(int maxSize, VideoConstraints constraints) {
+        int alignment = constraints.getAlignment();
+
         assert maxSize >= 0 : "Max size may not be negative";
         assert alignment > 0 : "Alignment must be positive";
         assert (alignment & (alignment - 1)) == 0 : "Alignment must be a power-of-two";

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -39,24 +39,38 @@ public final class Size {
         assert alignment > 0 : "Alignment must be positive";
         assert (alignment & (alignment - 1)) == 0 : "Alignment must be a power-of-two";
 
-        int alignedMaxSize = maxSize / alignment * alignment; // round to a multiple of alignment
-        int w, h;
+        boolean portrait = width < height;
+        Size maxCodecSize = portrait ? constraints.getMaxCodecPortraitSize() : constraints.getMaxCodecLandscapeSize();
 
-        if (maxSize > 0 && (width > alignedMaxSize || height > alignedMaxSize)) {
-            if (width > height) {
-                w = alignedMaxSize;
-                h = round(height * alignedMaxSize / width, alignment);
+        int maxWidth = maxCodecSize.width;
+        int maxHeight = maxCodecSize.height;
+        if (maxSize > 0) {
+            if (maxSize < maxWidth) {
+                maxWidth = maxSize;
+            }
+            if (maxSize < maxHeight) {
+                maxHeight = maxSize;
+            }
+        }
+        maxWidth = maxWidth / alignment * alignment;
+        maxHeight = maxHeight / alignment * alignment;
+
+        int w, h;
+        if (width > maxWidth || height > maxHeight) {
+            if (width * maxHeight > height * maxWidth) {
+                w = maxWidth;
+                h = round(height * maxWidth / width, alignment);
             } else {
-                w = round(width * alignedMaxSize / height, alignment);
-                h = alignedMaxSize;
+                w = round(width * maxHeight / height, alignment);
+                h = maxHeight;
             }
         } else {
             w = round(width, alignment);
             h = round(height, alignment);
         }
 
-        assert maxSize == 0 || w <= maxSize : "The width cannot exceed maxSize if maxSize is aligned";
-        assert maxSize == 0 || h <= maxSize : "The height cannot exceed maxSize if maxSize is aligned";
+        assert w <= maxWidth : "The width cannot exceed maxWidth";
+        assert h <= maxHeight : "The height cannot exceed maxHeight";
 
         return new Size(w, h);
     }

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -72,6 +72,15 @@ public final class Size {
         assert w <= maxWidth : "The width cannot exceed maxWidth";
         assert h <= maxHeight : "The height cannot exceed maxHeight";
 
+        // Minimum codec size must be respected (regardless of requested maxSize)
+        int minCodecSize = constraints.getMinCodecSize();
+        if (w < minCodecSize) {
+            w = minCodecSize;
+        }
+        if (h < minCodecSize) {
+            h = minCodecSize;
+        }
+
         return new Size(w, h);
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/device/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Size.java
@@ -31,7 +31,8 @@ public final class Size {
         return new Size(height, width);
     }
 
-    public Size constrain(int maxSize, VideoConstraints constraints) {
+    public Size constrain(VideoConstraints constraints) {
+        int maxSize = constraints.getMaxSize();
         int alignment = constraints.getAlignment();
 
         assert maxSize >= 0 : "Max size may not be negative";

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -149,7 +149,7 @@ public class CameraCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().limit(maxSize).round(getAlignment());
+        videoSize = filter.getOutputSize().constrain(maxSize, getAlignment());
     }
 
     private static String selectCamera(String explicitCameraId, CameraFacing cameraFacing) throws CameraAccessException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -59,7 +59,6 @@ public class CameraCapture extends SurfaceCapture {
     private final String explicitCameraId;
     private final CameraFacing cameraFacing;
     private final Size explicitSize;
-    private final int maxSize;
     private final CameraAspectRatio aspectRatio;
     private final int fps;
     private final boolean highSpeed;
@@ -93,7 +92,6 @@ public class CameraCapture extends SurfaceCapture {
         this.explicitCameraId = options.getCameraId();
         this.cameraFacing = options.getCameraFacing();
         this.explicitSize = options.getCameraSize();
-        this.maxSize = options.getMaxSize();
         this.aspectRatio = options.getCameraAspectRatio();
         this.fps = options.getCameraFps();
         this.highSpeed = options.getCameraHighSpeed();
@@ -128,6 +126,7 @@ public class CameraCapture extends SurfaceCapture {
     @Override
     public void prepare() throws IOException {
         try {
+            int maxSize = getVideoConstraints().getMaxSize();
             captureSize = selectSize(cameraId, explicitSize, maxSize, aspectRatio, highSpeed);
             if (captureSize == null) {
                 throw new IOException("Could not select camera size");
@@ -149,7 +148,7 @@ public class CameraCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().constrain(maxSize, getVideoConstraints());
+        videoSize = filter.getOutputSize().constrain(getVideoConstraints());
     }
 
     private static String selectCamera(String explicitCameraId, CameraFacing cameraFacing) throws CameraAccessException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -149,7 +149,7 @@ public class CameraCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().constrain(maxSize, getAlignment());
+        videoSize = filter.getOutputSize().constrain(maxSize, getVideoConstraints());
     }
 
     private static String selectCamera(String explicitCameraId, CameraFacing cameraFacing) throws CameraAccessException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -59,7 +59,7 @@ public class CameraCapture extends SurfaceCapture {
     private final String explicitCameraId;
     private final CameraFacing cameraFacing;
     private final Size explicitSize;
-    private int maxSize;
+    private final int maxSize;
     private final CameraAspectRatio aspectRatio;
     private final int fps;
     private final boolean highSpeed;
@@ -372,16 +372,6 @@ public class CameraCapture extends SurfaceCapture {
     @Override
     public Size getSize() {
         return videoSize;
-    }
-
-    @Override
-    public boolean setMaxSize(int maxSize) {
-        if (explicitSize != null) {
-            return false;
-        }
-
-        this.maxSize = maxSize;
-        return true;
     }
 
     @SuppressLint("MissingPermission")

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -49,7 +49,7 @@ public class NewDisplayCapture extends SurfaceCapture {
 
     private Size mainDisplaySize;
     private int mainDisplayDpi;
-    private int maxSize;
+    private final int maxSize;
     private final int displayImePolicy;
     private final Rect crop;
     private final boolean captureOrientationLocked;
@@ -249,12 +249,6 @@ public class NewDisplayCapture extends SurfaceCapture {
     @Override
     public synchronized Size getSize() {
         return videoSize;
-    }
-
-    @Override
-    public synchronized boolean setMaxSize(int newMaxSize) {
-        maxSize = newMaxSize;
-        return true;
     }
 
     private static int scaleDpi(Size initialSize, int initialDpi, Size size) {

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -134,7 +134,7 @@ public class NewDisplayCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         Size outputSize = filter.getOutputSize();
-        Size filteredSize = outputSize.constrain(maxSize, getAlignment());
+        Size filteredSize = outputSize.constrain(maxSize, getVideoConstraints());
         if (!filteredSize.equals(outputSize)) {
             filter.addResize(filteredSize);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -133,13 +133,9 @@ public class NewDisplayCapture extends SurfaceCapture {
         filter.addOrientation(displayRotation, captureOrientationLocked, captureOrientation);
         filter.addAngle(angle);
 
-        int alignment = getAlignment();
-        Size filteredSize = filter.getOutputSize();
-        if (!filteredSize.isMultipleOf(alignment) || (maxSize != 0 && filteredSize.getMax() > maxSize)) {
-            if (maxSize != 0) {
-                filteredSize = filteredSize.limit(maxSize);
-            }
-            filteredSize = filteredSize.round(alignment);
+        Size outputSize = filter.getOutputSize();
+        Size filteredSize = outputSize.constrain(maxSize, getAlignment());
+        if (!filteredSize.equals(outputSize)) {
             filter.addResize(filteredSize);
         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -50,7 +50,7 @@ public class NewDisplayCapture extends SurfaceCapture {
     private Size mainDisplaySize;
     private int mainDisplayDpi;
     private int maxSize;
-    private int displayImePolicy;
+    private final int displayImePolicy;
     private final Rect crop;
     private final boolean captureOrientationLocked;
     private final Orientation captureOrientation;

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -49,7 +49,6 @@ public class NewDisplayCapture extends SurfaceCapture {
 
     private Size mainDisplaySize;
     private int mainDisplayDpi;
-    private final int maxSize;
     private final int displayImePolicy;
     private final Rect crop;
     private final boolean captureOrientationLocked;
@@ -69,7 +68,6 @@ public class NewDisplayCapture extends SurfaceCapture {
         this.vdListener = vdListener;
         this.newDisplay = options.getNewDisplay();
         assert newDisplay != null;
-        this.maxSize = options.getMaxSize();
         this.displayImePolicy = options.getDisplayImePolicy();
         this.crop = options.getCrop();
         assert options.getCaptureOrientationLock() != null;
@@ -134,7 +132,7 @@ public class NewDisplayCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         Size outputSize = filter.getOutputSize();
-        Size filteredSize = outputSize.constrain(maxSize, getVideoConstraints());
+        Size filteredSize = outputSize.constrain(getVideoConstraints());
         if (!filteredSize.equals(outputSize)) {
             filter.addResize(filteredSize);
         }

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -29,7 +29,7 @@ public class ScreenCapture extends SurfaceCapture {
 
     private final VirtualDisplayListener vdListener;
     private final int displayId;
-    private int maxSize;
+    private final int maxSize;
     private final Rect crop;
     private Orientation.Lock captureOrientationLock;
     private Orientation captureOrientation;
@@ -185,12 +185,6 @@ public class ScreenCapture extends SurfaceCapture {
     @Override
     public Size getSize() {
         return videoSize;
-    }
-
-    @Override
-    public boolean setMaxSize(int newMaxSize) {
-        maxSize = newMaxSize;
-        return true;
     }
 
     private static IBinder createDisplay() throws Exception {

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -97,7 +97,7 @@ public class ScreenCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().constrain(maxSize, getAlignment());
+        videoSize = filter.getOutputSize().constrain(maxSize, getVideoConstraints());
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -97,7 +97,7 @@ public class ScreenCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().limit(maxSize).round(getAlignment());
+        videoSize = filter.getOutputSize().constrain(maxSize, getAlignment());
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -29,7 +29,6 @@ public class ScreenCapture extends SurfaceCapture {
 
     private final VirtualDisplayListener vdListener;
     private final int displayId;
-    private final int maxSize;
     private final Rect crop;
     private Orientation.Lock captureOrientationLock;
     private Orientation captureOrientation;
@@ -50,7 +49,6 @@ public class ScreenCapture extends SurfaceCapture {
         this.vdListener = vdListener;
         this.displayId = options.getDisplayId();
         assert displayId != Device.DISPLAY_ID_NONE;
-        this.maxSize = options.getMaxSize();
         this.crop = options.getCrop();
         this.captureOrientationLock = options.getCaptureOrientationLock();
         this.captureOrientation = options.getCaptureOrientation();
@@ -97,7 +95,7 @@ public class ScreenCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().constrain(maxSize, getVideoConstraints());
+        videoSize = filter.getOutputSize().constrain(getVideoConstraints());
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -17,7 +17,7 @@ public abstract class SurfaceCapture {
     }
 
     private CaptureListener listener;
-    private int alignment;
+    private VideoConstraints constraints;
 
     /**
      * Notify the listener that the capture has been invalidated (for example, because its size changed, or due to a manual user request).
@@ -29,9 +29,9 @@ public abstract class SurfaceCapture {
     /**
      * Called once before the first capture starts.
      */
-    public final void init(CaptureListener listener, int alignment) throws ConfigurationException, IOException {
+    public final void init(CaptureListener listener, VideoConstraints constraints) throws ConfigurationException, IOException {
         this.listener = listener;
-        this.alignment = alignment;
+        this.constraints = constraints;
         init();
     }
 
@@ -83,13 +83,11 @@ public abstract class SurfaceCapture {
     }
 
     /**
-     * Return the video alignment
-     * <p>
-     * This a power-of-2 value that the video width and height must be multiples of.
+     * Return the video constraints.
      *
-     * @return the video alignment
+     * @return the video constraints
      */
-    protected int getAlignment() {
-        return alignment;
+    protected VideoConstraints getVideoConstraints() {
+        return constraints;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -74,13 +74,6 @@ public abstract class SurfaceCapture {
     public abstract Size getSize();
 
     /**
-     * Set the maximum capture size (set by the encoder if it does not support the current size).
-     *
-     * @param maxSize Maximum size
-     */
-    public abstract boolean setMaxSize(int maxSize);
-
-    /**
      * Indicate if the capture has been closed internally.
      *
      * @return {@code true} is the capture is closed, {@code false} otherwise.

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -67,6 +67,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     private void streamCapture() throws IOException, ConfigurationException {
         Codec codec = streamer.getCodec();
         MediaCodec mediaCodec = createMediaCodec(codec, encoderName);
+        MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
 
         MediaCodecInfo.VideoCapabilities caps = mediaCodec.getCodecInfo().getCapabilitiesForType(codec.getMimeType())
                 .getVideoCapabilities();
@@ -76,8 +77,6 @@ public class SurfaceEncoder implements AsyncProcessor {
             alignment = minSizeAlignment;
             Ln.d("Actual video size alignment: " + alignment + "px");
         }
-
-        MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
 
         capture.init(reset, alignment);
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -18,7 +18,6 @@ import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
 import android.os.Build;
 import android.os.Looper;
-import android.os.SystemClock;
 import android.view.Surface;
 
 import java.io.IOException;
@@ -32,21 +31,13 @@ public class SurfaceEncoder implements AsyncProcessor {
     private static final int REPEAT_FRAME_DELAY_US = 100_000; // repeat after 100ms
     private static final String KEY_MAX_FPS_TO_ENCODER = "max-fps-to-encoder";
 
-    // Keep the values in descending order
-    private static final int[] MAX_SIZE_FALLBACK = {2560, 1920, 1600, 1280, 1024, 800};
-    private static final int MAX_CONSECUTIVE_ERRORS = 3;
-
     private final SurfaceCapture capture;
     private final Streamer streamer;
     private final String encoderName;
     private final List<CodecOption> codecOptions;
     private final int videoBitRate;
     private final float maxFps;
-    private final boolean downsizeOnError;
     private final int minSizeAlignment;
-
-    private boolean firstFrameSent;
-    private int consecutiveErrors;
 
     private Thread thread;
     private final AtomicBoolean stopped = new AtomicBoolean();
@@ -60,7 +51,6 @@ public class SurfaceEncoder implements AsyncProcessor {
         this.maxFps = options.getMaxFps();
         this.codecOptions = options.getVideoCodecOptions();
         this.encoderName = options.getVideoEncoder();
-        this.downsizeOnError = options.getDownsizeOnError();
         this.minSizeAlignment = options.getMinSizeAlignment();
     }
 
@@ -121,16 +111,6 @@ public class SurfaceEncoder implements AsyncProcessor {
                         // The capture might have been closed internally (for example if the camera is disconnected)
                         alive = !stopped.get() && !capture.isClosed();
                     }
-                } catch (IllegalStateException | IllegalArgumentException | IOException e) {
-                    if (IO.isBrokenPipe(e)) {
-                        // Do not retry on broken pipe, which is expected on close because the socket is closed by the client
-                        throw e;
-                    }
-                    Ln.e("Capture/encoding error: " + e.getClass().getName() + ": " + e.getMessage());
-                    if (!prepareRetry(size)) {
-                        throw e;
-                    }
-                    alive = true;
                 } finally {
                     reset.setRunningMediaCodec(null);
                     if (captureStarted) {
@@ -155,54 +135,6 @@ public class SurfaceEncoder implements AsyncProcessor {
         }
     }
 
-    private boolean prepareRetry(Size currentSize) {
-        if (firstFrameSent) {
-            ++consecutiveErrors;
-            if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-                // Definitively fail
-                return false;
-            }
-
-            // Wait a bit to increase the probability that retrying will fix the problem
-            SystemClock.sleep(50);
-            return true;
-        }
-
-        if (!downsizeOnError) {
-            // Must fail immediately
-            return false;
-        }
-
-        // Downsizing on error is only enabled if an encoding failure occurs before the first frame (downsizing later could be surprising)
-
-        int newMaxSize = chooseMaxSizeFallback(currentSize);
-        if (newMaxSize == 0) {
-            // Must definitively fail
-            return false;
-        }
-
-        boolean accepted = capture.setMaxSize(newMaxSize);
-        if (!accepted) {
-            return false;
-        }
-
-        // Retry with a smaller size
-        Ln.i("Retrying with -m" + newMaxSize + "...");
-        return true;
-    }
-
-    private static int chooseMaxSizeFallback(Size failedSize) {
-        int currentMaxSize = Math.max(failedSize.getWidth(), failedSize.getHeight());
-        for (int value : MAX_SIZE_FALLBACK) {
-            if (value < currentMaxSize) {
-                // We found a smaller value to reduce the video size
-                return value;
-            }
-        }
-        // No fallback, fail definitively
-        return 0;
-    }
-
     private void encode(MediaCodec codec, Streamer streamer) throws IOException {
         MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
 
@@ -214,14 +146,6 @@ public class SurfaceEncoder implements AsyncProcessor {
                 // On EOS, there might be data or not, depending on bufferInfo.size
                 if (outputBufferId >= 0 && bufferInfo.size > 0) {
                     ByteBuffer codecBuffer = codec.getOutputBuffer(outputBufferId);
-
-                    boolean isConfig = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0;
-                    if (!isConfig) {
-                        // If this is not a config packet, then it contains a frame
-                        firstFrameSent = true;
-                        consecutiveErrors = 0;
-                    }
-
                     streamer.writePacket(codecBuffer, bufferInfo);
                 }
             } finally {

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -73,7 +73,11 @@ public class SurfaceEncoder implements AsyncProcessor {
         int maxPortraitWidth = caps.getSupportedWidthsFor(maxPortraitHeight).getUpper();
         Size maxPortraitSize = new Size(maxPortraitWidth, maxPortraitHeight);
 
-        return new VideoConstraints(maxSize, alignment, maxLandscapeSize, maxPortraitSize);
+        int minWidth = caps.getSupportedWidths().getLower();
+        int minHeight = caps.getSupportedHeights().getLower();
+        int minSize = Math.max(minWidth, minHeight);
+
+        return new VideoConstraints(maxSize, alignment, maxLandscapeSize, maxPortraitSize, minSize);
     }
 
     private void streamCapture() throws IOException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -65,7 +65,15 @@ public class SurfaceEncoder implements AsyncProcessor {
             Ln.d("Actual video size alignment: " + alignment + "px");
         }
 
-        return new VideoConstraints(maxSize, alignment);
+        int maxLandscapeWidth = caps.getSupportedWidths().getUpper();
+        int maxLandscapeHeight = caps.getSupportedHeightsFor(maxLandscapeWidth).getUpper();
+        Size maxLandscapeSize = new Size(maxLandscapeWidth, maxLandscapeHeight);
+
+        int maxPortraitHeight = caps.getSupportedHeights().getUpper();
+        int maxPortraitWidth = caps.getSupportedWidthsFor(maxPortraitHeight).getUpper();
+        Size maxPortraitSize = new Size(maxPortraitWidth, maxPortraitHeight);
+
+        return new VideoConstraints(maxSize, alignment, maxLandscapeSize, maxPortraitSize);
     }
 
     private void streamCapture() throws IOException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -56,20 +56,26 @@ public class SurfaceEncoder implements AsyncProcessor {
         this.minSizeAlignment = options.getMinSizeAlignment();
     }
 
-    private void streamCapture() throws IOException, ConfigurationException {
-        Codec codec = streamer.getCodec();
-        MediaCodec mediaCodec = createMediaCodec(codec, encoderName);
-        MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
-
-        MediaCodecInfo.VideoCapabilities caps = mediaCodec.getCodecInfo().getCapabilitiesForType(codec.getMimeType())
-                .getVideoCapabilities();
-        int alignment = caps != null ? Math.max(caps.getWidthAlignment(), caps.getHeightAlignment()) : 8;
+    private static VideoConstraints createVideoConstraints(int maxSize, int minSizeAlignment, MediaCodecInfo.VideoCapabilities caps) {
+        assert caps != null;
+        int alignment = Math.max(caps.getWidthAlignment(), caps.getHeightAlignment());
         Ln.d("Video codec size alignment requirement: " + alignment + "px");
         if (alignment < minSizeAlignment) {
             alignment = minSizeAlignment;
             Ln.d("Actual video size alignment: " + alignment + "px");
         }
-        VideoConstraints constraints = new VideoConstraints(maxSize, alignment);
+
+        return new VideoConstraints(maxSize, alignment);
+    }
+
+    private void streamCapture() throws IOException, ConfigurationException {
+        Codec codec = streamer.getCodec();
+        MediaCodec mediaCodec = createMediaCodec(codec, encoderName);
+        MediaFormat format = createFormat(codec.getMimeType(), videoBitRate, maxFps, codecOptions);
+
+        MediaCodecInfo.VideoCapabilities caps = mediaCodec.getCodecInfo().getCapabilitiesForType(codec.getMimeType()).getVideoCapabilities();
+        assert caps != null; // caps cannot be null for a video codec
+        VideoConstraints constraints = createVideoConstraints(maxSize, minSizeAlignment, caps);
 
         capture.init(reset, constraints);
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -36,6 +36,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     private final String encoderName;
     private final List<CodecOption> codecOptions;
     private final int videoBitRate;
+    private final int maxSize;
     private final float maxFps;
     private final int minSizeAlignment;
 
@@ -48,6 +49,7 @@ public class SurfaceEncoder implements AsyncProcessor {
         this.capture = capture;
         this.streamer = streamer;
         this.videoBitRate = options.getVideoBitRate();
+        this.maxSize = options.getMaxSize();
         this.maxFps = options.getMaxFps();
         this.codecOptions = options.getVideoCodecOptions();
         this.encoderName = options.getVideoEncoder();
@@ -67,7 +69,7 @@ public class SurfaceEncoder implements AsyncProcessor {
             alignment = minSizeAlignment;
             Ln.d("Actual video size alignment: " + alignment + "px");
         }
-        VideoConstraints constraints = new VideoConstraints(alignment);
+        VideoConstraints constraints = new VideoConstraints(maxSize, alignment);
 
         capture.init(reset, constraints);
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -67,8 +67,9 @@ public class SurfaceEncoder implements AsyncProcessor {
             alignment = minSizeAlignment;
             Ln.d("Actual video size alignment: " + alignment + "px");
         }
+        VideoConstraints constraints = new VideoConstraints(alignment);
 
-        capture.init(reset, alignment);
+        capture.init(reset, constraints);
 
         try {
             boolean alive;

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
@@ -1,0 +1,22 @@
+package com.genymobile.scrcpy.video;
+
+public class VideoConstraints {
+    private final int alignment;
+
+    public VideoConstraints(int alignment) {
+        assert alignment > 0 : "Alignment must be positive";
+        assert (alignment & (alignment - 1)) == 0 : "Alignment must be a power-of-two";
+        this.alignment = alignment;
+    }
+
+    /**
+     * Return the video alignment.
+     * <p>
+     * This a power-of-2 value that the video width and height must be multiples of.
+     *
+     * @return the video alignment
+     */
+    public int getAlignment() {
+        return alignment;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
@@ -7,8 +7,9 @@ public class VideoConstraints {
     private final int alignment;
     private final Size maxCodecLandscapeSize;
     private final Size maxCodecPortraitSize;
+    private final int minCodecSize;
 
-    public VideoConstraints(int maxSize, int alignment, Size maxCodecLandscapeSize, Size maxCodecPortraitSize) {
+    public VideoConstraints(int maxSize, int alignment, Size maxCodecLandscapeSize, Size maxCodecPortraitSize, int minCodecSize) {
         assert maxSize >= 0 : "Max size must not be negative";
         this.maxSize = maxSize;
 
@@ -21,6 +22,9 @@ public class VideoConstraints {
 
         assert maxCodecPortraitSize != null;
         this.maxCodecPortraitSize = maxCodecPortraitSize;
+
+        assert minCodecSize >= 0;
+        this.minCodecSize = minCodecSize;
     }
 
     /**
@@ -59,5 +63,14 @@ public class VideoConstraints {
      */
     public Size getMaxCodecPortraitSize() {
         return maxCodecPortraitSize;
+    }
+
+    /**
+     * Return the min size supported by the codec.
+     *
+     * @return the min size
+     */
+    public int getMinCodecSize() {
+        return minCodecSize;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
@@ -1,12 +1,25 @@
 package com.genymobile.scrcpy.video;
 
 public class VideoConstraints {
+    private final int maxSize;
     private final int alignment;
 
-    public VideoConstraints(int alignment) {
+    public VideoConstraints(int maxSize, int alignment) {
+        assert maxSize >= 0 : "Max size must not be negative";
+        this.maxSize = maxSize;
+
         assert alignment > 0 : "Alignment must be positive";
         assert (alignment & (alignment - 1)) == 0 : "Alignment must be a power-of-two";
         this.alignment = alignment;
+    }
+
+    /**
+     * Return the max size (0 if not requested)
+     *
+     * @return the max requested size
+     */
+    public int getMaxSize() {
+        return maxSize;
     }
 
     /**

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
@@ -1,16 +1,26 @@
 package com.genymobile.scrcpy.video;
 
+import com.genymobile.scrcpy.device.Size;
+
 public class VideoConstraints {
     private final int maxSize;
     private final int alignment;
+    private final Size maxCodecLandscapeSize;
+    private final Size maxCodecPortraitSize;
 
-    public VideoConstraints(int maxSize, int alignment) {
+    public VideoConstraints(int maxSize, int alignment, Size maxCodecLandscapeSize, Size maxCodecPortraitSize) {
         assert maxSize >= 0 : "Max size must not be negative";
         this.maxSize = maxSize;
 
         assert alignment > 0 : "Alignment must be positive";
         assert (alignment & (alignment - 1)) == 0 : "Alignment must be a power-of-two";
         this.alignment = alignment;
+
+        assert maxCodecLandscapeSize != null;
+        this.maxCodecLandscapeSize = maxCodecLandscapeSize;
+
+        assert maxCodecPortraitSize != null;
+        this.maxCodecPortraitSize = maxCodecPortraitSize;
     }
 
     /**
@@ -31,5 +41,23 @@ public class VideoConstraints {
      */
     public int getAlignment() {
         return alignment;
+    }
+
+    /**
+     * Return the max landscape size supported by the codec.
+     *
+     * @return the max landscape size
+     */
+    public Size getMaxCodecLandscapeSize() {
+        return maxCodecLandscapeSize;
+    }
+
+    /**
+     * Return the max portrait size supported by the codec.
+     *
+     * @return the max portrait size
+     */
+    public Size getMaxCodecPortraitSize() {
+        return maxCodecPortraitSize;
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
@@ -7,36 +7,36 @@ import org.junit.Test;
 
 public class SizeTest {
 
-    private VideoConstraints createVideoConstraints(int alignment) {
-        return new VideoConstraints(alignment);
+    private VideoConstraints createVideoConstraints(int maxSize, int alignment) {
+        return new VideoConstraints(maxSize, alignment);
     }
 
     @Test
     public void testConstrainSize() {
         Size size = new Size(207, 209);
 
-        Assert.assertEquals(size, size.constrain(0, createVideoConstraints(1)));
-        Assert.assertEquals(new Size(208, 210), size.constrain(0, createVideoConstraints(2)));
-        Assert.assertEquals(new Size(208, 208), size.constrain(0, createVideoConstraints(4)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(0, 1)));
+        Assert.assertEquals(new Size(208, 210), size.constrain(createVideoConstraints(0, 2)));
+        Assert.assertEquals(new Size(208, 208), size.constrain(createVideoConstraints(0, 4)));
 
-        Size s = size.constrain(208, createVideoConstraints(2));
+        Size s = size.constrain(createVideoConstraints(208, 2));
         Assert.assertEquals(208, s.getHeight());
         Assert.assertTrue(s.getWidth() >= 206 && s.getWidth() <= 208 && s.getWidth() % 2 == 0);
 
-        Assert.assertEquals(new Size(207 * 208 / 209, 208), size.constrain(208, createVideoConstraints(2)));
-        Assert.assertEquals(new Size(208, 208), size.constrain(208, createVideoConstraints(4)));
+        Assert.assertEquals(new Size(207 * 208 / 209, 208), size.constrain(createVideoConstraints(208, 2)));
+        Assert.assertEquals(new Size(208, 208), size.constrain(createVideoConstraints(208, 4)));
     }
 
     @Test
     public void testConstrainSizeUnchanged() {
         Size size = new Size(256, 512);
 
-        Assert.assertEquals(size, size.constrain(0, createVideoConstraints(1)));
-        Assert.assertEquals(size, size.constrain(512, createVideoConstraints(1)));
-        Assert.assertEquals(size, size.constrain(515, createVideoConstraints(1)));
-        Assert.assertEquals(size, size.constrain(512, createVideoConstraints(16)));
-        Assert.assertEquals(size, size.constrain(515, createVideoConstraints(16)));
-        Assert.assertEquals(size, size.constrain(0, createVideoConstraints(16)));
-        Assert.assertEquals(size, size.constrain(4096, createVideoConstraints(16)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(0, 1)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(512, 1)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(515, 1)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(512, 16)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(515, 16)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(0, 16)));
+        Assert.assertEquals(size, size.constrain(createVideoConstraints(4096, 16)));
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
@@ -1,0 +1,35 @@
+package com.genymobile.scrcpy.device;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SizeTest {
+    @Test
+    public void testConstrainSize() {
+        Size size = new Size(207, 209);
+
+        Assert.assertEquals(size, size.constrain(0, 1));
+        Assert.assertEquals(new Size(208, 210), size.constrain(0, 2));
+        Assert.assertEquals(new Size(208, 208), size.constrain(0, 4));
+
+        Size s = size.constrain(208, 2);
+        Assert.assertEquals(208, s.getHeight());
+        Assert.assertTrue(s.getWidth() >= 206 && s.getWidth() <= 208 && s.getWidth() % 2 == 0);
+
+        Assert.assertEquals(new Size(207 * 208 / 209, 208), size.constrain(208, 2));
+        Assert.assertEquals(new Size(208, 208), size.constrain(208, 4));
+    }
+
+    @Test
+    public void testConstrainSizeUnchanged() {
+        Size size = new Size(256, 512);
+
+        Assert.assertEquals(size, size.constrain(0, 1));
+        Assert.assertEquals(size, size.constrain(512, 1));
+        Assert.assertEquals(size, size.constrain(515, 1));
+        Assert.assertEquals(size, size.constrain(512, 16));
+        Assert.assertEquals(size, size.constrain(515, 16));
+        Assert.assertEquals(size, size.constrain(0, 16));
+        Assert.assertEquals(size, size.constrain(4096, 16));
+    }
+}

--- a/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
@@ -8,7 +8,12 @@ import org.junit.Test;
 public class SizeTest {
 
     private VideoConstraints createVideoConstraints(int maxSize, int alignment) {
-        return new VideoConstraints(maxSize, alignment);
+        Size maxCodecSize = new Size(4096, 4096);
+        return createVideoConstraints(maxSize, alignment, maxCodecSize);
+    }
+
+    private VideoConstraints createVideoConstraints(int maxSize, int alignment, Size maxCodecSize) {
+        return new VideoConstraints(maxSize, alignment, maxCodecSize, maxCodecSize);
     }
 
     @Test
@@ -38,5 +43,20 @@ public class SizeTest {
         Assert.assertEquals(size, size.constrain(createVideoConstraints(515, 16)));
         Assert.assertEquals(size, size.constrain(createVideoConstraints(0, 16)));
         Assert.assertEquals(size, size.constrain(createVideoConstraints(4096, 16)));
+    }
+
+    @Test
+    public void testConstrainMaxCodecSize() {
+        Size maxCodecSize = new Size(400, 600);
+
+        Size size = new Size(314, 617);
+        Assert.assertEquals(new Size(314 * 600 / 617, 600), size.constrain(createVideoConstraints(0, 1, maxCodecSize)));
+        Assert.assertEquals(new Size(314 * 550 / 617, 550), size.constrain(createVideoConstraints(550, 1, maxCodecSize)));
+
+        size = new Size(512, 536);
+        Assert.assertEquals(new Size(400, 536 * 400 / 512), size.constrain(createVideoConstraints(0, 1, maxCodecSize)));
+        Assert.assertEquals(new Size(400, 536 * 400 / 512), size.constrain(createVideoConstraints(550, 1, maxCodecSize)));
+        Assert.assertEquals(new Size(400, 536 * 400 / 512), size.constrain(createVideoConstraints(500, 1, maxCodecSize)));
+        Assert.assertEquals(new Size(512 * 410 / 536, 410), size.constrain(createVideoConstraints(410, 1, maxCodecSize)));
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
@@ -13,7 +13,11 @@ public class SizeTest {
     }
 
     private VideoConstraints createVideoConstraints(int maxSize, int alignment, Size maxCodecSize) {
-        return new VideoConstraints(maxSize, alignment, maxCodecSize, maxCodecSize);
+        return new VideoConstraints(maxSize, alignment, maxCodecSize, maxCodecSize, 0);
+    }
+
+    private VideoConstraints createVideoConstraints(int maxSize, int alignment, Size maxCodecSize, int minCodecSize) {
+        return new VideoConstraints(maxSize, alignment, maxCodecSize, maxCodecSize, minCodecSize);
     }
 
     @Test
@@ -58,5 +62,14 @@ public class SizeTest {
         Assert.assertEquals(new Size(400, 536 * 400 / 512), size.constrain(createVideoConstraints(550, 1, maxCodecSize)));
         Assert.assertEquals(new Size(400, 536 * 400 / 512), size.constrain(createVideoConstraints(500, 1, maxCodecSize)));
         Assert.assertEquals(new Size(512 * 410 / 536, 410), size.constrain(createVideoConstraints(410, 1, maxCodecSize)));
+    }
+
+    @Test
+    public void testConstrainMinCodecSize() {
+        Size maxCodecSize = new Size(1024, 1024);
+
+        Size size = new Size(800, 600);
+        Assert.assertEquals(new Size(800, 600), size.constrain(createVideoConstraints(800, 1, maxCodecSize, 512)));
+        Assert.assertEquals(new Size(512, 512), size.constrain(createVideoConstraints(400, 1, maxCodecSize, 512)));
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/device/SizeTest.java
@@ -1,35 +1,42 @@
 package com.genymobile.scrcpy.device;
 
+import com.genymobile.scrcpy.video.VideoConstraints;
+
 import org.junit.Assert;
 import org.junit.Test;
 
 public class SizeTest {
+
+    private VideoConstraints createVideoConstraints(int alignment) {
+        return new VideoConstraints(alignment);
+    }
+
     @Test
     public void testConstrainSize() {
         Size size = new Size(207, 209);
 
-        Assert.assertEquals(size, size.constrain(0, 1));
-        Assert.assertEquals(new Size(208, 210), size.constrain(0, 2));
-        Assert.assertEquals(new Size(208, 208), size.constrain(0, 4));
+        Assert.assertEquals(size, size.constrain(0, createVideoConstraints(1)));
+        Assert.assertEquals(new Size(208, 210), size.constrain(0, createVideoConstraints(2)));
+        Assert.assertEquals(new Size(208, 208), size.constrain(0, createVideoConstraints(4)));
 
-        Size s = size.constrain(208, 2);
+        Size s = size.constrain(208, createVideoConstraints(2));
         Assert.assertEquals(208, s.getHeight());
         Assert.assertTrue(s.getWidth() >= 206 && s.getWidth() <= 208 && s.getWidth() % 2 == 0);
 
-        Assert.assertEquals(new Size(207 * 208 / 209, 208), size.constrain(208, 2));
-        Assert.assertEquals(new Size(208, 208), size.constrain(208, 4));
+        Assert.assertEquals(new Size(207 * 208 / 209, 208), size.constrain(208, createVideoConstraints(2)));
+        Assert.assertEquals(new Size(208, 208), size.constrain(208, createVideoConstraints(4)));
     }
 
     @Test
     public void testConstrainSizeUnchanged() {
         Size size = new Size(256, 512);
 
-        Assert.assertEquals(size, size.constrain(0, 1));
-        Assert.assertEquals(size, size.constrain(512, 1));
-        Assert.assertEquals(size, size.constrain(515, 1));
-        Assert.assertEquals(size, size.constrain(512, 16));
-        Assert.assertEquals(size, size.constrain(515, 16));
-        Assert.assertEquals(size, size.constrain(0, 16));
-        Assert.assertEquals(size, size.constrain(4096, 16));
+        Assert.assertEquals(size, size.constrain(0, createVideoConstraints(1)));
+        Assert.assertEquals(size, size.constrain(512, createVideoConstraints(1)));
+        Assert.assertEquals(size, size.constrain(515, createVideoConstraints(1)));
+        Assert.assertEquals(size, size.constrain(512, createVideoConstraints(16)));
+        Assert.assertEquals(size, size.constrain(515, createVideoConstraints(16)));
+        Assert.assertEquals(size, size.constrain(0, createVideoConstraints(16)));
+        Assert.assertEquals(size, size.constrain(4096, createVideoConstraints(16)));
     }
 }


### PR DESCRIPTION
A mechanism was introduced to retry capture at a lower resolution to support devices unable to encode at the device screen resolution (#2947).
    
While useful, this approach is inherently limited and will not be able to handle the dynamic resizing required for resizable virtual displays.

Disable this mechanism entirely, and adjust the size in advance according to video encoder capababilities.