### PR TITLE
[Draft] Keep awake by simulating user activity

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -80,6 +80,7 @@ _scrcpy() {
         --record-format=
         --record-orientation=
         --render-driver=
+        --render-fit=
         --require-audio
         -s --serial=
         -S --turn-screen-off
@@ -174,6 +175,10 @@ _scrcpy() {
             ;;
         --render-driver)
             COMPREPLY=($(compgen -W 'direct3d opengl opengles2 opengles metal software' -- "$cur"))
+            return
+            ;;
+        --render-fit)
+            COMPREPLY=($(compgen -W 'letterbox disabled' -- "$cur"))
             return
             ;;
         --shortcut-mod)

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -179,7 +179,7 @@ _scrcpy() {
             return
             ;;
         --render-fit)
-            COMPREPLY=($(compgen -W 'letterbox disabled' -- "$cur"))
+            COMPREPLY=($(compgen -W 'letterbox stretched disabled' -- "$cur"))
             return
             ;;
         --shortcut-mod)

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -108,7 +108,8 @@ _scrcpy() {
         --window-x=
         --window-y=
         --window-width=
-        --window-height="
+        --window-height=
+        -x --flex-display"
 
     _init_completion -s || return
 

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -113,6 +113,7 @@ arguments=(
     '--window-y=[Set the initial window vertical position]'
     '--window-width=[Set the initial window width]'
     '--window-height=[Set the initial window height]'
+    {-x,--flex-display}'[Continuously resize the virtual display to match the window]'
 )
 
 _arguments -s $arguments

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -85,6 +85,7 @@ arguments=(
     '--record-format=[Force recording format]:format:(mp4 mkv m4a mka opus aac flac wav)'
     '--record-orientation=[Set the record orientation]:orientation values:(0 90 180 270)'
     '--render-driver=[Request SDL to use the given render driver]:driver name:(direct3d opengl opengles2 opengles metal software)'
+    '--render-fit=[Set the render-fit mode]:mode:(letterbox disabled)'
     '--require-audio=[Make scrcpy fail if audio is enabled but does not work]'
     {-s,--serial=}'[The device serial number \(mandatory for multiple devices only\)]:serial:($("${ADB-adb}" devices | awk '\''$2 == "device" {print $1}'\''))'
     {-S,--turn-screen-off}'[Turn the device screen off immediately]'

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -85,7 +85,7 @@ arguments=(
     '--record-format=[Force recording format]:format:(mp4 mkv m4a mka opus aac flac wav)'
     '--record-orientation=[Set the record orientation]:orientation values:(0 90 180 270)'
     '--render-driver=[Request SDL to use the given render driver]:driver name:(direct3d opengl opengles2 opengles metal software)'
-    '--render-fit=[Set the render-fit mode]:mode:(letterbox disabled)'
+    '--render-fit=[Set the render-fit mode]:mode:(letterbox stretched disabled)'
     '--require-audio=[Make scrcpy fail if audio is enabled but does not work]'
     {-s,--serial=}'[The device serial number \(mandatory for multiple devices only\)]:serial:($("${ADB-adb}" devices | awk '\''$2 == "device" {print $1}'\''))'
     {-S,--turn-screen-off}'[Turn the device screen off immediately]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -515,6 +515,17 @@ Supported names are currently "direct3d", "opengl", "opengles2", "opengles", "me
 <https://wiki.libsdl.org/SDL_HINT_RENDER_DRIVER>
 
 .TP
+.BI "\-\-render\-fit " mode
+Set the render-fit mode to configure how the rendering fits the window.
+
+Possible values are "letterbox" and "disabled":
+
+ - "letterbox": preserve the aspect ratio and fit the window as best as possible (black bars are added either at the top and bottom or at the sides if needed).
+ - "disabled": render the display at the top-left corner, without scaling.
+
+Default is "letterbox".
+
+.TP
 .B \-\-require\-audio
 By default, scrcpy mirrors only the video if audio capture fails on the device. This option makes scrcpy fail if audio is enabled but does not work.
 

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -518,9 +518,10 @@ Supported names are currently "direct3d", "opengl", "opengles2", "opengles", "me
 .BI "\-\-render\-fit " mode
 Set the render-fit mode to configure how the rendering fits the window.
 
-Possible values are "letterbox" and "disabled":
+Possible values are "letterbox", "stretched" and "disabled":
 
  - "letterbox": preserve the aspect ratio and fit the window as best as possible (black bars are added either at the top and bottom or at the sides if needed).
+ - "stretched": fit the window without preserving the aspect ratio.
  - "disabled": render the display at the top-left corner, without scaling.
 
 Default is "letterbox", unless --flex-display is set, in which case it is "disabled".

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -523,7 +523,7 @@ Possible values are "letterbox" and "disabled":
  - "letterbox": preserve the aspect ratio and fit the window as best as possible (black bars are added either at the top and bottom or at the sides if needed).
  - "disabled": render the display at the top-left corner, without scaling.
 
-Default is "letterbox".
+Default is "letterbox", unless --flex-display is set, in which case it is "disabled".
 
 .TP
 .B \-\-require\-audio
@@ -694,6 +694,10 @@ Default is 0 (automatic).
 Set the initial window height.
 
 Default is 0 (automatic).
+
+.TP
+.B \-x, \-\-flex\-display
+Continuously resize the virtual display to match the window.
 
 .SH EXIT STATUS
 .B scrcpy

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -784,10 +784,13 @@ static const struct sc_option options[] = {
         .argdesc = "mode",
         .text = "Set the render-fit mode to configure how the rendering fits "
                 "the window.\n"
-                "Possible values are \"letterbox\" and \"disabled\".\n"
+                "Possible values are \"letterbox\", \"stretched\" and "
+                "\"disabled\".\n"
                 "\"letterbox\": preserve the aspect ratio and fit the window "
                 "as best as possible (black bars are added either at the top "
                 "and bottom or at the sides if needed).\n"
+                "\"stretched\": fit the window without preserving the aspect "
+                "ratio.\n"
                 "\"disabled\": render the display at the top-left corner, "
                 "without scaling.\n"
                 "Default is \"letterbox\", unless --flex-display is set, in "
@@ -2354,12 +2357,18 @@ parse_render_fit(const char *optarg, enum sc_render_fit *mode) {
         return true;
     }
 
+    if (!strcmp(optarg, "stretched")) {
+        *mode = SC_RENDER_FIT_STRETCHED;
+        return true;
+    }
+
     if (!strcmp(optarg, "disabled")) {
         *mode = SC_RENDER_FIT_DISABLED;
         return true;
     }
 
-    LOGE("Unsupported render-fit: %s (expected letterbox or disabled)", optarg);
+    LOGE("Unsupported render-fit: %s (expected letterbox, stretched or "
+         "disabled)", optarg);
     return false;
 }
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -105,6 +105,7 @@ enum {
     OPT_CAMERA_ZOOM,
     OPT_MIN_SIZE_ALIGNMENT,
     OPT_NO_WINDOW_ASPECT_RATIO_LOCK,
+    OPT_RENDER_FIT,
 };
 
 struct sc_option {
@@ -776,6 +777,20 @@ static const struct sc_option options[] = {
                 "Supported names are currently \"direct3d\", \"opengl\", "
                 "\"opengles2\", \"opengles\", \"metal\" and \"software\".\n"
                 "<https://wiki.libsdl.org/SDL_HINT_RENDER_DRIVER>",
+    },
+    {
+        .longopt_id = OPT_RENDER_FIT,
+        .longopt = "render-fit",
+        .argdesc = "mode",
+        .text = "Set the render-fit mode to configure how the rendering fits "
+                "the window.\n"
+                "Possible values are \"letterbox\" and \"disabled\".\n"
+                "\"letterbox\": preserve the aspect ratio and fit the window "
+                "as best as possible (black bars are added either at the top "
+                "and bottom or at the sides if needed).\n"
+                "\"disabled\": render the display at the top-left corner, "
+                "without scaling.\n"
+                "Default is \"letterbox\".",
     },
     {
         .longopt_id = OPT_REQUIRE_AUDIO,
@@ -2327,6 +2342,22 @@ parse_mouse_bindings(const char *s, struct sc_mouse_bindings *mb) {
 }
 
 static bool
+parse_render_fit(const char *optarg, enum sc_render_fit *mode) {
+    if (!strcmp(optarg, "letterbox")) {
+        *mode = SC_RENDER_FIT_LETTERBOX;
+        return true;
+    }
+
+    if (!strcmp(optarg, "disabled")) {
+        *mode = SC_RENDER_FIT_DISABLED;
+        return true;
+    }
+
+    LOGE("Unsupported render-fit: %s (expected letterbox or disabled)", optarg);
+    return false;
+}
+
+static bool
 parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                        const char *optstring, const struct option *longopts) {
     struct scrcpy_options *opts = &args->opts;
@@ -2758,6 +2789,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_WINDOW_ASPECT_RATIO_LOCK:
                 opts->window_aspect_ratio_lock = false;
+                break;
+            case OPT_RENDER_FIT:
+                if (!parse_render_fit(optarg, &opts->render_fit)) {
+                    return false;
+                }
                 break;
             default:
                 // getopt prints the error message on stderr

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -790,7 +790,8 @@ static const struct sc_option options[] = {
                 "and bottom or at the sides if needed).\n"
                 "\"disabled\": render the display at the top-left corner, "
                 "without scaling.\n"
-                "Default is \"letterbox\".",
+                "Default is \"letterbox\", unless --flex-display is set, in "
+                "which case it is \"disabled\".",
     },
     {
         .longopt_id = OPT_REQUIRE_AUDIO,
@@ -1014,6 +1015,11 @@ static const struct sc_option options[] = {
         .argdesc = "value",
         .text = "Set the initial window height.\n"
                 "Default is 0 (automatic).",
+    },
+    {
+        .shortopt = 'x',
+        .longopt = "flex-display",
+        .text = "Continuously resize the virtual display to match the window.",
     },
 };
 
@@ -2795,6 +2801,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                     return false;
                 }
                 break;
+            case 'x':
+                opts->flex_display = true;
+                break;
             default:
                 // getopt prints the error message on stderr
                 return false;
@@ -2974,6 +2983,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         }
     }
 
