### PR TITLE
Fix OpenGL runner shutdown deadlock

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -185,8 +185,7 @@ public final class Server {
                     asyncProcessor.join();
                 }
 
-                OpenGLRunner.quit(); // quit the OpenGL thread, if any
-                OpenGLRunner.join();
+                OpenGLRunner.shutdown();
             } catch (InterruptedException e) {
                 // ignore
             }

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -175,8 +175,6 @@ public final class Server {
                 asyncProcessor.stop();
             }
 
-            OpenGLRunner.quit(); // quit the OpenGL thread, if any
-
             connection.shutdown();
 
             try {
@@ -186,6 +184,8 @@ public final class Server {
                 for (AsyncProcessor asyncProcessor : asyncProcessors) {
                     asyncProcessor.join();
                 }
+
+                OpenGLRunner.quit(); // quit the OpenGL thread, if any
                 OpenGLRunner.join();
             } catch (InterruptedException e) {
                 // ignore

--- a/server/src/main/java/com/genymobile/scrcpy/opengl/OpenGLRunner.java
+++ b/server/src/main/java/com/genymobile/scrcpy/opengl/OpenGLRunner.java
@@ -23,7 +23,6 @@ public final class OpenGLRunner {
 
     private static HandlerThread handlerThread;
     private static Handler handler;
-    private static boolean quit;
 
     private EGLDisplay eglDisplay;
     private EGLContext eglContext;
@@ -49,32 +48,19 @@ public final class OpenGLRunner {
 
     public static synchronized void initOnce() {
         if (handlerThread == null) {
-            if (quit) {
-                throw new IllegalStateException("Could not init OpenGLRunner after it is quit");
-            }
             handlerThread = new HandlerThread("OpenGLRunner");
             handlerThread.start();
             handler = new Handler(handlerThread.getLooper());
         }
     }
 
-    public static void quit() {
+    public static void shutdown() throws InterruptedException {
         HandlerThread thread;
         synchronized (OpenGLRunner.class) {
             thread = handlerThread;
-            quit = true;
         }
         if (thread != null) {
             thread.quitSafely();
-        }
-    }
-
-    public static void join() throws InterruptedException {
-        HandlerThread thread;
-        synchronized (OpenGLRunner.class) {
-            thread = handlerThread;
-        }
-        if (thread != null) {
             thread.join();
         }
     }


### PR DESCRIPTION
`OpenGLRunner.stopAndRelease()` posts work to its internal `HandlerThread`, so the thread must remain alive until the task completes. Otherwise, the method may never terminate.

However, `OpenGLRunner.quit()` was called before `asyncProcessor.join()` (in particular before `SurfaceEncoder.join()`), allowing the runner to be shut down while `SurfaceEncoder` was still running. In some cases, `capture.stop()`, which calls `glRunner.stopAndRelease()`, was invoked after the `HandlerThread` had already been quit, causing a deadlock. This led to server hangs and prevented a graceful shutdown.

Fix proper ordering of shutdown and joins so the OpenGL runner stops safely.

---

To reproduce, run:

```
scrcpy -Vdebug --angle=10
```

and quit.

## Before

`WARN: Killing the server...` after a 1-second watchdog:

```
DEBUG: User requested to quit
DEBUG: Quit...
DEBUG: Controller stopped
DEBUG: Demuxer 'video': end of frames
DEBUG: Receiver stopped
DEBUG: Demuxer 'audio': end of frames
[server] DEBUG: Controller stopped
[server] DEBUG: Device message sender stopped
[server] DEBUG: Audio encoder stopped
WARN: Killing the server...
DEBUG: Server disconnected
DEBUG: Server terminated
```

## After

It terminates gracefully:

```
DEBUG: User requested to quit
DEBUG: Quit...
DEBUG: Controller stopped
DEBUG: Demuxer 'video': end of frames
DEBUG: Receiver stopped
DEBUG: Demuxer 'audio': end of frames
[server] DEBUG: Controller stopped
[server] DEBUG: Device message sender stopped
[server] DEBUG: Audio encoder stopped
[server] DEBUG: Screen streaming stopped
DEBUG: Server disconnected
DEBUG: Server terminated
```