### PR TITLE
Add support for VP8 and VP9 video encoders

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -110,7 +110,7 @@ _scrcpy() {
 
     case "$prev" in
         --video-codec)
-            COMPREPLY=($(compgen -W 'h264 h265 av1' -- "$cur"))
+            COMPREPLY=($(compgen -W 'h264 h265 av1 vp8 vp9' -- "$cur"))
             return
             ;;
         --audio-codec)

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -118,7 +118,7 @@ _scrcpy() {
 
     case "$prev" in
         --video-codec)
-            COMPREPLY=($(compgen -W 'h264 h265 av1' -- "$cur"))
+            COMPREPLY=($(compgen -W 'h264 h265 av1 vp8 vp9' -- "$cur"))
             return
             ;;
         --audio-codec)

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -97,7 +97,7 @@ arguments=(
     {-v,--version}'[Print the version of scrcpy]'
     {-V,--verbosity=}'[Set the log level]:verbosity:(verbose debug info warn error)'
     '--video-buffer=[Add a buffering delay \(in milliseconds\) before displaying video frames]'
-    '--video-codec=[Select the video codec]:codec:(h264 h265 av1)'
+    '--video-codec=[Select the video codec]:codec:(h264 h265 av1 vp8 vp9)'
     '--video-codec-options=[Set a list of comma-separated key\:type=value options for the device video encoder]'
     '--video-encoder=[Use a specific MediaCodec video encoder]'
     '--video-source=[Select the video source]:source:(display camera)'

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -105,7 +105,7 @@ arguments=(
     {-v,--version}'[Print the version of scrcpy]'
     {-V,--verbosity=}'[Set the log level]:verbosity:(verbose debug info warn error)'
     '--video-buffer=[Add a buffering delay \(in milliseconds\) before displaying video frames]'
-    '--video-codec=[Select the video codec]:codec:(h264 h265 av1)'
+    '--video-codec=[Select the video codec]:codec:(h264 h265 av1 vp8 vp9)'
     '--video-codec-options=[Set a list of comma-separated key\:type=value options for the device video encoder]'
     '--video-encoder=[Use a specific MediaCodec video encoder]'
     '--video-source=[Select the video source]:source:(display camera)'

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -63,6 +63,8 @@ else
         --enable-decoder=h264
         --enable-decoder=hevc
         --enable-decoder=av1
+        --enable-decoder=vp8
+        --enable-decoder=vp9
         --enable-decoder=libdav1d
         --enable-decoder=pcm_s16le
         --enable-decoder=opus

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -604,7 +604,7 @@ Default is 0 (no buffering).
 
 .TP
 .BI "\-\-video\-codec " name
-Select a video codec (h264, h265 or av1).
+Select a video codec (h264, h265, av1, vp8 or vp9).
 
 Default is h264.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -652,7 +652,7 @@ Default is 0 (no buffering).
 
 .TP
 .BI "\-\-video\-codec " name
-Select a video codec (h264, h265 or av1).
+Select a video codec (h264, h265, av1, vp8 or vp9).
 
 Default is h264.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -987,7 +987,7 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_VIDEO_CODEC,
         .longopt = "video-codec",
         .argdesc = "name",
-        .text = "Select a video codec (h264, h265 or av1).\n"
+        .text = "Select a video codec (h264, h265, av1, vp8 or vp9).\n"
                 "Default is h264.",
     },
     {
@@ -1994,7 +1994,15 @@ parse_video_codec(const char *optarg, enum sc_codec *codec) {
         *codec = SC_CODEC_AV1;
         return true;
     }
-    LOGE("Unsupported video codec: %s (expected h264, h265 or av1)", optarg);
+    if (!strcmp(optarg, "vp8")) {
+        *codec = SC_CODEC_VP8;
+        return true;
+    }
+    if (!strcmp(optarg, "vp9")) {
+        *codec = SC_CODEC_VP9;
+        return true;
+    }
+    LOGE("Unsupported video codec: %s (expected h264, h265, av1, vp8 or vp9)", optarg);
     return false;
 }
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -968,7 +968,7 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_VIDEO_CODEC,
         .longopt = "video-codec",
         .argdesc = "name",
-        .text = "Select a video codec (h264, h265 or av1).\n"
+        .text = "Select a video codec (h264, h265, av1, vp8 or vp9).\n"
                 "Default is h264.",
     },
     {
@@ -2016,7 +2016,15 @@ parse_video_codec(const char *optarg, enum sc_codec *codec) {
         *codec = SC_CODEC_AV1;
         return true;
     }
-    LOGE("Unsupported video codec: %s (expected h264, h265 or av1)", optarg);
+    if (!strcmp(optarg, "vp8")) {
+        *codec = SC_CODEC_VP8;
+        return true;
+    }
+    if (!strcmp(optarg, "vp9")) {
+        *codec = SC_CODEC_VP9;
+        return true;
+    }
+    LOGE("Unsupported video codec: %s (expected h264, h265, av1, vp8 or vp9)", optarg);
     return false;
 }
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -3373,6 +3373,12 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             LOGE("Recording to MP4 container does not support RAW audio");
             return false;
         }
