### PR TITLE
Set default audio-output-buffer to 10ms

### DIFF
--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -87,9 +87,9 @@ Default is output.
 .BI "\-\-audio\-output\-buffer " ms
 Configure the size of the SDL audio output buffer (in milliseconds).
 
-If you get "robotic" audio playback, you should test with a higher value (10). Do not change this setting otherwise.
+Do not change this setting unless you have a good reason.
 
-Default is 5.
+Default is 10.
 
 .TP
 .BI "\-b, \-\-video\-bit\-rate " value

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -241,9 +241,8 @@ static const struct sc_option options[] = {
         .argdesc = "ms",
         .text = "Configure the size of the SDL audio output buffer (in "
                 "milliseconds).\n"
-                "If you get \"robotic\" audio playback, you should test with "
-                "a higher value (10). Do not change this setting otherwise.\n"
-                "Default is 5.",
+                "Do not change this setting unless you have a good reason.\n"
+                "Default is 10.",
     },
     {
         .shortopt = 'b',

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -66,7 +66,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .display_id = 0,
     .video_buffer = 0,
     .audio_buffer = -1, // depends on the audio format,
-    .audio_output_buffer = SC_TICK_FROM_MS(5),
+    .audio_output_buffer = SC_TICK_FROM_MS(10),
     .time_limit = 0,
     .screen_off_timeout = -1,
 #ifdef HAVE_V4L2

--- a/doc/audio.md
+++ b/doc/audio.md
@@ -188,12 +188,11 @@ scrcpy --video-buffer=200 --audio-buffer=200
 ```
 
 It is also possible to configure another audio buffer (the audio output buffer),
-by default set to 5ms. Don't change it, unless you get some [robotic and glitchy
-sound][#3793]:
+by default set to 10ms. Do not change this setting unless you have a good reason
+(see [robotic and glitchy sound][#3793]). For instance:
 
 ```bash
-# Only if absolutely necessary
-scrcpy --audio-output-buffer=10
+scrcpy --audio-output-buffer=5
 ```
 
 [#3793]: https://github.com/Genymobile/scrcpy/issues/3793


### PR DESCRIPTION
Change the default value of `--audio-output-buffer` from 5ms to 10ms.

In practice, the audio output backends do not support values below 10ms. When the setting is set to 5ms, several successive calls are made every 10ms or more.

Additionally, a 5ms output buffer can cause audio glitches on some computers.

Fixes #3793
Refs <https://github.com/libsdl-org/SDL/issues/13319>
Refs <https://github.com/libsdl-org/SDL/issues/13397>