+    if (opts->render_fit == SC_RENDER_FIT_AUTO) {
+        opts->render_fit = opts->flex_display ? SC_RENDER_FIT_DISABLED
+                                              : SC_RENDER_FIT_LETTERBOX;
+    }
+
     if (otg) {
         if (!opts->control) {
             LOGE("--no-control is not allowed in OTG mode");
@@ -3091,6 +3105,28 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     if (opts->display_id != 0 && opts->new_display) {
         LOGE("Cannot specify both --display-id and --new-display");
         return false;
+    }
+
+    if (opts->flex_display) {
+        if (opts->video_source != SC_VIDEO_SOURCE_DISPLAY
+                || !opts->new_display) {
+            LOGE("-x/--flex-display can only be applied to displays created "
+                 "with --new-display");
+            return false;
+        }
+
+        if (opts->max_size) {
+            LOGE("--max-size is not compatible with -x/--flex-display");
+            return false;
+        }
+
+        if (opts->crop) {
+            LOGE("--crop is not compatible with -x/--flex-display");
+            return false;
+        }
+
+        // Force free resizing
+        opts->window_aspect_ratio_lock = false;
     }
 
     if (opts->display_ime_policy != SC_DISPLAY_IME_POLICY_UNDEFINED

--- a/app/src/control_msg.c
+++ b/app/src/control_msg.c
@@ -185,6 +185,10 @@ sc_control_msg_serialize(const struct sc_control_msg *msg, uint8_t *buf) {
         case SC_CONTROL_MSG_TYPE_CAMERA_SET_TORCH:
             buf[1] = msg->camera_set_torch.on ? 1 : 0;
             return 2;
+        case SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY:
+            sc_write16be(&buf[1], msg->resize_display.width);
+            sc_write16be(&buf[3], msg->resize_display.height);
+            return 5;
         case SC_CONTROL_MSG_TYPE_EXPAND_NOTIFICATION_PANEL:
         case SC_CONTROL_MSG_TYPE_EXPAND_SETTINGS_PANEL:
         case SC_CONTROL_MSG_TYPE_COLLAPSE_PANELS:
@@ -272,6 +276,10 @@ sc_control_msg_log(const struct sc_control_msg *msg) {
         case SC_CONTROL_MSG_TYPE_SET_DISPLAY_POWER:
             LOG_CMSG("display power %s",
                      msg->set_display_power.on ? "on" : "off");
+            break;
+        case SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY:
+            LOG_CMSG("resize display %" PRIu16 "x%" PRIu16,
+                     msg->resize_display.width, msg->resize_display.height);
             break;
         case SC_CONTROL_MSG_TYPE_EXPAND_NOTIFICATION_PANEL:
             LOG_CMSG("expand notification panel");

--- a/app/src/control_msg.h
+++ b/app/src/control_msg.h
@@ -46,6 +46,7 @@ enum sc_control_msg_type {
     SC_CONTROL_MSG_TYPE_CAMERA_SET_TORCH,
     SC_CONTROL_MSG_TYPE_CAMERA_ZOOM_IN,
     SC_CONTROL_MSG_TYPE_CAMERA_ZOOM_OUT,
+    SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY,
 };
 
 enum sc_copy_key {
@@ -117,6 +118,10 @@ struct sc_control_msg {
         struct {
             bool on;
         } camera_set_torch;
+        struct {
+            uint16_t width;
+            uint16_t height;
+        } resize_display;
     };
 };
 

--- a/app/src/controller.c
+++ b/app/src/controller.c
@@ -59,6 +59,9 @@ sc_controller_init(struct sc_controller *controller, sc_socket control_socket,
     controller->control_socket = control_socket;
     controller->stopped = false;
 
+    controller->resize_display.width = 0;
+    controller->resize_display.height = 0;
+
     assert(cbs && cbs->on_ended);
     controller->cbs = cbs;
     controller->cbs_userdata = cbs_userdata;
@@ -92,6 +95,9 @@ sc_controller_destroy(struct sc_controller *controller) {
 bool
 sc_controller_push_msg(struct sc_controller *controller,
                        const struct sc_control_msg *msg) {
+    // RESIZE_DISPLAY messages are handled separately
+    assert(msg->type != SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY);
+
     bool pushed = false;
 
     sc_mutex_lock(&controller->mutex);
@@ -117,6 +123,20 @@ sc_controller_push_msg(struct sc_controller *controller,
     sc_mutex_unlock(&controller->mutex);
 
     return pushed;
+}
+
+void
+sc_controller_resize_display(struct sc_controller *controller,
+                             uint16_t width, uint16_t height) {
+    assert(width && height);
+    sc_mutex_lock(&controller->mutex);
+    bool was_set = controller->resize_display.width;
+    controller->resize_display.width = width;
+    controller->resize_display.height = height;
+    if (!was_set) {
+        sc_cond_signal(&controller->msg_cond);
+    }
+    sc_mutex_unlock(&controller->mutex);
 }
 
 static bool
@@ -148,6 +168,7 @@ run_controller(void *data) {
     for (;;) {
         sc_mutex_lock(&controller->mutex);
         while (!controller->stopped
+                && !controller->resize_display.width
                 && sc_vecdeque_is_empty(&controller->queue)) {
             sc_cond_wait(&controller->msg_cond, &controller->mutex);
         }
@@ -158,8 +179,20 @@ run_controller(void *data) {
             break;
         }
 
-        assert(!sc_vecdeque_is_empty(&controller->queue));
-        struct sc_control_msg msg = sc_vecdeque_pop(&controller->queue);
+        bool has_resize_display = controller->resize_display.width;
+        assert(has_resize_display || !sc_vecdeque_is_empty(&controller->queue));
+
+        struct sc_control_msg msg;
+
+        if (has_resize_display) {
+            msg.type = SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY;
+            msg.resize_display.width = controller->resize_display.width;
+            msg.resize_display.height = controller->resize_display.height;
+            controller->resize_display.width = 0;
+            controller->resize_display.height = 0;
+        } else {
+            msg = sc_vecdeque_pop(&controller->queue);
+        }
         sc_mutex_unlock(&controller->mutex);
 
         if (sc_get_log_level() <= SC_LOG_LEVEL_VERBOSE) {

--- a/app/src/controller.c
+++ b/app/src/controller.c
@@ -92,10 +92,6 @@ sc_controller_destroy(struct sc_controller *controller) {
 bool
 sc_controller_push_msg(struct sc_controller *controller,
                        const struct sc_control_msg *msg) {
-    if (sc_get_log_level() <= SC_LOG_LEVEL_VERBOSE) {
-        sc_control_msg_log(msg);
-    }
-
     bool pushed = false;
 
     sc_mutex_lock(&controller->mutex);
@@ -165,6 +161,10 @@ run_controller(void *data) {
         assert(!sc_vecdeque_is_empty(&controller->queue));
         struct sc_control_msg msg = sc_vecdeque_pop(&controller->queue);
         sc_mutex_unlock(&controller->mutex);
+
+        if (sc_get_log_level() <= SC_LOG_LEVEL_VERBOSE) {
+            sc_control_msg_log(&msg);
+        }
 
         bool eos;
         bool ok = process_msg(controller, &msg, &eos);

--- a/app/src/controller.h
+++ b/app/src/controller.h
@@ -20,7 +20,17 @@ struct sc_controller {
     sc_mutex mutex;
     sc_cond msg_cond;
     bool stopped;
+
     struct sc_control_msg_queue queue;
+
+    // The RESIZE_DISPLAY control message is never enqueued, it has top priority
+    // and a new request overwrites any previous one
+    struct {
+        // enabled if width != 0
+        uint16_t width;
+        uint16_t height;
+    } resize_display;
+
     struct sc_receiver receiver;
 
     const struct sc_controller_callbacks *cbs;
@@ -57,5 +67,9 @@ sc_controller_join(struct sc_controller *controller);
 bool
 sc_controller_push_msg(struct sc_controller *controller,
                        const struct sc_control_msg *msg);
+
+void
+sc_controller_resize_display(struct sc_controller *controller,
+                             uint16_t width, uint16_t height);
 
 #endif

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -76,10 +76,10 @@ sc_demuxer_recv_header(struct sc_demuxer *demuxer,
     // which only contains a 12-byte header:
     //
     //  byte 0   byte 1   byte 2   byte 3
-    // 10000000 00000000 00000000 00000000
-    // ^<-------------------------------->
-    // |               padding
-    //  `- session packet flag
+    // 10000000 00000000 00000000 0000000.
+    // ^<------------------------------->^
+    // |               padding           |
+    //  `- session packet flag            `- client resized flag
     //
     //  byte 4   byte 5   byte 6   byte 7   byte 8   byte 9   byte 10  byte 11
     // ........ ........ ........ ........ ........ ........ ........ ........
@@ -126,6 +126,7 @@ sc_demuxer_parse_session(const uint8_t *header,
     assert(sc_demuxer_is_session(header));
     session->video.width = sc_read32be(&header[4]);
     session->video.height = sc_read32be(&header[8]);
+    session->video.client_resized = header[3] & 1;
 }
 
 static bool

--- a/app/src/frame_buffer.c
+++ b/app/src/frame_buffer.c
@@ -19,13 +19,6 @@ sc_frame_buffer_init(struct sc_frame_buffer *fb) {
         return false;
     }
 
-    bool ok = sc_mutex_init(&fb->mutex);
-    if (!ok) {
-        av_frame_free(&fb->pending_frame);
-        av_frame_free(&fb->tmp_frame);
-        return false;
-    }
-
     // there is initially no frame, so consider it has already been consumed
     fb->pending_frame_consumed = true;
 
@@ -34,7 +27,6 @@ sc_frame_buffer_init(struct sc_frame_buffer *fb) {
 
 void
 sc_frame_buffer_destroy(struct sc_frame_buffer *fb) {
-    sc_mutex_destroy(&fb->mutex);
     av_frame_free(&fb->pending_frame);
     av_frame_free(&fb->tmp_frame);
 }
@@ -47,8 +39,12 @@ swap_frames(AVFrame **lhs, AVFrame **rhs) {
 }
 
 bool
-sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame,
-                     bool *previous_frame_skipped) {
+sc_frame_buffer_has_frame(struct sc_frame_buffer *fb) {
+    return !fb->pending_frame_consumed;
+}
+
+bool
+sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame) {
     // Use a temporary frame to preserve pending_frame in case of error.
     // tmp_frame is an empty frame, no need to call av_frame_unref() beforehand.
     int r = av_frame_ref(fb->tmp_frame, frame);
@@ -57,32 +53,21 @@ sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame,
         return false;
     }
 
-    sc_mutex_lock(&fb->mutex);
-
     // Now that av_frame_ref() succeeded, we can replace the previous
     // pending_frame
     swap_frames(&fb->pending_frame, &fb->tmp_frame);
     av_frame_unref(fb->tmp_frame);
 
-    if (previous_frame_skipped) {
-        *previous_frame_skipped = !fb->pending_frame_consumed;
-    }
     fb->pending_frame_consumed = false;
-
-    sc_mutex_unlock(&fb->mutex);
-
     return true;
 }
 
 void
 sc_frame_buffer_consume(struct sc_frame_buffer *fb, AVFrame *dst) {
-    sc_mutex_lock(&fb->mutex);
     assert(!fb->pending_frame_consumed);
     fb->pending_frame_consumed = true;
 
     av_frame_move_ref(dst, fb->pending_frame);
     // av_frame_move_ref() resets its source frame, so no need to call
     // av_frame_unref()
-
-    sc_mutex_unlock(&fb->mutex);
 }

--- a/app/src/frame_buffer.h
+++ b/app/src/frame_buffer.h
@@ -6,8 +6,6 @@
 #include <stdbool.h>
 #include <libavutil/frame.h>
 
-#include "util/thread.h"
-
 // forward declarations
 typedef struct AVFrame AVFrame;
 
@@ -24,8 +22,6 @@ struct sc_frame_buffer {
     AVFrame *pending_frame;
     AVFrame *tmp_frame; // To preserve the pending frame on error
 
-    sc_mutex mutex;
-
     bool pending_frame_consumed;
 };
 
@@ -36,8 +32,10 @@ void
 sc_frame_buffer_destroy(struct sc_frame_buffer *fb);
 
 bool
-sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame,
-                     bool *skipped);
+sc_frame_buffer_has_frame(struct sc_frame_buffer *fb);
+
+bool
+sc_frame_buffer_push(struct sc_frame_buffer *fb, const AVFrame *frame);
 
 void
 sc_frame_buffer_consume(struct sc_frame_buffer *fb, AVFrame *dst);

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -59,6 +59,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .display_orientation = SC_ORIENTATION_0,
     .record_orientation = SC_ORIENTATION_0,
     .display_ime_policy = SC_DISPLAY_IME_POLICY_UNDEFINED,
+    .render_fit = SC_RENDER_FIT_LETTERBOX,
     .window_x = SC_WINDOW_POSITION_UNDEFINED,
     .window_y = SC_WINDOW_POSITION_UNDEFINED,
     .window_width = 0,

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -59,7 +59,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .display_orientation = SC_ORIENTATION_0,
     .record_orientation = SC_ORIENTATION_0,
     .display_ime_policy = SC_DISPLAY_IME_POLICY_UNDEFINED,
-    .render_fit = SC_RENDER_FIT_LETTERBOX,
+    .render_fit = SC_RENDER_FIT_AUTO,
     .window_x = SC_WINDOW_POSITION_UNDEFINED,
     .window_y = SC_WINDOW_POSITION_UNDEFINED,
     .window_width = 0,
@@ -117,6 +117,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .vd_destroy_content = true,
     .vd_system_decorations = true,
     .camera_torch = false,
+    .flex_display = false,
 };
 
 enum sc_orientation

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -221,6 +221,7 @@ enum sc_shortcut_mod {
 };
 
 enum sc_render_fit {
+    SC_RENDER_FIT_AUTO,
     SC_RENDER_FIT_LETTERBOX,
     SC_RENDER_FIT_DISABLED,
 };
@@ -336,6 +337,7 @@ struct scrcpy_options {
     bool vd_destroy_content;
     bool vd_system_decorations;
     bool camera_torch;
+    bool flex_display;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -223,6 +223,7 @@ enum sc_shortcut_mod {
 enum sc_render_fit {
     SC_RENDER_FIT_AUTO,
     SC_RENDER_FIT_LETTERBOX,
+    SC_RENDER_FIT_STRETCHED,
     SC_RENDER_FIT_DISABLED,
 };
 

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -220,6 +220,11 @@ enum sc_shortcut_mod {
     SC_SHORTCUT_MOD_RSUPER = 1 << 5,
 };
 
+enum sc_render_fit {
+    SC_RENDER_FIT_LETTERBOX,
+    SC_RENDER_FIT_DISABLED,
+};
+
 struct sc_port_range {
     uint16_t first;
     uint16_t last;
@@ -269,6 +274,7 @@ struct scrcpy_options {
     enum sc_orientation display_orientation;
     enum sc_orientation record_orientation;
     enum sc_display_ime_policy display_ime_policy;
+    enum sc_render_fit render_fit;
     int16_t window_x; // SC_WINDOW_POSITION_UNDEFINED for "auto"
     int16_t window_y; // SC_WINDOW_POSITION_UNDEFINED for "auto"
     uint16_t window_width;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -465,6 +465,7 @@ scrcpy(struct scrcpy_options *options) {
         .camera_zoom = options->camera_zoom,
         .vd_destroy_content = options->vd_destroy_content,
         .vd_system_decorations = options->vd_system_decorations,
+        .flex_display = options->flex_display,
         .list = options->list,
     };
 
@@ -797,6 +798,7 @@ aoa_complete:
         struct sc_screen_params screen_params = {
             .video = options->video_playback,
             .camera = options->video_source == SC_VIDEO_SOURCE_CAMERA,
+            .flex_display = options->flex_display,
             .controller = controller,
             .fp = fp,
             .kp = kp,

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -814,6 +814,7 @@ aoa_complete:
             .window_height = options->window_height,
             .window_aspect_ratio_lock = options->window_aspect_ratio_lock,
             .window_borderless = options->window_borderless,
+            .render_fit = options->render_fit,
             .orientation = options->display_orientation,
             .mipmaps = options->mipmaps,
             .fullscreen = options->fullscreen,

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -329,6 +329,8 @@ sc_screen_frame_sink_open(struct sc_frame_sink *sink,
     screen->content_size = get_oriented_size(screen->frame_size,
                                              screen->orientation);
 
+    screen->current_session = *session;
+
     bool ok = sc_push_event(SC_EVENT_OPEN_WINDOW);
     if (!ok) {
         return false;
@@ -361,6 +363,7 @@ sc_screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
     sc_mutex_lock(&screen->mutex);
     bool previous_skipped = sc_frame_buffer_has_frame(&screen->fb);
     bool ok = sc_frame_buffer_push(&screen->fb, frame);
+    screen->prevent_auto_resize = screen->current_session.video.client_resized;
     sc_mutex_unlock(&screen->mutex);
     if (!ok) {
         return false;
@@ -378,6 +381,14 @@ sc_screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
         }
     }
 
+    return true;
+}
+
+static bool
+sc_screen_frame_sink_push_session(struct sc_frame_sink *sink,
+                                  const struct sc_stream_session *session) {
+    struct sc_screen *screen = DOWNCAST(sink);
+    screen->current_session = *session;
     return true;
 }
 
@@ -402,6 +413,8 @@ sc_screen_init(struct sc_screen *screen,
     screen->req.height = params->window_height;
     screen->req.fullscreen = params->fullscreen;
     screen->req.start_fps_counter = params->start_fps_counter;
+
+    screen->prevent_auto_resize = false;
 
     bool ok = sc_mutex_init(&screen->mutex);
     if (!ok) {
@@ -570,10 +583,13 @@ sc_screen_init(struct sc_screen *screen,
     }
 #endif
 
+    memset(&screen->current_session, 0, sizeof(screen->current_session));
+
     static const struct sc_frame_sink_ops ops = {
         .open = sc_screen_frame_sink_open,
         .close = sc_screen_frame_sink_close,
         .push = sc_screen_frame_sink_push,
+        .push_session = sc_screen_frame_sink_push_session,
     };
 
     screen->frame_sink.ops = &ops;
@@ -725,16 +741,19 @@ resize_for_content(struct sc_screen *screen, struct sc_size old_content_size,
 }
 
 static void
-set_content_size(struct sc_screen *screen, struct sc_size new_content_size) {
+set_content_size(struct sc_screen *screen, struct sc_size new_content_size,
+                 bool resize) {
     assert(screen->video);
 
-    if (is_windowed(screen)) {
-        resize_for_content(screen, screen->content_size, new_content_size);
-    } else if (!screen->resize_pending) {
-        // Store the windowed size to be able to compute the optimal size once
-        // fullscreen/maximized/minimized are disabled
-        screen->windowed_content_size = screen->content_size;
-        screen->resize_pending = true;
+    if (resize) {
+        if (is_windowed(screen)) {
+            resize_for_content(screen, screen->content_size, new_content_size);
+        } else if (!screen->resize_pending) {
+            // Store the windowed size to be able to compute the optimal size
+            // once fullscreen/maximized/minimized are disabled
+            screen->windowed_content_size = screen->content_size;
+            screen->resize_pending = true;
+        }
     }
 
     screen->content_size = new_content_size;
@@ -764,7 +783,7 @@ sc_screen_set_orientation(struct sc_screen *screen,
     struct sc_size new_content_size =
         get_oriented_size(screen->frame_size, orientation);
 
-    set_content_size(screen, new_content_size);
+    set_content_size(screen, new_content_size, true);
 
     screen->orientation = orientation;
     LOGI("Display orientation set to %s", sc_orientation_get_name(orientation));
@@ -773,7 +792,7 @@ sc_screen_set_orientation(struct sc_screen *screen,
 }
 
 static bool
-sc_screen_apply_frame(struct sc_screen *screen) {
+sc_screen_apply_frame(struct sc_screen *screen, bool can_resize) {
     assert(screen->video);
     assert(screen->window_shown);
 
@@ -790,7 +809,7 @@ sc_screen_apply_frame(struct sc_screen *screen) {
 
         struct sc_size new_content_size =
             get_oriented_size(new_frame_size, screen->orientation);
-        set_content_size(screen, new_content_size);
+        set_content_size(screen, new_content_size, can_resize);
         sc_screen_update_content_rect(screen);
     }
 
@@ -826,8 +845,10 @@ sc_screen_update_frame(struct sc_screen *screen) {
     av_frame_unref(screen->frame);
     sc_mutex_lock(&screen->mutex);
     sc_frame_buffer_consume(&screen->fb, screen->frame);
+    // read with lock held
+    bool can_resize = !screen->prevent_auto_resize;
     sc_mutex_unlock(&screen->mutex);
-    return sc_screen_apply_frame(screen);
+    return sc_screen_apply_frame(screen, can_resize);
 }
 
 void
@@ -845,7 +866,7 @@ sc_screen_set_paused(struct sc_screen *screen, bool paused) {
         av_frame_free(&screen->frame);
         screen->frame = screen->resume_frame;
         screen->resume_frame = NULL;
-        bool ok = sc_screen_apply_frame(screen);
+        bool ok = sc_screen_apply_frame(screen, true);
         if (!ok) {
             LOGE("Resume frame update failed");
         }

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -286,10 +286,33 @@ end:
 }
 
 static void
-sc_screen_on_resize(struct sc_screen *screen) {
+sc_screen_request_resize_display(struct sc_screen *screen, uint16_t width,
+                                 uint16_t height) {
+    assert(screen->flex_display);
+    assert(!screen->camera);
+    if (sc_orientation_is_swap(screen->orientation)) {
+        uint16_t tmp = width;
+        width = height;
+        height = tmp;
+    }
+
+    LOGV("resize_display(%" PRIu16 ", %" PRIu16 ")", width, height);
+    sc_controller_resize_display(screen->controller, width, height);
+}
+
+static void
+sc_screen_on_resize(struct sc_screen *screen, const SDL_WindowEvent *event) {
     // This event can be triggered before the window is shown
     if (screen->window_shown) {
         sc_screen_render(screen, true);
+
+        if (screen->flex_display) {
+            assert(!(event->data1 & ~0xFFFF));
+            assert(!(event->data2 & ~0xFFFF));
+            uint16_t width = event->data1;
+            uint16_t height = event->data2;
+            sc_screen_request_resize_display(screen, width, height);
+        }
     }
 }
 
@@ -311,7 +334,7 @@ event_watcher(void *data, SDL_Event *event) {
     if (event->type == SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED) {
         // In practice, it seems to always be called from the same thread in
         // that specific case. Anyway, it's just a workaround.
-        sc_screen_on_resize(screen);
+        sc_screen_on_resize(screen, &event->window);
     }
 
     return true;
@@ -406,6 +429,8 @@ sc_screen_frame_sink_push_session(struct sc_frame_sink *sink,
 bool
 sc_screen_init(struct sc_screen *screen,
                const struct sc_screen_params *params) {
+    screen->controller = params->controller;
+
     screen->resize_pending = false;
     screen->window_shown = false;
     screen->paused = false;
@@ -418,6 +443,7 @@ sc_screen_init(struct sc_screen *screen,
     screen->camera = params->camera;
     screen->window_aspect_ratio_lock = params->window_aspect_ratio_lock;
     screen->render_fit = params->render_fit;
+    screen->flex_display = params->flex_display;
 
     screen->req.x = params->window_x;
     screen->req.y = params->window_y;
@@ -740,11 +766,13 @@ resize_for_content(struct sc_screen *screen, struct sc_size old_content_size,
     assert(screen->video);
 
     struct sc_size window_size = sc_sdl_get_window_size(screen->window);
-    struct sc_size target_size = {
-        .width = (uint32_t) window_size.width * new_content_size.width
-                / old_content_size.width,
-        .height = (uint32_t) window_size.height * new_content_size.height
-                / old_content_size.height,
+    struct sc_size target_size = new_content_size;
+    if (!screen->flex_display) {
+        // Scale proportionally
+        target_size.width = (uint32_t) window_size.width * target_size.width
+                          / old_content_size.width;
+        target_size.height = (uint32_t) window_size.height * target_size.height
+                           / old_content_size.height;
     };
     target_size = get_optimal_size(target_size, new_content_size, true);
     assert(is_windowed(screen));
@@ -760,6 +788,10 @@ set_content_size(struct sc_screen *screen, struct sc_size new_content_size,
     if (resize) {
         if (is_windowed(screen)) {
             resize_for_content(screen, screen->content_size, new_content_size);
+        } else if (screen->flex_display) {
+            // Force a display resize, the client cannot resize in fullscreen
+            struct sc_size size = sc_sdl_get_window_size(screen->window);
+            sc_screen_request_resize_display(screen, size.width, size.height);
         } else if (!screen->resize_pending) {
             // Store the windowed size to be able to compute the optimal size
             // once fullscreen/maximized/minimized are disabled
@@ -1003,7 +1035,7 @@ sc_screen_handle_event(struct sc_screen *screen, const SDL_Event *event) {
 // If defined, then the actions are already performed by the event watcher
 #ifndef CONTINUOUS_RESIZING_WORKAROUND
         case SDL_EVENT_WINDOW_PIXEL_SIZE_CHANGED:
-            sc_screen_on_resize(screen);
+            sc_screen_on_resize(screen, &event->window);
             return;
 #endif
         case SDL_EVENT_WINDOW_RESTORED:

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -158,16 +158,27 @@ sc_screen_is_relative_mode(struct sc_screen *screen) {
 
 static void
 compute_content_rect(struct sc_size render_size, struct sc_size content_size,
-                     bool is_icon, SDL_FRect *rect) {
-    if (is_icon && content_size.width <= render_size.width
+                     bool is_icon, enum sc_render_fit render_fit,
+                     SDL_FRect *rect) {
+    if (is_icon) {
+        if (content_size.width <= render_size.width
                 && content_size.height <= render_size.height) {
-        // Center without upscaling
-        rect->x = (render_size.width - content_size.width) / 2.f;
-        rect->y = (render_size.height - content_size.height) / 2.f;
+            // Center without upscaling
+            rect->x = (render_size.width - content_size.width) / 2.f;
+            rect->y = (render_size.height - content_size.height) / 2.f;
+            rect->w = content_size.width;
+            rect->h = content_size.height;
+            return;
+        }
+    } else if (render_fit == SC_RENDER_FIT_DISABLED) {
+        rect->x = 0;
+        rect->y = 0;
         rect->w = content_size.width;
         rect->h = content_size.height;
         return;
     }
+
+    assert(render_fit == SC_RENDER_FIT_LETTERBOX);
 
     if (is_optimal_size(render_size, content_size)) {
         rect->x = 0;
@@ -202,7 +213,7 @@ sc_screen_update_content_rect(struct sc_screen *screen) {
     struct sc_size render_size =
         sc_sdl_get_render_output_size(screen->renderer);
     compute_content_rect(render_size, screen->content_size, is_icon,
-                         &screen->rect);
+                         screen->render_fit, &screen->rect);
 }
 
 // render the texture to the renderer
@@ -406,6 +417,7 @@ sc_screen_init(struct sc_screen *screen,
     screen->video = params->video;
     screen->camera = params->camera;
     screen->window_aspect_ratio_lock = params->window_aspect_ratio_lock;
+    screen->render_fit = params->render_fit;
 
     screen->req.x = params->window_x;
     screen->req.y = params->window_y;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -158,22 +158,22 @@ sc_screen_is_relative_mode(struct sc_screen *screen) {
 
 static void
 compute_content_rect(struct sc_size render_size, struct sc_size content_size,
-                     bool can_upscale, SDL_FRect *rect) {
-    if (is_optimal_size(render_size, content_size)) {
-        rect->x = 0;
-        rect->y = 0;
-        rect->w = render_size.width;
-        rect->h = render_size.height;
-        return;
-    }
-
-    if (!can_upscale && content_size.width <= render_size.width
-                     && content_size.height <= render_size.height) {
+                     bool is_icon, SDL_FRect *rect) {
+    if (is_icon && content_size.width <= render_size.width
+                && content_size.height <= render_size.height) {
         // Center without upscaling
         rect->x = (render_size.width - content_size.width) / 2.f;
         rect->y = (render_size.height - content_size.height) / 2.f;
         rect->w = content_size.width;
         rect->h = content_size.height;
+        return;
+    }
+
+    if (is_optimal_size(render_size, content_size)) {
+        rect->x = 0;
+        rect->y = 0;
+        rect->w = render_size.width;
+        rect->h = render_size.height;
         return;
     }
 
@@ -197,11 +197,11 @@ compute_content_rect(struct sc_size render_size, struct sc_size content_size,
 static void
 sc_screen_update_content_rect(struct sc_screen *screen) {
     // Only upscale video frames, not icon
-    bool can_upscale = screen->video && !screen->disconnected;
+    bool is_icon = !screen->video || screen->disconnected;
 
     struct sc_size render_size =
         sc_sdl_get_render_output_size(screen->renderer);
-    compute_content_rect(render_size, screen->content_size, can_upscale,
+    compute_content_rect(render_size, screen->content_size, is_icon,
                          &screen->rect);
 }
 

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -176,6 +176,12 @@ compute_content_rect(struct sc_size render_size, struct sc_size content_size,
         rect->w = content_size.width;
         rect->h = content_size.height;
         return;
+    } else if (render_fit == SC_RENDER_FIT_STRETCHED) {
+        rect->x = 0;
+        rect->y = 0;
+        rect->w = render_size.width;
+        rect->h = render_size.height;
+        return;
     }
 
     assert(render_fit == SC_RENDER_FIT_LETTERBOX);

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -358,8 +358,10 @@ sc_screen_frame_sink_push(struct sc_frame_sink *sink, const AVFrame *frame) {
     struct sc_screen *screen = DOWNCAST(sink);
     assert(screen->video);
 
-    bool previous_skipped;
-    bool ok = sc_frame_buffer_push(&screen->fb, frame, &previous_skipped);
+    sc_mutex_lock(&screen->mutex);
+    bool previous_skipped = sc_frame_buffer_has_frame(&screen->fb);
+    bool ok = sc_frame_buffer_push(&screen->fb, frame);
+    sc_mutex_unlock(&screen->mutex);
     if (!ok) {
         return false;
     }
@@ -401,9 +403,14 @@ sc_screen_init(struct sc_screen *screen,
     screen->req.fullscreen = params->fullscreen;
     screen->req.start_fps_counter = params->start_fps_counter;
 
-    bool ok = sc_frame_buffer_init(&screen->fb);
+    bool ok = sc_mutex_init(&screen->mutex);
     if (!ok) {
         return false;
+    }
+
+    ok = sc_frame_buffer_init(&screen->fb);
+    if (!ok) {
+        goto error_destroy_mutex;
     }
 
     if (!sc_fps_counter_init(&screen->fps_counter)) {
@@ -603,6 +610,8 @@ error_destroy_fps_counter:
     sc_fps_counter_destroy(&screen->fps_counter);
 error_destroy_frame_buffer:
     sc_frame_buffer_destroy(&screen->fb);
+error_destroy_mutex:
+    sc_mutex_destroy(&screen->mutex);
 
     return false;
 }
@@ -683,6 +692,7 @@ sc_screen_destroy(struct sc_screen *screen) {
     SDL_DestroyWindow(screen->window);
     sc_fps_counter_destroy(&screen->fps_counter);
     sc_frame_buffer_destroy(&screen->fb);
+    sc_mutex_destroy(&screen->mutex);
 
     SDL_Event event;
     int nevents = SDL_PeepEvents(&event, 1, SDL_GETEVENT,
@@ -807,12 +817,16 @@ sc_screen_update_frame(struct sc_screen *screen) {
         } else {
             av_frame_unref(screen->resume_frame);
         }
+        sc_mutex_lock(&screen->mutex);
         sc_frame_buffer_consume(&screen->fb, screen->resume_frame);
+        sc_mutex_unlock(&screen->mutex);
         return true;
     }
 
     av_frame_unref(screen->frame);
+    sc_mutex_lock(&screen->mutex);
     sc_frame_buffer_consume(&screen->fb, screen->frame);
+    sc_mutex_unlock(&screen->mutex);
     return sc_screen_apply_frame(screen);
 }
 

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -22,6 +22,7 @@
 #include "trait/key_processor.h"
 #include "trait/frame_sink.h"
 #include "trait/mouse_processor.h"
+#include "util/thread.h"
 
 #ifdef __APPLE__
 # define SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
@@ -41,8 +42,10 @@ struct sc_screen {
     struct sc_texture tex;
     struct sc_input_manager im;
     struct sc_mouse_capture mc; // only used in mouse relative mode
-    struct sc_frame_buffer fb;
     struct sc_fps_counter fps_counter;
+
+    struct sc_mutex mutex;
+    struct sc_frame_buffer fb; // protected by mutex
 
     // The initial requested window properties
     struct {

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -65,6 +65,8 @@ struct sc_screen {
     SDL_GLContext gl_context;
 #endif
 
+    enum sc_render_fit render_fit;
+
     struct sc_size frame_size;
     struct sc_size content_size; // rotated frame_size
 
@@ -118,6 +120,7 @@ struct sc_screen_params {
     bool window_aspect_ratio_lock;
     bool window_borderless;
 
+    enum sc_render_fit render_fit;
     enum sc_orientation orientation;
     bool mipmaps;
 

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -38,6 +38,9 @@ struct sc_screen {
     bool video;
     bool camera;
     bool window_aspect_ratio_lock;
+    bool flex_display;
+
+    struct sc_controller *controller;
 
     struct sc_texture tex;
     struct sc_input_manager im;
@@ -97,6 +100,7 @@ struct sc_screen {
 struct sc_screen_params {
     bool video;
     bool camera;
+    bool flex_display;
 
     struct sc_controller *controller;
     struct sc_file_pusher *fp;

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -46,6 +46,8 @@ struct sc_screen {
 
     struct sc_mutex mutex;
     struct sc_frame_buffer fb; // protected by mutex
+    // When true, a frame size change must not cause the window to be resized
+    bool prevent_auto_resize; // protected by mutex
 
     // The initial requested window properties
     struct {
@@ -76,6 +78,9 @@ struct sc_screen {
     // rectangle of the content (excluding black borders)
     struct SDL_FRect rect;
     bool window_shown;
+
+    // only accessed from the thread calling sc_frame_sink_ops functions
+    struct sc_stream_session current_session;
 
     AVFrame *frame;
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -413,6 +413,9 @@ execute_server(struct sc_server *server,
         VALIDATE_STRING(params->new_display);
         ADD_PARAM("new_display=%s", params->new_display);
     }
+    if (params->flex_display) {
+        ADD_PARAM("flex_display=true");
+    }
     if (params->display_ime_policy != SC_DISPLAY_IME_POLICY_UNDEFINED) {
         ADD_PARAM("display_ime_policy=%s",
             sc_server_get_display_ime_policy_name(params->display_ime_policy));

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -72,6 +72,7 @@ struct sc_server_params {
     bool camera_torch;
     bool vd_destroy_content;
     bool vd_system_decorations;
+    bool flex_display;
     uint8_t list;
 };
 

--- a/app/src/trait/packet_sink.h
+++ b/app/src/trait/packet_sink.h
@@ -18,6 +18,7 @@ struct sc_packet_sink {
 struct sc_stream_session_video {
     uint32_t width;
     uint32_t height;
+    bool client_resized;
 };
 
 struct sc_stream_session {

--- a/app/src/v4l2_sink.c
+++ b/app/src/v4l2_sink.c
@@ -128,9 +128,8 @@ run_v4l2_sink(void *data) {
         }
 
         vs->has_frame = false;
-        sc_mutex_unlock(&vs->mutex);
-
         sc_frame_buffer_consume(&vs->fb, vs->frame);
+        sc_mutex_unlock(&vs->mutex);
 
         bool ok = encode_and_write_frame(vs, vs->frame);
         av_frame_unref(vs->frame);
@@ -311,19 +310,20 @@ sc_v4l2_sink_close(struct sc_v4l2_sink *vs) {
 
 static bool
 sc_v4l2_sink_push(struct sc_v4l2_sink *vs, const AVFrame *frame) {
-    bool previous_skipped;
-    bool ok = sc_frame_buffer_push(&vs->fb, frame, &previous_skipped);
+    sc_mutex_lock(&vs->mutex);
+    bool previous_skipped = sc_frame_buffer_has_frame(&vs->fb);
+    bool ok = sc_frame_buffer_push(&vs->fb, frame);
     if (!ok) {
+        sc_mutex_unlock(&vs->mutex);
         return false;
     }
 
     if (!previous_skipped) {
-        sc_mutex_lock(&vs->mutex);
         vs->has_frame = true;
         sc_cond_signal(&vs->cond);
-        sc_mutex_unlock(&vs->mutex);
     }
 
+    sc_mutex_unlock(&vs->mutex);
     return true;
 }
 

--- a/app/tests/test_control_msg_serialize.c
+++ b/app/tests/test_control_msg_serialize.c
@@ -495,6 +495,27 @@ static void test_serialize_camera_zoom_out(void) {
     assert(!memcmp(buf, expected, sizeof(expected)));
 }
 
+static void test_serialize_resize_display(void) {
+    struct sc_control_msg msg = {
+        .type = SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY,
+        .resize_display = {
+            .width = 1920,
+            .height = 1080,
+        },
+    };
+
+    uint8_t buf[SC_CONTROL_MSG_MAX_SIZE];
+    size_t size = sc_control_msg_serialize(&msg, buf);
+    assert(size == 5);
+
+    const uint8_t expected[] = {
+        SC_CONTROL_MSG_TYPE_RESIZE_DISPLAY,
+        1920 >> 8, 1920 & 0xff,
+        1080 >> 8, 1080 & 0xff,
+    };
+    assert(!memcmp(buf, expected, sizeof(expected)));
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -522,5 +543,6 @@ int main(int argc, char *argv[]) {
     test_serialize_camera_set_torch();
     test_serialize_camera_zoom_in();
     test_serialize_camera_zoom_out();
+    test_serialize_resize_display();
     return 0;
 }

--- a/doc/develop.md
+++ b/doc/develop.md
@@ -370,16 +370,21 @@ session (a session changes when the device rotates):
 
 ```
      byte 0   byte 1   byte 2   byte 3
-    10000000 00000000 00000000 00000000
-    ^<-------------------------------->
-    |               padding
-     `- session packet flag
+    10000000 00000000 00000000 0000000.
+    ^<------------------------------->^
+    |               padding           |
+     `- session packet flag            `- client resized flag
 
      byte 4   byte 5   byte 6   byte 7   byte 8   byte 9   byte 10  byte 11
     ........ ........ ........ ........ ........ ........ ........ ........
     <---------------------------------> <--------------------------------->
                 video width                         video height
 ```
+
+The "client resized" flag is used for _flex displays_ to indicate that the frame
+size changed due to a client resize request (see [#6772]).
+
+[#6772]: https://github.com/Genymobile/scrcpy/pull/6772
 
 For the _audio_ stream, there are no _session packets_.
 

--- a/doc/virtual_display.md
+++ b/doc/virtual_display.md
@@ -13,6 +13,24 @@ scrcpy --new-display=/240    # use the main display size and 240 dpi
 
 The new virtual display is destroyed on exit.
 
+
+## Flex display
+
+To continuously resize the virtual display to match the window size, enable
+"flex display" using `--flex-display` (or `-x`):
+
+```bash
+# Start Android Settings in a window
+scrcpy --new-display=1024x768 --start-app=com.android.settings --flex-display
+
+# -x is equivalent to --flex-display
+scrcpy --new-display=1024x768 --start-app=com.android.settings -x
+
+# By default, the display size/dpi is 1280x960/160
+scrcpy --new-display --start-app=com.android.settings --flex-display
+```
+
+
 ## Start app
 
 On some devices, a launcher is available in the virtual display.

--- a/doc/window.md
+++ b/doc/window.md
@@ -69,3 +69,25 @@ computer. To disable it:
 ```bash
 scrcpy --disable-screensaver
 ```
+
+
+## Render fit
+
+By default, the video stream is rendered in [letterbox] mode: the content fits
+the window as best as possible while preserving the aspect ratio.
+
+For [flex displays], the display is continuously resized to match the window, so
+render fit is _disabled_: the content is rendered at the top-left corner,
+without scaling.
+
+It is also possible to _stretch_ the content to fit the window without
+preserving the aspect ratio (`--render-fit=stretched`).
+
+```bash
+scrcpy --render-fit=letterbox  # default
+scrcpy --render-fit=disabled   # default for flex displays
+scrcpy --render-fit=stretched
+```
+
+[letterbox]: https://en.wikipedia.org/wiki/Letterboxing_(filming)
+[flex displays]: virtual_display.md#flex-display

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -66,6 +66,7 @@ public class Options {
     private NewDisplay newDisplay;
     private boolean vdDestroyContent = true;
     private boolean vdSystemDecorations = true;
+    private boolean flexDisplay;
 
     private Orientation.Lock captureOrientationLock = Orientation.Lock.Unlocked;
     private Orientation captureOrientation = Orientation.Orient0;
@@ -256,6 +257,10 @@ public class Options {
 
     public boolean getVDSystemDecorations() {
         return vdSystemDecorations;
+    }
+
+    public boolean getFlexDisplay() {
+        return flexDisplay;
     }
 
     public boolean getList() {
@@ -505,6 +510,9 @@ public class Options {
                     break;
                 case "vd_system_decorations":
                     options.vdSystemDecorations = Boolean.parseBoolean(value);
+                    break;
+                case "flex_display":
+                    options.flexDisplay = Boolean.parseBoolean(value);
                     break;
                 case "capture_orientation":
                     Pair<Orientation.Lock, Orientation> pair = parseCaptureOrientation(value);

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessage.java
@@ -28,6 +28,7 @@ public final class ControlMessage {
     public static final int TYPE_CAMERA_SET_TORCH = 18;
     public static final int TYPE_CAMERA_ZOOM_IN = 19;
     public static final int TYPE_CAMERA_ZOOM_OUT = 20;
+    public static final int TYPE_RESIZE_DISPLAY = 21;
 
     public static final long SEQUENCE_INVALID = 0;
 
@@ -56,6 +57,8 @@ public final class ControlMessage {
     private boolean on;
     private int vendorId;
     private int productId;
+    private int width;
+    private int height;
 
     private ControlMessage() {
     }
@@ -176,6 +179,14 @@ public final class ControlMessage {
         return msg;
     }
 
+    public static ControlMessage createResizeDisplay(int width, int height) {
+        ControlMessage msg = new ControlMessage();
+        msg.type = TYPE_RESIZE_DISPLAY;
+        msg.width = width;
+        msg.height = height;
+        return msg;
+    }
+
     public int getType() {
         return type;
     }
@@ -258,5 +269,13 @@ public final class ControlMessage {
 
     public int getProductId() {
         return productId;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/ControlMessageReader.java
@@ -60,6 +60,8 @@ public class ControlMessageReader {
                 return parseStartApp();
             case ControlMessage.TYPE_CAMERA_SET_TORCH:
                 return parseCameraSetTorch();
+            case ControlMessage.TYPE_RESIZE_DISPLAY:
+                return parseResizeDisplay();
             default:
                 throw new ControlProtocolException("Unknown event type: " + type);
         }
@@ -173,6 +175,12 @@ public class ControlMessageReader {
     private ControlMessage parseCameraSetTorch() throws IOException {
         boolean on = dis.readBoolean();
         return ControlMessage.createCameraSetTorch(on);
+    }
+
+    private ControlMessage parseResizeDisplay() throws IOException {
+        int width = dis.readUnsignedShort();
+        int height = dis.readUnsignedShort();
+        return ControlMessage.createResizeDisplay(width, height);
     }
 
     private Position parsePosition() throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -13,6 +13,7 @@ import com.genymobile.scrcpy.model.Size;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.CameraCapture;
+import com.genymobile.scrcpy.video.CaptureControl;
 import com.genymobile.scrcpy.video.SurfaceCapture;
 import com.genymobile.scrcpy.video.VideoSource;
 import com.genymobile.scrcpy.video.VirtualDisplayListener;
@@ -815,7 +816,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private void resetVideo() {
         if (surfaceCapture != null) {
             Ln.i("Video capture reset");
-            surfaceCapture.getCaptureControl().reset();
+            surfaceCapture.getCaptureControl().reset(CaptureControl.RESET_REASON_CLIENT_RESET);
         }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -815,7 +815,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private void resetVideo() {
         if (surfaceCapture != null) {
             Ln.i("Video capture reset");
-            surfaceCapture.invalidate();
+            surfaceCapture.getCaptureControl().reset();
         }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -20,6 +20,7 @@ import com.genymobile.scrcpy.video.VideoSource;
 import com.genymobile.scrcpy.video.VirtualDisplayListener;
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.InputManager;
+import com.genymobile.scrcpy.wrappers.PowerManager;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 
 import android.content.Intent;
@@ -240,6 +241,17 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     @Override
     public void start(TerminationListener listener) {
+        Thread t = new Thread(() -> {
+            PowerManager pm = ServiceManager.getPowerManager();
+            while (true) {
+                SystemClock.sleep(4000);
+                pm.userActivity(getActionDisplayId());
+            }
+        });
+        t.setName("keep-presence");
+        t.setDaemon(true);
+        t.start();
+
         thread = new Thread(() -> {
             try {
                 control();

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -614,7 +614,17 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     }
 
     private boolean pressBackOrTurnScreenOn(int action) {
-        if (displayId == Device.DISPLAY_ID_NONE || Device.isScreenOn(displayId)) {
+        boolean injectBack;
+        // Device.isScreenOn(displayId) ignores the displayId below Android 14
+        if (Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
+            // Inject BACK if the screen is on for the current virtual display id
+            int actionDisplayId = getActionDisplayId();
+            injectBack = actionDisplayId == Device.DISPLAY_ID_NONE || Device.isScreenOn(actionDisplayId);
+        } else {
+            // Inject BACK if the display is not the main display, or if the main display is on
+            injectBack = displayId != 0 || Device.isScreenOn(0);
+        }
+        if (injectBack) {
             return injectKeyEvent(action, KeyEvent.KEYCODE_BACK, 0, 0, Device.INJECT_MODE_ASYNC);
         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -14,6 +14,7 @@ import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.CameraCapture;
 import com.genymobile.scrcpy.video.CaptureControl;
+import com.genymobile.scrcpy.video.NewDisplayCapture;
 import com.genymobile.scrcpy.video.SurfaceCapture;
 import com.genymobile.scrcpy.video.VideoSource;
 import com.genymobile.scrcpy.video.VirtualDisplayListener;
@@ -369,6 +370,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
                     return true;
                 case ControlMessage.TYPE_START_APP:
                     startAppAsync(msg.getText());
+                    return true;
+                case ControlMessage.TYPE_RESIZE_DISPLAY:
+                    resizeDisplay(msg.getWidth(), msg.getHeight());
                     return true;
                 default:
                     // fall through
@@ -818,5 +822,10 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
             Ln.i("Video capture reset");
             surfaceCapture.getCaptureControl().reset(CaptureControl.RESET_REASON_CLIENT_RESET);
         }
+    }
+
+    private void resizeDisplay(int width, int height) {
+        NewDisplayCapture newDisplayCapture = (NewDisplayCapture) surfaceCapture;
+        newDisplayCapture.requestResize(width, height);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/device/Streamer.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Streamer.java
@@ -88,11 +88,15 @@ public final class Streamer {
         writePacket(codecBuffer, pts, config, keyFrame);
     }
 
-    public void writeSessionMeta(int width, int height) throws IOException {
+    public void writeSessionMeta(int width, int height, boolean isClientResize) throws IOException {
         if (sendStreamMeta) {
             headerBuffer.clear();
 
-            headerBuffer.putInt((int) (PACKET_FLAG_SESSION >> 32)); // Set the first bit to 1
+            int flags = (int) (PACKET_FLAG_SESSION >> 32); // set the first bit to 1
+            if (isClientResize) {
+                flags |= 1;
+            }
+            headerBuffer.putInt(flags);
             headerBuffer.putInt(width);
             headerBuffer.putInt(height);
             headerBuffer.flip();

--- a/server/src/main/java/com/genymobile/scrcpy/display/DisplayMonitor.java
+++ b/server/src/main/java/com/genymobile/scrcpy/display/DisplayMonitor.java
@@ -16,7 +16,7 @@ import android.view.IDisplayWindowListener;
 public class DisplayMonitor {
 
     public interface Listener {
-        void onDisplayPropertiesChanged();
+        void onDisplayPropertiesChanged(DisplayProperties props);
     }
 
     // On Android 14, DisplayListener may be broken (it never sends events). This is fixed in recent Android 14 upgrades, but we can't really
@@ -113,9 +113,9 @@ public class DisplayMonitor {
             // We can't compare with the current properties, so reset unconditionally
             DisplayProperties oldProps = getAndSetDisplayProperties(null); // exchange with synchronization
             if (Ln.isEnabled(Ln.Level.VERBOSE)) {
-                Ln.v("DisplayMonitor: requestReset(): " + oldProps + " -> (unknown)");
+                Ln.v("DisplayMonitor: " + oldProps + " -> (unknown)");
             }
-            listener.onDisplayPropertiesChanged();
+            listener.onDisplayPropertiesChanged(null);
         } else {
             DisplayProperties newProps = new DisplayProperties(di.getSize(), di.getRotation());
 
@@ -123,11 +123,11 @@ public class DisplayMonitor {
             if (!newProps.equals(oldProps)) {
                 // Reset only if the properties are different
                 if (Ln.isEnabled(Ln.Level.VERBOSE)) {
-                    Ln.v("DisplayMonitor: requestReset(): " + oldProps + " -> " + newProps);
+                    Ln.v("DisplayMonitor: " + oldProps + " -> " + newProps);
                 }
-                listener.onDisplayPropertiesChanged();
+                listener.onDisplayPropertiesChanged(newProps);
             } else if (Ln.isEnabled(Ln.Level.VERBOSE)) {
-                Ln.v("DisplayMonitor: DisplayProperties not changed (" + newProps + "): do not requestReset()");
+                Ln.v("DisplayMonitor: " + newProps + " (unchanged)");
             }
         }
     }

--- a/server/src/main/java/com/genymobile/scrcpy/display/DisplayPropertiesTracker.java
+++ b/server/src/main/java/com/genymobile/scrcpy/display/DisplayPropertiesTracker.java
@@ -1,0 +1,86 @@
+package com.genymobile.scrcpy.display;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DisplayPropertiesTracker {
+
+    private static final long PENDING_CACHE_DURATION = 3000; // ms
+
+    private static class PendingChange {
+        private final DisplayProperties props;
+        private final long timestamp;
+
+        PendingChange(DisplayProperties props, long timestamp) {
+            this.props = props;
+            this.timestamp = timestamp;
+        }
+    }
+
+    private final List<PendingChange> pending = new ArrayList<>();
+
+    private static long nowMs() {
+        return System.nanoTime() / 1000000;
+    }
+
+    public synchronized void pushClientRequest(DisplayProperties props) {
+        long now = nowMs();
+        pending.add(new PendingChange(props, now));
+    }
+
+    /**
+     * Function to be called when the display properties changed.
+     *
+     * @param props the new display properties
+     * @return {@code true} if this change is the result of a client request
+     */
+    public synchronized boolean onChanged(DisplayProperties props) {
+        cleanExpired();
+        int index = getMatchingPendingIndex(props);
+        if (index == -1) {
+            return false;
+        }
+
+        pending.subList(0, index + 1).clear();
+        return true;
+    }
+
+    private int getMatchingPendingIndex(DisplayProperties props) {
+        for (int i = 0; i < pending.size(); ++i) {
+            if (pending.get(i).props.equals(props)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private int getFirstNonExpiredIndex() {
+        long now = nowMs();
+        for (int i = 0; i < pending.size(); ++i) {
+            if (pending.get(i).timestamp + PENDING_CACHE_DURATION >= now) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private void cleanExpired() {
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        int firstNonExpiredIndex = getFirstNonExpiredIndex();
+        if (firstNonExpiredIndex == 0) {
+            // All items are fresh
+            return;
+        }
+
+        if (firstNonExpiredIndex == -1) {
+            // All items have expired
+            pending.clear();
+        } else {
+            // Remove all the items up to the first non-expired index
+            pending.subList(0, firstNonExpiredIndex).clear();
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/display/DisplayResizeDebouncer.java
+++ b/server/src/main/java/com/genymobile/scrcpy/display/DisplayResizeDebouncer.java
@@ -1,0 +1,73 @@
+package com.genymobile.scrcpy.display;
+
+import com.genymobile.scrcpy.model.Size;
+import com.genymobile.scrcpy.util.Ln;
+
+public final class DisplayResizeDebouncer {
+
+    private static final long DEBOUNCE_DELAY_MS = 300;
+
+    public interface Callback {
+        void trigger(Size size);
+    }
+
+    private final Callback callback;
+    private Size request;
+    private long deadline;
+
+    public DisplayResizeDebouncer(Callback callback) {
+        this.callback = callback;
+
+        Thread thread = new Thread(this::debounce);
+        thread.setName("debouncer");
+        thread.setDaemon(true);
+        thread.start();
+    }
+
+    private void debounce() {
+        try {
+            while (true) {
+                Size newSize;
+                synchronized (this) {
+                    while (true) {
+                        long now = nowMs();
+                        if (request != null && now >= deadline) {
+                            break;
+                        }
+                        if (request == null) {
+                            wait();
+                        } else {
+                            assert now < deadline;
+                            wait(deadline - now);
+                        }
+                    }
+                    assert request != null : "An active deadline implies request != null";
+                    newSize = request;
+                    request = null;
+                }
+                callback.trigger(newSize);
+            }
+        } catch (InterruptedException e) {
+            Ln.e("Unexpected interruption", e);
+        }
+    }
+
+    public synchronized void requestResize(Size size) {
+        assert size != null;
+        if (request == null) {
+            deadline = nowMs() + DEBOUNCE_DELAY_MS;
+        }
+        request = size;
+        notify();
+    }
+
+    public synchronized void cancelResize() {
+        request = null;
+        deadline = 0;
+        notify();
+    }
+
+    private long nowMs() {
+        return System.nanoTime() / 1000000;
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/model/Orientation.java
+++ b/server/src/main/java/com/genymobile/scrcpy/model/Orientation.java
@@ -46,4 +46,9 @@ public enum Orientation {
     public int getRotation() {
         return ordinal() & 3;
     }
+
+    public boolean isSwap() {
+        // width and height are swapped on 90-degree rotations
+        return (ordinal() & 1) != 0;
+    }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/model/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/model/Size.java
@@ -73,13 +73,16 @@ public final class Size {
         assert h <= maxHeight : "The height cannot exceed maxHeight";
 
         // Minimum codec size must be respected (regardless of requested maxSize)
-        int minCodecSize = constraints.getMinCodecSize();
+        int minCodecSize = alignUp(constraints.getMinCodecSize(), alignment);
         if (w < minCodecSize) {
             w = minCodecSize;
         }
         if (h < minCodecSize) {
             h = minCodecSize;
         }
+
+        assert w % alignment == 0 : "The width must be a multiple of alignment";
+        assert h % alignment == 0 : "The height must be a multiple of alignment";
 
         return new Size(w, h);
     }
@@ -95,6 +98,10 @@ public final class Size {
 
     private static int align(int value, int alignment) {
         return value / alignment * alignment;
+    }
+
+    private static int alignUp(int value, int alignment) {
+        return (value + alignment - 1) / alignment * alignment;
     }
 
     public Rect toRect() {

--- a/server/src/main/java/com/genymobile/scrcpy/model/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/model/Size.java
@@ -59,14 +59,14 @@ public final class Size {
         if (width > maxWidth || height > maxHeight) {
             if (width * maxHeight > height * maxWidth) {
                 w = maxWidth;
-                h = round(height * maxWidth / width, alignment);
+                h = align(height * maxWidth / width, alignment);
             } else {
-                w = round(width * maxHeight / height, alignment);
+                w = align(width * maxHeight / height, alignment);
                 h = maxHeight;
             }
         } else {
-            w = round(width, alignment);
-            h = round(height, alignment);
+            w = align(width, alignment);
+            h = align(height, alignment);
         }
 
         assert w <= maxWidth : "The width cannot exceed maxWidth";
@@ -91,10 +91,6 @@ public final class Size {
             return this;
         }
         return new Size(w, h);
-    }
-
-    private static int round(int value, int alignment) {
-        return (value + (alignment / 2)) / alignment * alignment;
     }
 
     private static int align(int value, int alignment) {

--- a/server/src/main/java/com/genymobile/scrcpy/model/Size.java
+++ b/server/src/main/java/com/genymobile/scrcpy/model/Size.java
@@ -52,8 +52,8 @@ public final class Size {
                 maxHeight = maxSize;
             }
         }
-        maxWidth = maxWidth / alignment * alignment;
-        maxHeight = maxHeight / alignment * alignment;
+        maxWidth = align(maxWidth, alignment);
+        maxHeight = align(maxHeight, alignment);
 
         int w, h;
         if (width > maxWidth || height > maxHeight) {
@@ -85,8 +85,8 @@ public final class Size {
     }
 
     public Size align(int alignment) {
-        int w = width / alignment * alignment;
-        int h = height / alignment * alignment;
+        int w = align(width, alignment);
+        int h = align(height, alignment);
         if (w == width && h == height) {
             return this;
         }
@@ -95,6 +95,10 @@ public final class Size {
 
     private static int round(int value, int alignment) {
         return (value + (alignment / 2)) / alignment * alignment;
+    }
+
+    private static int align(int value, int alignment) {
+        return value / alignment * alignment;
     }
 
     public Rect toRect() {

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -323,7 +323,7 @@ public class CameraCapture extends SurfaceCapture {
                 } catch (CameraAccessException e) {
                     Ln.e("Camera error", e);
                     disconnected.set(true);
-                    invalidate();
+                    getCaptureControl().reset();
                 }
             }
 
@@ -331,7 +331,7 @@ public class CameraCapture extends SurfaceCapture {
             public void onConfigureFailed(CameraCaptureSession session) {
                 Ln.e("Camera configuration error");
                 disconnected.set(true);
-                invalidate();
+                getCaptureControl().reset();
             }
         });
 
@@ -388,7 +388,7 @@ public class CameraCapture extends SurfaceCapture {
             public void onDisconnected(CameraDevice camera) {
                 Ln.w("Camera disconnected");
                 disconnected.set(true);
-                invalidate();
+                getCaptureControl().reset();
             }
 
             @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -323,7 +323,7 @@ public class CameraCapture extends SurfaceCapture {
                 } catch (CameraAccessException e) {
                     Ln.e("Camera error", e);
                     disconnected.set(true);
-                    getCaptureControl().reset();
+                    getCaptureControl().reset(CaptureControl.RESET_REASON_TERMINATED);
                 }
             }
 
@@ -331,7 +331,7 @@ public class CameraCapture extends SurfaceCapture {
             public void onConfigureFailed(CameraCaptureSession session) {
                 Ln.e("Camera configuration error");
                 disconnected.set(true);
-                getCaptureControl().reset();
+                getCaptureControl().reset(CaptureControl.RESET_REASON_TERMINATED);
             }
         });
 
@@ -388,7 +388,7 @@ public class CameraCapture extends SurfaceCapture {
             public void onDisconnected(CameraDevice camera) {
                 Ln.w("Camera disconnected");
                 disconnected.set(true);
-                getCaptureControl().reset();
+                getCaptureControl().reset(CaptureControl.RESET_REASON_TERMINATED);
             }
 
             @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/CaptureControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CaptureControl.java
@@ -7,6 +7,7 @@ public class CaptureControl {
     public static final int RESET_REASON_TERMINATED = 1;
     public static final int RESET_REASON_DISPLAY_PROPERTIES_CHANGED = 1 << 1;
     public static final int RESET_REASON_CLIENT_RESET = 1 << 2;
+    public static final int RESET_REASON_CLIENT_RESIZED = 1 << 3;
 
     private int reset = 0;
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/CaptureControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CaptureControl.java
@@ -2,21 +2,30 @@ package com.genymobile.scrcpy.video;
 
 import android.media.MediaCodec;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 public class CaptureControl {
 
-    private final AtomicBoolean reset = new AtomicBoolean();
+    public static final int RESET_REASON_TERMINATED = 1;
+    public static final int RESET_REASON_DISPLAY_PROPERTIES_CHANGED = 1 << 1;
+    public static final int RESET_REASON_CLIENT_RESET = 1 << 2;
+
+    private int reset = 0;
 
     // Current instance of MediaCodec to "interrupt" on reset
     private MediaCodec runningMediaCodec;
 
-    public boolean consumeReset() {
-        return reset.getAndSet(false);
+    public synchronized boolean isResetRequested() {
+        return reset != 0;
     }
 
-    public synchronized void reset() {
-        reset.set(true);
+    public synchronized int consumeReset() {
+        int value = reset;
+        reset = 0;
+        return value;
+    }
+
+    public synchronized void reset(int reason) {
+        assert reason != 0;
+        reset |= reason;
         if (runningMediaCodec != null) {
             try {
                 runningMediaCodec.signalEndOfInputStream();

--- a/server/src/main/java/com/genymobile/scrcpy/video/CaptureControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CaptureControl.java
@@ -4,7 +4,7 @@ import android.media.MediaCodec;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class CaptureReset implements SurfaceCapture.CaptureListener {
+public class CaptureControl {
 
     private final AtomicBoolean reset = new AtomicBoolean();
 
@@ -28,10 +28,5 @@ public class CaptureReset implements SurfaceCapture.CaptureListener {
 
     public synchronized void setRunningMediaCodec(MediaCodec runningMediaCodec) {
         this.runningMediaCodec = runningMediaCodec;
-    }
-
-    @Override
-    public void onInvalidated() {
-        reset();
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -6,6 +6,8 @@ import com.genymobile.scrcpy.control.PositionMapper;
 import com.genymobile.scrcpy.display.DisplayInfo;
 import com.genymobile.scrcpy.display.DisplayMonitor;
 import com.genymobile.scrcpy.display.DisplayProperties;
+import com.genymobile.scrcpy.display.DisplayPropertiesTracker;
+import com.genymobile.scrcpy.display.DisplayResizeDebouncer;
 import com.genymobile.scrcpy.model.NewDisplay;
 import com.genymobile.scrcpy.model.Orientation;
 import com.genymobile.scrcpy.model.Size;
@@ -58,11 +60,15 @@ public class NewDisplayCapture extends SurfaceCapture {
     private final float angle;
     private final boolean vdDestroyContent;
     private final boolean vdSystemDecorations;
+    private final boolean flexDisplay;
 
     private VirtualDisplay virtualDisplay;
     private Size videoSize;
     private Size displaySize; // the logical size of the display (including rotation)
     private Size physicalSize; // the physical size of the display (without rotation)
+
+    private DisplayPropertiesTracker tracker;
+    private DisplayResizeDebouncer debouncer;
 
     private int dpi;
 
@@ -79,13 +85,33 @@ public class NewDisplayCapture extends SurfaceCapture {
         this.angle = options.getAngle();
         this.vdDestroyContent = options.getVDDestroyContent();
         this.vdSystemDecorations = options.getVDSystemDecorations();
+        this.flexDisplay = options.getFlexDisplay();
     }
 
     @Override
     protected void init() {
         displaySize = newDisplay.getSize();
         dpi = newDisplay.getDpi();
-        if (displaySize == null || dpi == 0) {
+        if (flexDisplay) {
+            if (crop != null) {
+                throw new IllegalArgumentException("Flex display does not support cropping");
+            }
+            if (getVideoConstraints().getMaxSize() != 0) {
+                // A maxSize request constrains the resulting size while preserving the aspect ratio, which is meaningless for a flex display
+                throw new IllegalArgumentException("Flex display does not support explicit maxSize constraint");
+            }
+
+            tracker = new DisplayPropertiesTracker();
+            debouncer = new DisplayResizeDebouncer(this::triggerResize);
+
+            // Hardcode default values if not defined
+            if (displaySize == null) {
+                displaySize = new Size(1280, 960);
+            }
+            if (dpi == 0) {
+                dpi = 160;
+            }
+        } else if (displaySize == null || dpi == 0) {
             DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(0);
             if (displayInfo != null) {
                 mainDisplaySize = displayInfo.getSize();
@@ -103,16 +129,20 @@ public class NewDisplayCapture extends SurfaceCapture {
 
     @Override
     public void prepare() {
+        VideoConstraints constraints = getVideoConstraints();
+
         int displayRotation;
         if (virtualDisplay == null) {
-            if (!newDisplay.hasExplicitSize()) {
+            if (displaySize == null) {
+                assert !flexDisplay;
                 displaySize = mainDisplaySize;
             }
 
             // Align the physical display size to avoid unnecessary mismatches with the output size
-            displaySize = displaySize.align(getVideoConstraints().getAlignment());
+            displaySize = displaySize.align(constraints.getAlignment());
 
-            if (!newDisplay.hasExplicitDpi()) {
+            if (dpi == 0) {
+                assert !flexDisplay;
                 dpi = scaleDpi(mainDisplaySize, mainDisplayDpi, displaySize);
             }
 
@@ -123,9 +153,8 @@ public class NewDisplayCapture extends SurfaceCapture {
             DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(virtualDisplay.getDisplay().getDisplayId());
             dpi = displayInfo.getDpi();
             displayRotation = displayInfo.getRotation();
-
             // Align the physical display size to avoid unnecessary mismatches with the output size
-            displaySize = displayInfo.getSize().align(getVideoConstraints().getAlignment());
+            displaySize = displayInfo.getSize().align(constraints.getAlignment());
         }
 
         VideoFilter filter = new VideoFilter(displaySize);
@@ -139,7 +168,7 @@ public class NewDisplayCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         Size outputSize = filter.getOutputSize();
-        Size filteredSize = outputSize.constrain(getVideoConstraints());
+        Size filteredSize = outputSize.constrain(constraints);
         if (!filteredSize.equals(outputSize)) {
             filter.addResize(filteredSize);
         }
@@ -192,16 +221,28 @@ public class NewDisplayCapture extends SurfaceCapture {
                             | VIRTUAL_DISPLAY_FLAG_DEVICE_DISPLAY_GROUP;
                 }
             }
-            virtualDisplay = ServiceManager.getDisplayManager()
+            VirtualDisplay vd = ServiceManager.getDisplayManager()
                     .createNewVirtualDisplay("scrcpy", displaySize.getWidth(), displaySize.getHeight(), dpi, surface, flags);
-            virtualDisplayId = virtualDisplay.getDisplay().getDisplayId();
+            setCurrentVirtualDisplay(vd); // used for client resize
+            virtualDisplayId = vd.getDisplay().getDisplayId();
             Ln.i("New display: " + displaySize.getWidth() + "x" + displaySize.getHeight() + "/" + dpi + " (id=" + virtualDisplayId + ")");
 
             if (displayImePolicy != -1) {
                 ServiceManager.getWindowManager().setDisplayImePolicy(virtualDisplayId, displayImePolicy);
             }
 
-            displayMonitor.start(virtualDisplayId, () -> getCaptureControl().reset(CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED));
+            displayMonitor.start(virtualDisplayId, (props) -> {
+                boolean isClientResize = tracker.onChanged(props);
+                int reason;
+                if (isClientResize) {
+                    reason = CaptureControl.RESET_REASON_CLIENT_RESIZED;
+                } else {
+                    reason = CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED;
+                    // Display properties have changed, cancel pending client resize requests
+                    debouncer.cancelResize();
+                }
+                getCaptureControl().reset(reason);
+            });
         } catch (Exception e) {
             Ln.e("Could not create display", e);
             throw new AssertionError("Could not create display");
@@ -243,7 +284,7 @@ public class NewDisplayCapture extends SurfaceCapture {
 
         if (virtualDisplay != null) {
             virtualDisplay.release();
-            virtualDisplay = null;
+            setCurrentVirtualDisplay(null);
         }
     }
 
@@ -256,5 +297,40 @@ public class NewDisplayCapture extends SurfaceCapture {
         int den = initialSize.getMax();
         int num = size.getMax();
         return initialDpi * num / den;
+    }
+
+    public void requestResize(int width, int height) {
+        if (!flexDisplay) {
+            throw new IllegalStateException("Cannot resize a non-flex display");
+        }
+
+        Size newSize = new Size(width, height).constrain(getVideoConstraints());
+        if (Ln.isEnabled(Ln.Level.VERBOSE)) {
+            Ln.v(getClass().getSimpleName() + ": requestResize(" + width + ", " + height + ")");
+            Ln.v(getClass().getSimpleName() + ": constrained size = " + newSize);
+        }
+
+        debouncer.requestResize(newSize);
+    }
+
+    private synchronized void setCurrentVirtualDisplay(VirtualDisplay virtualDisplay) {
+        this.virtualDisplay = virtualDisplay;
+    }
+
+    private synchronized VirtualDisplay getCurrentVirtualDisplay() {
+        return virtualDisplay;
+    }
+
+    private synchronized void triggerResize(Size size) {
+        VirtualDisplay vd = getCurrentVirtualDisplay(); // with synchronization
+        if (vd != null) {
+            DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(vd.getDisplay().getDisplayId());
+            int displayRotation = displayInfo.getRotation();
+            if (captureOrientation.isSwap() ^ (displayRotation % 2) != 0) {
+                size = size.rotate();
+            }
+            tracker.pushClientRequest(new DisplayProperties(size, displayRotation));
+            vd.resize(size.getWidth(), size.getHeight(), dpi);
+        }
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -117,7 +117,7 @@ public class NewDisplayCapture extends SurfaceCapture {
             }
 
             displayRotation = 0;
-            // Set the current display properties to avoid an unnecessary call to invalidate()
+            // Set the current display properties to avoid an unnecessary capture reset
             displayMonitor.setSessionDisplayProperties(new DisplayProperties(displaySize, displayRotation));
         } else {
             DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(virtualDisplay.getDisplay().getDisplayId());
@@ -201,7 +201,7 @@ public class NewDisplayCapture extends SurfaceCapture {
                 ServiceManager.getWindowManager().setDisplayImePolicy(virtualDisplayId, displayImePolicy);
             }
 
-            displayMonitor.start(virtualDisplayId, this::invalidate);
+            displayMonitor.start(virtualDisplayId, () -> getCaptureControl().reset());
         } catch (Exception e) {
             Ln.e("Could not create display", e);
             throw new AssertionError("Could not create display");

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -201,7 +201,7 @@ public class NewDisplayCapture extends SurfaceCapture {
                 ServiceManager.getWindowManager().setDisplayImePolicy(virtualDisplayId, displayImePolicy);
             }
 
-            displayMonitor.start(virtualDisplayId, () -> getCaptureControl().reset());
+            displayMonitor.start(virtualDisplayId, () -> getCaptureControl().reset(CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED));
         } catch (Exception e) {
             Ln.e("Could not create display", e);
             throw new AssertionError("Could not create display");

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -61,7 +61,7 @@ public class ScreenCapture extends SurfaceCapture {
 
     @Override
     public void init() {
-        displayMonitor.start(displayId, this::invalidate);
+        displayMonitor.start(displayId, () -> getCaptureControl().reset());
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -61,7 +61,7 @@ public class ScreenCapture extends SurfaceCapture {
 
     @Override
     public void init() {
-        displayMonitor.start(displayId, () -> getCaptureControl().reset());
+        displayMonitor.start(displayId, () -> getCaptureControl().reset(CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED));
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -61,7 +61,7 @@ public class ScreenCapture extends SurfaceCapture {
 
     @Override
     public void init() {
-        displayMonitor.start(displayId, () -> getCaptureControl().reset(CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED));
+        displayMonitor.start(displayId, (props) -> getCaptureControl().reset(CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED));
     }
 
     @Override

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -12,27 +12,21 @@ import java.io.IOException;
  */
 public abstract class SurfaceCapture {
 
-    public interface CaptureListener {
-        void onInvalidated();
-    }
-
-    private CaptureListener listener;
+    private CaptureControl captureControl;
     private VideoConstraints constraints;
 
-    /**
-     * Notify the listener that the capture has been invalidated (for example, because its size changed, or due to a manual user request).
-     */
-    public void invalidate() {
-        listener.onInvalidated();
-    }
 
     /**
      * Called once before the first capture starts.
      */
-    public final void init(CaptureListener listener, VideoConstraints constraints) throws ConfigurationException, IOException {
-        this.listener = listener;
+    public final void init(CaptureControl captureControl, VideoConstraints constraints) throws ConfigurationException, IOException {
+        this.captureControl = captureControl;
         this.constraints = constraints;
         init();
+    }
+
+    public CaptureControl getCaptureControl() {
+        return captureControl;
     }
 
     /**

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -128,7 +128,7 @@ public class SurfaceEncoder implements AsyncProcessor {
                     } else {
                         if (!captureControl.isResetRequested()) {
                             // If a reset is requested during encode(), it will interrupt the encoding by an EOS
-                            streamer.writeSessionMeta(size.getWidth(), size.getHeight());
+                            streamer.writeSessionMeta(size.getWidth(), size.getHeight(), false);
                             encode(mediaCodec, streamer);
                         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -97,7 +97,10 @@ public class SurfaceEncoder implements AsyncProcessor {
             streamer.writeVideoHeader();
 
             do {
-                captureControl.consumeReset(); // If a capture reset was requested, it is implicitly fulfilled
+                int resetReasons = captureControl.consumeReset();
+                if ((resetReasons & CaptureControl.RESET_REASON_TERMINATED) != 0) {
+                    break;
+                }
                 capture.prepare();
                 Size size = capture.getSize();
 
@@ -123,12 +126,12 @@ public class SurfaceEncoder implements AsyncProcessor {
                     if (stopped.get()) {
                         alive = false;
                     } else {
-                        boolean resetRequested = captureControl.consumeReset();
-                        if (!resetRequested) {
+                        if (!captureControl.isResetRequested()) {
                             // If a reset is requested during encode(), it will interrupt the encoding by an EOS
                             streamer.writeSessionMeta(size.getWidth(), size.getHeight());
                             encode(mediaCodec, streamer);
                         }
+
                         // The capture might have been closed internally (for example if the camera is disconnected)
                         alive = !stopped.get() && !capture.isClosed();
                     }
@@ -275,7 +278,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     public void stop() {
         if (thread != null) {
             stopped.set(true);
-            captureControl.reset();
+            captureControl.reset(CaptureControl.RESET_REASON_TERMINATED);
         }
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -43,7 +43,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     private Thread thread;
     private final AtomicBoolean stopped = new AtomicBoolean();
 
-    private final CaptureReset reset = new CaptureReset();
+    private final CaptureControl captureControl = new CaptureControl();
 
     public SurfaceEncoder(SurfaceCapture capture, Streamer streamer, Options options) {
         this.capture = capture;
@@ -89,7 +89,7 @@ public class SurfaceEncoder implements AsyncProcessor {
         assert caps != null; // caps cannot be null for a video codec
         VideoConstraints constraints = createVideoConstraints(maxSize, minSizeAlignment, caps);
 
-        capture.init(reset, constraints);
+        capture.init(captureControl, constraints);
 
         try {
             boolean alive;
@@ -97,7 +97,7 @@ public class SurfaceEncoder implements AsyncProcessor {
             streamer.writeVideoHeader();
 
             do {
-                reset.consumeReset(); // If a capture reset was requested, it is implicitly fulfilled
+                captureControl.consumeReset(); // If a capture reset was requested, it is implicitly fulfilled
                 capture.prepare();
                 Size size = capture.getSize();
 
@@ -118,12 +118,12 @@ public class SurfaceEncoder implements AsyncProcessor {
                     mediaCodecStarted = true;
 
                     // Set the MediaCodec instance to "interrupt" (by signaling an EOS) on reset
-                    reset.setRunningMediaCodec(mediaCodec);
+                    captureControl.setRunningMediaCodec(mediaCodec);
 
                     if (stopped.get()) {
                         alive = false;
                     } else {
-                        boolean resetRequested = reset.consumeReset();
+                        boolean resetRequested = captureControl.consumeReset();
                         if (!resetRequested) {
                             // If a reset is requested during encode(), it will interrupt the encoding by an EOS
                             streamer.writeSessionMeta(size.getWidth(), size.getHeight());
@@ -133,7 +133,7 @@ public class SurfaceEncoder implements AsyncProcessor {
                         alive = !stopped.get() && !capture.isClosed();
                     }
                 } finally {
-                    reset.setRunningMediaCodec(null);
+                    captureControl.setRunningMediaCodec(null);
                     if (captureStarted) {
                         capture.stop();
                     }
@@ -275,7 +275,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     public void stop() {
         if (thread != null) {
             stopped.set(true);
-            reset.reset();
+            captureControl.reset();
         }
     }
 

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -127,8 +127,12 @@ public class SurfaceEncoder implements AsyncProcessor {
                         alive = false;
                     } else {
                         if (!captureControl.isResetRequested()) {
+                            // The reset is due to a resize initiated by the client
+                            boolean isClientResize = (resetReasons & CaptureControl.RESET_REASON_CLIENT_RESIZED) != 0
+                                    && (resetReasons & CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED) == 0;
+                            streamer.writeSessionMeta(size.getWidth(), size.getHeight(), isClientResize);
+
                             // If a reset is requested during encode(), it will interrupt the encoding by an EOS
-                            streamer.writeSessionMeta(size.getWidth(), size.getHeight(), false);
                             encode(mediaCodec, streamer);
                         }
 

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/PowerManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/PowerManager.java
@@ -5,12 +5,17 @@ import com.genymobile.scrcpy.util.Ln;
 
 import android.os.Build;
 import android.os.IInterface;
+import android.os.SystemClock;
 
 import java.lang.reflect.Method;
 
 public final class PowerManager {
+
+    private static final int USER_ACTIVITY_EVENT_OTHER = 0;
+
     private final IInterface manager;
     private Method isScreenOnMethod;
+    private Method userActivityMethod;
 
     static PowerManager create() {
         IInterface manager = ServiceManager.getService("power", "android.os.IPowerManager");
@@ -43,6 +48,33 @@ public final class PowerManager {
         } catch (ReflectiveOperationException e) {
             Ln.e("Could not invoke method", e);
             return false;
+        }
+    }
+
+    private Method getUserActivityMethod() throws NoSuchMethodException {
+        if (userActivityMethod == null) {
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12) {
+                // userActivity(int displayId, long time, int event, int flags);
+                userActivityMethod = manager.getClass().getMethod("userActivity", int.class, long.class, int.class, int.class);
+            } else {
+                // userActivity(long time, int event, int flags);
+                userActivityMethod = manager.getClass().getMethod("userActivity", long.class, int.class, int.class);
+            }
+        }
+        return userActivityMethod;
+    }
+
+    public void userActivity(int displayId) {
+        try {
+            Method method = getUserActivityMethod();
+            long time = SystemClock.uptimeMillis();
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12) {
+                method.invoke(manager, displayId, time, USER_ACTIVITY_EVENT_OTHER, 0);
+                return;
+            }
+            method.invoke(manager, time, USER_ACTIVITY_EVENT_OTHER, 0);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
         }
     }
 }

--- a/server/src/test/java/com/genymobile/scrcpy/control/ControlMessageReaderTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/control/ControlMessageReaderTest.java
@@ -473,6 +473,26 @@ public class ControlMessageReaderTest {
     }
 
     @Test
+    public void testParseResizeDisplay() throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(bos);
+        dos.writeByte(ControlMessage.TYPE_RESIZE_DISPLAY);
+        dos.writeShort(1920);
+        dos.writeShort(1080);
+        byte[] packet = bos.toByteArray();
+
+        ByteArrayInputStream bis = new ByteArrayInputStream(packet);
+        ControlMessageReader reader = new ControlMessageReader(bis);
+
+        ControlMessage event = reader.read();
+        Assert.assertEquals(ControlMessage.TYPE_RESIZE_DISPLAY, event.getType());
+        Assert.assertEquals(1920, event.getWidth());
+        Assert.assertEquals(1080, event.getHeight());
+
+        Assert.assertEquals(-1, bis.read()); // EOS
+    }
+
+    @Test
     public void testMultiEvents() throws IOException {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(bos);

--- a/server/src/test/java/com/genymobile/scrcpy/model/SizeTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/model/SizeTest.java
@@ -25,15 +25,15 @@ public class SizeTest {
         Size size = new Size(207, 209);
 
         Assert.assertEquals(size, size.constrain(createVideoConstraints(0, 1)));
-        Assert.assertEquals(new Size(208, 210), size.constrain(createVideoConstraints(0, 2)));
-        Assert.assertEquals(new Size(208, 208), size.constrain(createVideoConstraints(0, 4)));
+        Assert.assertEquals(new Size(206, 208), size.constrain(createVideoConstraints(0, 2)));
+        Assert.assertEquals(new Size(204, 208), size.constrain(createVideoConstraints(0, 4)));
 
         Size s = size.constrain(createVideoConstraints(208, 2));
         Assert.assertEquals(208, s.getHeight());
         Assert.assertTrue(s.getWidth() >= 206 && s.getWidth() <= 208 && s.getWidth() % 2 == 0);
 
         Assert.assertEquals(new Size(207 * 208 / 209, 208), size.constrain(createVideoConstraints(208, 2)));
-        Assert.assertEquals(new Size(208, 208), size.constrain(createVideoConstraints(208, 4)));
+        Assert.assertEquals(new Size(204, 208), size.constrain(createVideoConstraints(208, 4)));
     }
 
     @Test


### PR DESCRIPTION
To fix #6787, call `PowerManager.userActivity()` every 4 seconds to keep the virtual display awake.

It is implemented on top of #6772 and #6788.

This is just a PoC. Please test.

Are there any side effects?

Binaries are available here (download `release-XXX` where `XXX` is your platform): https://github.com/rom1v/scrcpy/actions/runs/24926398341