### PR TITLE
docs: fix typos and incorrect comments in documentation

### DIFF
--- a/doc/camera.md
+++ b/doc/camera.md
@@ -150,7 +150,7 @@ scrcpy --video-source=camera --camera-size=1920x1080 --camera-fps=240
 ## Brace expansion tip
 
 All camera options start with `--camera-`, so if your shell supports it, you can
-benefit from [brace expansion] (for example, it is supported _bash_ and _zsh_):
+benefit from [brace expansion] (for example, it is supported by _bash_ and _zsh_):
 
 ```bash
 scrcpy --video-source=camera --camera-{facing=back,ar=16:9,high-speed,fps=120}

--- a/doc/device.md
+++ b/doc/device.md
@@ -25,7 +25,7 @@ changed manually:
 
 
 ```bash
-# get the current show_touches value
+# get the current stay_on_while_plugged_in value
 adb shell settings get global stay_on_while_plugged_in
 # enable for AC/USB/wireless chargers
 adb shell settings put global stay_on_while_plugged_in 7

--- a/doc/video.md
+++ b/doc/video.md
@@ -161,7 +161,7 @@ The orientation can be set separately for display and record if necessary, via
 `--display-orientation` and `--record-orientation`.
 
 The rotation is applied to a recorded file by writing a display transformation
-to the MP4 or MKV target file. Flipping is not supported, so only the 4 first
+to the MP4 or MKV target file. Flipping is not supported, so only the first four
 values are allowed when recording.
 
 
@@ -229,7 +229,7 @@ get a smoother playback (see [#2464]).
 [#2464]: https://github.com/Genymobile/scrcpy/issues/2464
 
 The configuration is available independently for the display,
-[v4l2 sinks](video.md#video4linux) and [audio](audio.md#buffering) playback.
+[v4l2 sinks](v4l2.md#buffering) and [audio](audio.md#buffering) playback.
 
 ```bash
 scrcpy --video-buffer=50     # add 50ms buffering for video playback


### PR DESCRIPTION
Fixes #6817

Simple typo and wording fixes:

1. **device.md**: Fix incorrect comment referencing `show_touches` (should be `stay_on_while_plugged_in`)
2. **video.md**: Fix 'the 4 first' to 'the first four' for clearer wording  
3. **video.md**: Fix broken link from `video.md#video4linux` to `v4l2.md#buffering`
4. **camera.md**: Fix 'supported _bash_' to 'supported by _bash_' for grammatically correct phrasing

All changes are purely cosmetic/documentation fixes, no functional changes.

---
*GH007 compliant — commit email: 166608075+Jah-yee@users.noreply.github.com*