+
+        if (opts->record_format == SC_RECORD_FORMAT_MP4
+                && opts->video_codec == SC_CODEC_VP8) {
+            LOGE("Recording to MP4 container does not support VP8 video");
+            return false;
+        }
     }
 
     if (opts->audio_codec == SC_CODEC_FLAC && opts->audio_bit_rate) {

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -20,6 +20,8 @@ static enum AVCodecID
 sc_demuxer_to_avcodec_id(uint32_t codec_id) {
 #define SC_CODEC_ID_H264 UINT32_C(0x68323634) // "h264" in ASCII
 #define SC_CODEC_ID_H265 UINT32_C(0x68323635) // "h265" in ASCII
+#define SC_CODEC_ID_VP8 UINT32_C(0x00767038) // "vp8" in ASCII
+#define SC_CODEC_ID_VP9 UINT32_C(0x00767039) // "vp9" in ASCII
 #define SC_CODEC_ID_AV1 UINT32_C(0x00617631) // "av1" in ASCII
 #define SC_CODEC_ID_OPUS UINT32_C(0x6f707573) // "opus" in ASCII
 #define SC_CODEC_ID_AAC UINT32_C(0x00616163) // "aac" in ASCII
@@ -30,6 +32,10 @@ sc_demuxer_to_avcodec_id(uint32_t codec_id) {
             return AV_CODEC_ID_H264;
         case SC_CODEC_ID_H265:
             return AV_CODEC_ID_HEVC;
+        case SC_CODEC_ID_VP8:
+            return AV_CODEC_ID_VP8;
+        case SC_CODEC_ID_VP9:
+            return AV_CODEC_ID_VP9;
         case SC_CODEC_ID_AV1:
 #ifdef SCRCPY_LAVC_HAS_AV1
             return AV_CODEC_ID_AV1;

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -21,6 +21,8 @@ sc_demuxer_to_avcodec_id(uint32_t codec_id) {
 #define SC_CODEC_ID_H264 UINT32_C(0x68323634) // "h264" in ASCII
 #define SC_CODEC_ID_H265 UINT32_C(0x68323635) // "h265" in ASCII
 #define SC_CODEC_ID_AV1 UINT32_C(0x00617631) // "av1" in ASCII
+#define SC_CODEC_ID_VP8 UINT32_C(0x00767038) // "vp8" in ASCII
+#define SC_CODEC_ID_VP9 UINT32_C(0x00767039) // "vp9" in ASCII
 #define SC_CODEC_ID_OPUS UINT32_C(0x6f707573) // "opus" in ASCII
 #define SC_CODEC_ID_AAC UINT32_C(0x00616163) // "aac" in ASCII
 #define SC_CODEC_ID_FLAC UINT32_C(0x666c6163) // "flac" in ASCII
@@ -37,6 +39,10 @@ sc_demuxer_to_avcodec_id(uint32_t codec_id) {
             LOGE("AV1 not supported by this FFmpeg version");
             return AV_CODEC_ID_NONE;
 #endif
+        case SC_CODEC_ID_VP8:
+            return AV_CODEC_ID_VP8;
+        case SC_CODEC_ID_VP9:
+            return AV_CODEC_ID_VP9;
         case SC_CODEC_ID_OPUS:
             return AV_CODEC_ID_OPUS;
         case SC_CODEC_ID_AAC:

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -43,6 +43,8 @@ enum sc_codec {
     SC_CODEC_H264,
     SC_CODEC_H265,
     SC_CODEC_AV1,
+    SC_CODEC_VP8,
+    SC_CODEC_VP9,
     SC_CODEC_OPUS,
     SC_CODEC_AAC,
     SC_CODEC_FLAC,

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -181,7 +181,8 @@ sc_recorder_close_output_file(struct sc_recorder *recorder) {
 
 static inline bool
 sc_recorder_must_wait_for_config_packets(struct sc_recorder *recorder) {
-    if (recorder->video && sc_vecdeque_is_empty(&recorder->video_queue)) {
+    if (recorder->video && recorder->video_expects_config_packet
+            && sc_vecdeque_is_empty(&recorder->video_queue)) {
         // The video queue is empty
         return true;
     }
@@ -207,8 +208,8 @@ sc_recorder_process_header(struct sc_recorder *recorder) {
         sc_cond_wait(&recorder->cond, &recorder->mutex);
     }
 
-    if (recorder->video && sc_vecdeque_is_empty(&recorder->video_queue)) {
-        assert(recorder->stopped);
+    if (recorder->stopped && recorder->video
+            && sc_vecdeque_is_empty(&recorder->video_queue)) {
         // If the recorder is stopped, don't process anything if there are not
         // at least video packets
         sc_mutex_unlock(&recorder->mutex);
@@ -217,7 +218,8 @@ sc_recorder_process_header(struct sc_recorder *recorder) {
     }
 
     AVPacket *video_pkt = NULL;
-    if (!sc_vecdeque_is_empty(&recorder->video_queue)) {
+    if (recorder->video_expects_config_packet &&
+            !sc_vecdeque_is_empty(&recorder->video_queue)) {
         assert(recorder->video);
         video_pkt = sc_vecdeque_pop(&recorder->video_queue);
     }
@@ -579,6 +581,10 @@ sc_recorder_video_packet_sink_open(struct sc_packet_sink *sink,
              sc_orientation_get_name(recorder->orientation));
     }
 
+    // A config packet is provided for all supported formats except VPx
+    recorder->video_expects_config_packet = ctx->codec_id != AV_CODEC_ID_VP8
+                                         && ctx->codec_id != AV_CODEC_ID_VP9;
+
     recorder->video_init = true;
     sc_cond_signal(&recorder->cond);
     sc_mutex_unlock(&recorder->mutex);
@@ -784,6 +790,7 @@ sc_recorder_init(struct sc_recorder *recorder, const char *filename,
     recorder->video_init = false;
     recorder->audio_init = false;
 
+    recorder->video_expects_config_packet = false;
     recorder->audio_expects_config_packet = false;
 
     sc_recorder_stream_init(&recorder->video_stream);

--- a/app/src/recorder.h
+++ b/app/src/recorder.h
@@ -53,6 +53,7 @@ struct sc_recorder {
     bool video_init;
     bool audio_init;
 
+    bool video_expects_config_packet;
     bool audio_expects_config_packet;
 
     struct sc_recorder_stream video_stream;

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -109,6 +109,10 @@ sc_server_get_codec_name(enum sc_codec codec) {
             return "h264";
         case SC_CODEC_H265:
             return "h265";
+        case SC_CODEC_VP8:
+            return "vp8";
+        case SC_CODEC_VP9:
+            return "vp9";
         case SC_CODEC_AV1:
             return "av1";
         case SC_CODEC_OPUS:

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -111,6 +111,10 @@ sc_server_get_codec_name(enum sc_codec codec) {
             return "h265";
         case SC_CODEC_AV1:
             return "av1";
+        case SC_CODEC_VP8:
+            return "vp8";
+        case SC_CODEC_VP9:
+            return "vp9";
         case SC_CODEC_OPUS:
             return "opus";
         case SC_CODEC_AAC:

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -356,6 +356,8 @@ Valid codec ids for _video_ streams are:
  - `"h264"` (`0x68323634`)
  - `"h265"` (`0x68323635`)
  - `"av1"` (`0x00617631`)
+ - `"vp8"` (`0x00767038`)
+ - `"vp9"` (`0x00767039`)
 
 Valid codec ids for _audio_ streams are:
  - `"opus"` (`0x6F707573`)

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoCodec.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoCodec.java
@@ -9,7 +9,9 @@ public enum VideoCodec implements Codec {
     H264(0x68_32_36_34, "h264", MediaFormat.MIMETYPE_VIDEO_AVC),
     H265(0x68_32_36_35, "h265", MediaFormat.MIMETYPE_VIDEO_HEVC),
     @SuppressLint("InlinedApi") // introduced in API 29
-    AV1(0x00_61_76_31, "av1", MediaFormat.MIMETYPE_VIDEO_AV1);
+    AV1(0x00_61_76_31, "av1", MediaFormat.MIMETYPE_VIDEO_AV1),
+    VP8(0x00_76_70_38, "vp8", MediaFormat.MIMETYPE_VIDEO_VP8),
+    VP9(0x00_76_70_39, "vp9", MediaFormat.MIMETYPE_VIDEO_VP9);
 
     private final int id; // 4-byte ASCII representation of the name
     private final String name;


### PR DESCRIPTION
### **Summary**
This PR adds support for **VP8** and **VP9** video codecs. This is primarily intended as a fallback for devices where the manufacturer has intentionally disabled H.264 (AVC) and H.265 (HEVC) encoders in the firmware.

### **The Problem (Onyx Boox Note X case)**
On recent Onyx Boox devices (e.g., Note X with current firmware), the vendor has disabled both hardware and software H.264/H.265 encoders. This makes `scrcpy` unusable as it cannot find any compatible video encoder.

### **Evidence**
In `/vendor/etc/media_codecs.xml`, all H.264/H.265 encoders are commented out:

<details>
<summary><b>/vendor/etc/media_codecs.xml</b></summary>

```xml
<MediaCodecs>
    <Include href="media_codecs_google_audio.xml" />
    <Include href="media_codecs_google_telephony.xml" />
    <Settings>
        <Setting name="max-video-encoder-input-buffers" value="11" />
    </Settings>
    <Encoders>
        <!-- Video Hardware  -->
        <!-- Disabled: H.264/AVC encoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.encoder.avc" type="video/avc" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Quirk name="requires-loaded-to-idle-after-allocation" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-60000000" />
            <Limit name="frame-rate" range="1-120" />
            <Limit name="concurrent-instances" max="16" />
            <Limit name="performance-point-1920x1080" value="30" />
            <Limit name="performance-point-1280x720" value="60" />
            <Limit name="performance-point-720x480" value="120" />
        </MediaCodec>
        -->
        <!-- Disabled: HEVC encoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.encoder.hevc" type="video/hevc" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Quirk name="requires-loaded-to-idle-after-allocation" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-60000000" />
            <Limit name="frame-rate" range="1-120" />
            <Limit name="concurrent-instances" max="16" />
            <Limit name="quality" range="0-100" default="80" />
            <Feature name="bitrate-modes" value="VBR,CBR" />
            <Limit name="performance-point-1920x1080" value="30" />
            <Limit name="performance-point-1280x720" value="60" />
            <Limit name="performance-point-720x480" value="120" />
        </MediaCodec>
        -->
        <!-- Disabled: HEVC CQ encoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.encoder.hevc.cq" type="video/hevc" >
                <Quirk name="requires-allocate-on-input-ports" />
                <Quirk name="requires-allocate-on-input-ports" />
                <Quirk name="requires-allocate-on-output-ports" />
                <Quirk name="requires-loaded-to-idle-after-allocation" />
                <Limit name="size" min="128x128" max="512x512" />
                <Limit name="frame-rate" range="1-20" />
                <Limit name="concurrent-instances" max="16" />
                <Limit name="quality" range="0-100" default="80" />
                <Feature name="bitrate-modes" value="CQ" />
                <Limit name="performance-point-512x512" value="2025" />
        </MediaCodec>
        -->
        <!-- Disabled: HEIC encoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.encoder.heic" type="image/vnd.android.heic" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Quirk name="requires-loaded-to-idle-after-allocation" />
            <Limit name="size" min="512x512" max="8192x8192" />
            <Limit name="frame-rate" range="1-20" />
            <Limit name="concurrent-instances" max="6" />
            <Limit name="quality" range="0-100" default="80" />
            <Feature name="bitrate-modes" value="CQ" />
            <Limit name="performance-point-8192x4320" value="3" />
            <Limit name="performance-point-1920x1080" value="6" />
        </MediaCodec>
        -->
        <!-- Video Software -->
        <!-- Disabled: H.263 encoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.encoder.h263sw" type="video/3gpp" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Quirk name="requires-loaded-to-idle-after-allocation" />
            <Limit name="size" min="96x96" max="864x480" />
            <Limit name="alignment" value="4x4" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="36" max="48600" />
            <Limit name="bitrate" range="1-2000000" />
            <Limit name="frame-rate" range="1-30" />
            <Limit name="concurrent-instances" max="3" />
            <Limit name="performance-point-720x480" value="30" />
        </MediaCodec>
        -->
        <!-- Disabled: MPEG-4 encoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.encoder.mpeg4sw" type="video/mp4v-es" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
             <Quirk name="requires-loaded-to-idle-after-allocation" />
             <Limit name="size" min="96x96" max="864x480" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" min="36" max="48600" />
             <Limit name="bitrate" range="1-8000000" />
             <Limit name="frame-rate" range="1-30" />
             <Limit name="concurrent-instances" max="3" />
             <Limit name="performance-point-720x480" value="30" />
        </MediaCodec>
        -->
    </Encoders>
    <Decoders>
       <!-- Video Hardware  -->
        <MediaCodec name="OMX.qcom.video.decoder.avc" type="video/avc" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-60000000" />
            <Limit name="frame-rate" range="1-120" />
            <Feature name="adaptive-playback" />
            <Limit name="concurrent-instances" max="16" />
            <Limit name="performance-point-1920x1080" value="30" />
            <Limit name="performance-point-1280x720" value="60" />
            <Limit name="performance-point-720x480" value="120" />
        </MediaCodec>
        <MediaCodec name="OMX.qcom.video.decoder.avc.secure" type="video/avc" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-35000000" />
            <Limit name="frame-rate" range="1-60" />
            <Feature name="adaptive-playback" />
            <Feature name="secure-playback" required="true" />
            <Limit name="concurrent-instances" max="3" />
            <Limit name="performance-point-1920x1080" value="30" />
        </MediaCodec>
        <MediaCodec name="OMX.qcom.video.decoder.vp9" type="video/x-vnd.on2.vp9" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-60000000" />
            <Limit name="frame-rate" range="1-120" />
            <Feature name="adaptive-playback" />
            <Limit name="concurrent-instances" max="6" />
            <Limit name="performance-point-1920x1080" value="30" />
            <Limit name="performance-point-1280x720" value="60" />
            <Limit name="performance-point-720x480" value="120" />
        </MediaCodec>
        <MediaCodec name="OMX.qcom.video.decoder.vp9.secure" type="video/x-vnd.on2.vp9" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-35000000" />
            <Limit name="frame-rate" range="1-60" />
            <Feature name="adaptive-playback" />
            <Feature name="secure-playback" required="true" />
            <Limit name="concurrent-instances" max="3" />
            <Limit name="performance-point-1920x1080" value="30" />
        </MediaCodec>
        <!-- Disabled: HEVC decoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.decoder.hevc" type="video/hevc" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-60000000" />
            <Limit name="frame-rate" range="1-120" />
            <Feature name="adaptive-playback" />
            <Limit name="concurrent-instances" max="16" />
            <Limit name="performance-point-1920x1080" value="30" />
            <Limit name="performance-point-1280x720" value="60" />
            <Limit name="performance-point-720x480" value="120" />
        </MediaCodec>
        -->
        <!-- Disabled: HEVC secure decoder -->
        <!--
        <MediaCodec name="OMX.qcom.video.decoder.hevc.secure" type="video/hevc" >
            <Quirk name="requires-allocate-on-input-ports" />
            <Quirk name="requires-allocate-on-output-ports" />
            <Limit name="size" min="128x128" max="1920x1088" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" min="64" max="244800" />
            <Limit name="bitrate" range="1-35000000" />
            <Limit name="frame-rate" range="1-60" />
            <Feature name="adaptive-playback" />
            <Feature name="secure-playback" required="true" />
            <Limit name="concurrent-instances" max="3" />
            <Limit name="performance-point-1920x1080" value="30" />
        </MediaCodec>
        -->
        <!-- Video Software -->
        <!-- Disabled: H.263 decoder -->
        <!--
        <MediaCodec name="OMX.qti.video.decoder.h263sw" type="video/3gpp" >
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
             <Limit name="size" min="96x96" max="864x480" />
             <Limit name="alignment" value="4x4" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" min="36" max="48600" />
             <Limit name="bitrate" range="1-16000000" />
             <Limit name="frame-rate" range="1-30" />
             <Feature name="adaptive-playback" />
             <Limit name="concurrent-instances" max="4" />
             <Limit name="performance-point-720x480" value="30" />
        </MediaCodec>
        -->
        <!-- Disabled: MPEG-4 decoder -->
        <!--
        <MediaCodec name="OMX.qti.video.decoder.mpeg4sw" type="video/mp4v-es">
             <Quirk name="requires-allocate-on-input-ports" />
             <Quirk name="requires-allocate-on-output-ports" />
             <Limit name="size" min="96x96" max="1920x1088" />
             <Limit name="alignment" value="2x2" />
             <Limit name="block-size" value="16x16" />
             <Limit name="blocks-per-second" min="36" max="244800" />
             <Limit name="bitrate" range="1-40000000" />
             <Limit name="frame-rate" range="1-30" />
             <Limit name="concurrent-instances" max="4" />
             <Limit name="performance-point-1920x1080" value="30" />
        </MediaCodec>
	-->
    </Decoders>
    <Include href="media_codecs_google_video.xml" />
</MediaCodecs>
```
</details>



Even the default Android software H.264 encoder in `media_codecs_google_video.xml` is disabled. Only **VP8** and **VP9** software encoders remain available:
<details>
<summary><b>media_codecs_google_video.xml</b></summary>

```xml
<Included>
    <Decoders>
        <!-- Disabled: MPEG-4 decoder -->
        <!--
        <MediaCodec name="OMX.google.mpeg4.decoder" type="video/mp4v-es">
            <Limit name="size" min="2x2" max="352x288" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" range="12-11880" />
            <Limit name="bitrate" range="1-384000" />
            <Feature name="adaptive-playback" />
        </MediaCodec>
        -->
        <!-- Disabled: H.263 decoder -->
        <!--
        <MediaCodec name="OMX.google.h263.decoder" type="video/3gpp">
            <Limit name="size" min="2x2" max="352x288" />
            <Limit name="alignment" value="2x2" />
            <Limit name="bitrate" range="1-384000" />
            <Feature name="adaptive-playback" />
        </MediaCodec>
        -->
        <MediaCodec name="OMX.google.h264.decoder" type="video/avc">
            <Limit name="size" min="2x2" max="4080x4080" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="block-count" range="1-32768" />
            <Limit name="blocks-per-second" range="1-1966080" />
            <Limit name="bitrate" range="1-48000000" />
            <Feature name="adaptive-playback" />
        </MediaCodec>
        <!-- Disabled: HEVC decoder -->
        <!--
        <MediaCodec name="OMX.google.hevc.decoder" type="video/hevc">
            <Limit name="size" min="2x2" max="4096x4096" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="8x8" />
            <Limit name="block-count" range="1-196608" />
            <Limit name="blocks-per-second" range="1-2000000" />
            <Limit name="bitrate" range="1-10000000" />
            <Feature name="adaptive-playback" />
        </MediaCodec>
        -->
        <MediaCodec name="OMX.google.vp8.decoder" type="video/x-vnd.on2.vp8">
            <Limit name="size" min="2x2" max="2048x2048" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="block-count" range="1-16384" />
            <Limit name="blocks-per-second" range="1-1000000" />
            <Limit name="bitrate" range="1-40000000" />
            <Feature name="adaptive-playback" />
        </MediaCodec>
        <MediaCodec name="OMX.google.vp9.decoder" type="video/x-vnd.on2.vp9">
            <Limit name="size" min="2x2" max="2048x2048" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="block-count" range="1-16384" />
            <Limit name="blocks-per-second" range="1-500000" />
            <Limit name="bitrate" range="1-40000000" />
            <Feature name="adaptive-playback" />
        </MediaCodec>
    </Decoders>

    <Encoders>
        <!-- Disabled: H.263 encoder -->
        <!--
        <MediaCodec name="OMX.google.h263.encoder" type="video/3gpp">
            <Limit name="size" min="176x144" max="176x144" />
            <Limit name="alignment" value="16x16" />
            <Limit name="bitrate" range="1-128000" />
        </MediaCodec>
        -->
        <!-- Disabled: H.264/AVC encoder -->
        <!--
        <MediaCodec name="OMX.google.h264.encoder" type="video/avc">
            <Limit name="size" min="16x16" max="2048x2048" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <Limit name="block-count" range="1-8192" />
            <Limit name="blocks-per-second" range="1-245760" />
            <Limit name="bitrate" range="1-12000000" />
            <Feature name="intra-refresh" />
        </MediaCodec>
        -->
        <!-- Disabled: MPEG-4 encoder -->
        <!--
        <MediaCodec name="OMX.google.mpeg4.encoder" type="video/mp4v-es">
            <Limit name="size" min="16x16" max="176x144" />
            <Limit name="alignment" value="16x16" />
            <Limit name="block-size" value="16x16" />
            <Limit name="blocks-per-second" range="12-1485" />
            <Limit name="bitrate" range="1-64000" />
        </MediaCodec>
        -->
        <MediaCodec name="OMX.google.vp8.encoder" type="video/x-vnd.on2.vp8">
            <!-- profiles and levels:  ProfileMain : Level_Version0-3 -->
            <Limit name="size" min="2x2" max="2048x2048" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <!-- 2016 devices can encode at about 10fps at this block count -->
            <Limit name="block-count" range="1-16384" />
            <Limit name="bitrate" range="1-40000000" />
            <Feature name="bitrate-modes" value="VBR,CBR" />
        </MediaCodec>
        <MediaCodec name="OMX.google.vp9.encoder" type="video/x-vnd.on2.vp9">
            <!-- profiles and levels:  ProfileMain : Level_Version0-3 -->
            <Limit name="size" min="2x2" max="2048x2048" />
            <Limit name="alignment" value="2x2" />
            <Limit name="block-size" value="16x16" />
            <!-- 2016 devices can encode at about 8fps at this block count -->
            <Limit name="block-count" range="1-3600" /> <!-- max 1280x720 -->
            <Limit name="bitrate" range="1-40000000" />
            <Feature name="bitrate-modes" value="VBR,CBR" />
        </MediaCodec>
    </Encoders>
</Included>
```
</details>

### **Known Limitations (Latency)**
Since these encoders are **software-based** on the affected devices, there is a **noticeable increase in latency** compared to hardware-accelerated H.264. 

However, this latency can be significantly mitigated by reducing the stream resolution and frame rate (e.g., using `--max-size=1024 --max-fps=15`). In my testing on the Onyx Boox Note X, these optimizations make the device much more responsive while maintaining a stable and clear stream. Given that the alternative is a total lack of functionality, this fallback is a necessary and usable compromise.

### **Testing Environment**
* **Host:** CachyOS (Kernel 6.19.11)
* **Desktop:** GNOME 50.0 (Wayland)
* **Target Device:** Onyx Boox Note X (Android 11, Firmware version: `2026-02-11_13-07_4.1.1-rel_0210_8841760b67`)

Fixes #6763

