### PR TITLE
Add --keep-active

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -34,6 +34,7 @@ _scrcpy() {
         --gamepad=
         -h --help
         -K
+        --keep-active
         --keyboard=
         --kill-adb-on-close
         --legacy-paste

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -41,6 +41,7 @@ arguments=(
     '--gamepad=[Set the gamepad input mode]:mode:(disabled uhid aoa)'
     {-h,--help}'[Print the help]'
     '-K[Use UHID/AOA keyboard \(same as --keyboard=uhid or --keyboard=aoa, depending on OTG mode\)]'
+    '--keep-active[Keep the screen on by simulating user activity]'
     '--keyboard=[Set the keyboard input mode]:mode:(disabled sdk uhid aoa)'
     '--kill-adb-on-close[Kill adb when scrcpy terminates]'
     '--legacy-paste[Inject computer clipboard text as a sequence of key events on Ctrl+v]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -234,6 +234,10 @@ Print this help.
 Same as \fB\-\-keyboard=uhid\fR, or \fB\-\-keyboard=aoa\fR if \fB\-\-otg\fR is set.
 
 .TP
+.B \-\-keep\-active
+Keep the screen on by simulating user activity.
+
+.TP
 .BI "\-\-keyboard " mode
 Select how to send keyboard inputs to the device.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -105,6 +105,7 @@ enum {
     OPT_CAMERA_ZOOM,
     OPT_MIN_SIZE_ALIGNMENT,
     OPT_NO_WINDOW_ASPECT_RATIO_LOCK,
+    OPT_KEEP_ACTIVE,
 };
 
 struct sc_option {
@@ -419,6 +420,11 @@ static const struct sc_option options[] = {
     {
         .shortopt = 'K',
         .text = "Same as --keyboard=uhid, or --keyboard=aoa if --otg is set.",
+    },
+    {
+        .longopt_id = OPT_KEEP_ACTIVE,
+        .longopt = "keep-active",
+        .text = "Keep the screen on by simulating user activity.",
     },
     {
         .longopt_id = OPT_KEYBOARD,
@@ -2759,6 +2765,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_NO_WINDOW_ASPECT_RATIO_LOCK:
                 opts->window_aspect_ratio_lock = false;
                 break;
+            case OPT_KEEP_ACTIVE:
+                opts->keep_active = true;
+                break;
             default:
                 // getopt prints the error message on stderr
                 return false;
@@ -3197,6 +3206,10 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         }
         if (opts->start_app) {
             LOGE("Cannot start an Android app if control is disabled");
+            return false;
+        }
+        if (opts->keep_active) {
+            LOGE("Cannot keep device active if control is disabled");
             return false;
         }
     }

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -116,6 +116,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .vd_destroy_content = true,
     .vd_system_decorations = true,
     .camera_torch = false,
+    .keep_active = false,
 };
 
 enum sc_orientation

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -330,6 +330,7 @@ struct scrcpy_options {
     bool vd_destroy_content;
     bool vd_system_decorations;
     bool camera_torch;
+    bool keep_active;
 };
 
 extern const struct scrcpy_options scrcpy_options_default;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -465,6 +465,7 @@ scrcpy(struct scrcpy_options *options) {
         .camera_zoom = options->camera_zoom,
         .vd_destroy_content = options->vd_destroy_content,
         .vd_system_decorations = options->vd_system_decorations,
+        .keep_active = options->keep_active,
         .list = options->list,
     };
 

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -423,6 +423,9 @@ execute_server(struct sc_server *server,
     if (!params->vd_system_decorations) {
         ADD_PARAM("vd_system_decorations=false");
     }
+    if (params->keep_active) {
+        ADD_PARAM("keep_active=true");
+    }
     if (params->list & SC_OPTION_LIST_ENCODERS) {
         ADD_PARAM("list_encoders=true");
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -72,6 +72,7 @@ struct sc_server_params {
     bool camera_torch;
     bool vd_destroy_content;
     bool vd_system_decorations;
+    bool keep_active;
     uint8_t list;
 };
 

--- a/doc/device.md
+++ b/doc/device.md
@@ -3,6 +3,17 @@
 Some command line arguments perform actions on the device itself while scrcpy is
 running.
 
+
+## Keep active
+
+To prevent the device from turning off due to inactivity, `--keep-active`
+periodically signals user activity to the system:
+
+```bash
+scrcpy --keep-active
+```
+
+
 ## Stay awake
 
 To prevent the device from sleeping after a delay **when the device is plugged

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -67,6 +67,8 @@ public class Options {
     private boolean vdDestroyContent = true;
     private boolean vdSystemDecorations = true;
 
+    private boolean keepActive;
+
     private Orientation.Lock captureOrientationLock = Orientation.Lock.Unlocked;
     private Orientation captureOrientation = Orientation.Orient0;
 
@@ -256,6 +258,10 @@ public class Options {
 
     public boolean getVDSystemDecorations() {
         return vdSystemDecorations;
+    }
+
+    public boolean getKeepActive() {
+        return keepActive;
     }
 
     public boolean getList() {
@@ -513,6 +519,9 @@ public class Options {
                     break;
                 case "display_ime_policy":
                     options.displayImePolicy = parseDisplayImePolicy(value);
+                    break;
+                case "keep_active":
+                    options.keepActive = Boolean.parseBoolean(value);
                     break;
                 case "send_device_meta":
                     options.sendDeviceMeta = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -70,10 +70,14 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     // control_msg.h values of the pointerId field in inject_touch_event message
     private static final int POINTER_ID_MOUSE = -1;
 
+    // Interval between simulated user activity events
+    private static final long KEEP_ACTIVE_INTERVAL_MS = 4000;
+
     private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor();
     private ExecutorService startAppExecutor;
 
     private Thread thread;
+    private Thread keepActiveThread;
 
     private UhidManager uhidManager;
 
@@ -85,6 +89,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     private final DeviceMessageSender sender;
     private final boolean clipboardAutosync;
     private final boolean powerOn;
+    private final boolean keepActive;
 
     private final KeyCharacterMap charMap = KeyCharacterMap.load(KeyCharacterMap.VIRTUAL_KEYBOARD);
 
@@ -115,6 +120,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
             this.sender = null;
             this.clipboardAutosync = false;
             this.powerOn = false;
+            this.keepActive = false;
             return;
         }
 
@@ -122,6 +128,7 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
         this.clipboardAutosync = options.getClipboardAutosync();
         this.powerOn = options.getPowerOn();
+        this.keepActive = options.getKeepActive();
         initPointers();
         sender = new DeviceMessageSender(controlChannel);
 
@@ -236,8 +243,35 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
         }
     }
 
+    private void startKeepActiveThread() {
+        keepActiveThread = new Thread(() -> {
+            try {
+                while (true) {
+                    Thread.sleep(KEEP_ACTIVE_INTERVAL_MS);
+                    int actionDisplayId = getActionDisplayId();
+                    if (actionDisplayId != Device.DISPLAY_ID_NONE) {
+                        Device.keepActive(actionDisplayId);
+                    }
+                }
+            } catch (InterruptedException e) {
+                // ignore
+            } catch (Throwable e) {
+                Ln.e("Keep active error", e);
+            } finally {
+                Ln.d("Keep active thread stopped");
+            }
+        });
+        keepActiveThread.setName("keep-active");
+        keepActiveThread.setDaemon(true);
+        keepActiveThread.start();
+    }
+
     @Override
     public void start(TerminationListener listener) {
+        if (keepActive) {
+            startKeepActiveThread();
+        }
+
         thread = new Thread(() -> {
             try {
                 control();
@@ -259,6 +293,9 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
 
     @Override
     public void stop() {
+        if (keepActiveThread != null) {
+            keepActiveThread.interrupt();
+        }
         if (thread != null) {
             thread.interrupt();
         }

--- a/server/src/main/java/com/genymobile/scrcpy/device/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/device/Device.java
@@ -88,6 +88,11 @@ public final class Device {
         return ServiceManager.getPowerManager().isScreenOn(displayId);
     }
 
+    public static void keepActive(int displayId) {
+        assert displayId != DISPLAY_ID_NONE;
+        ServiceManager.getPowerManager().userActivity(displayId);
+    }
+
     public static void expandNotificationPanel() {
         ServiceManager.getStatusBarManager().expandNotificationsPanel();
     }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/PowerManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/PowerManager.java
@@ -5,12 +5,17 @@ import com.genymobile.scrcpy.util.Ln;
 
 import android.os.Build;
 import android.os.IInterface;
+import android.os.SystemClock;
 
 import java.lang.reflect.Method;
 
 public final class PowerManager {
+
+    private static final int USER_ACTIVITY_EVENT_OTHER = 0;
+
     private final IInterface manager;
     private Method isScreenOnMethod;
+    private Method userActivityMethod;
 
     static PowerManager create() {
         IInterface manager = ServiceManager.getService("power", "android.os.IPowerManager");
@@ -43,6 +48,33 @@ public final class PowerManager {
         } catch (ReflectiveOperationException e) {
             Ln.e("Could not invoke method", e);
             return false;
+        }
+    }
+
+    private Method getUserActivityMethod() throws NoSuchMethodException {
+        if (userActivityMethod == null) {
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12) {
+                // userActivity(int displayId, long time, int event, int flags);
+                userActivityMethod = manager.getClass().getMethod("userActivity", int.class, long.class, int.class, int.class);
+            } else {
+                // userActivity(long time, int event, int flags);
+                userActivityMethod = manager.getClass().getMethod("userActivity", long.class, int.class, int.class);
+            }
+        }
+        return userActivityMethod;
+    }
+
+    public void userActivity(int displayId) {
+        try {
+            Method method = getUserActivityMethod();
+            long time = SystemClock.uptimeMillis();
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12) {
+                method.invoke(manager, displayId, time, USER_ACTIVITY_EVENT_OTHER, 0);
+                return;
+            }
+            method.invoke(manager, time, USER_ACTIVITY_EVENT_OTHER, 0);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
         }
     }
 }


### PR DESCRIPTION
An an option to simulate user activity to prevent the screen from turning off due to inactivity.

Fixes #6787
Supersedes #6789

---

Contrary to what I proposed here: https://github.com/Genymobile/scrcpy/pull/6789#issuecomment-4319038666
I didn't add a parameter to specify the interval duration. I think 4 seconds (less than 5) will work for all use cases, and the call is cheap, so there is no good reason to configure it. I'll add it later if necessary.