### PR TITLE
Align the virtual display size

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/model/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/model/Size.java
@@ -84,6 +84,15 @@ public final class Size {
         return new Size(w, h);
     }
 
+    public Size align(int alignment) {
+        int w = width / alignment * alignment;
+        int h = height / alignment * alignment;
+        if (w == width && h == height) {
+            return this;
+        }
+        return new Size(w, h);
+    }
+
     private static int round(int value, int alignment) {
         return (value + (alignment / 2)) / alignment * alignment;
     }

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -108,6 +108,10 @@ public class NewDisplayCapture extends SurfaceCapture {
             if (!newDisplay.hasExplicitSize()) {
                 displaySize = mainDisplaySize;
             }
+
+            // Align the physical display size to avoid unnecessary mismatches with the output size
+            displaySize = displaySize.align(getVideoConstraints().getAlignment());
+
             if (!newDisplay.hasExplicitDpi()) {
                 dpi = scaleDpi(mainDisplaySize, mainDisplayDpi, displaySize);
             }
@@ -117,9 +121,11 @@ public class NewDisplayCapture extends SurfaceCapture {
             displayMonitor.setSessionDisplayProperties(new DisplayProperties(displaySize, displayRotation));
         } else {
             DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(virtualDisplay.getDisplay().getDisplayId());
-            displaySize = displayInfo.getSize();
             dpi = displayInfo.getDpi();
             displayRotation = displayInfo.getRotation();
+
+            // Align the physical display size to avoid unnecessary mismatches with the output size
+            displaySize = displayInfo.getSize().align(getVideoConstraints().getAlignment());
         }
 
         VideoFilter filter = new VideoFilter(displaySize);


### PR DESCRIPTION
When the virtual display size is not aligned, a resize filter may be inserted to compensate for small dimension mismatches, increasing processing and resulting in a blurry image.