### PR TITLE
Restore retry-on-error mechanism

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -58,6 +58,7 @@ _scrcpy() {
         --no-audio-playback
         --no-cleanup
         --no-clipboard-autosync
+        --no-downsize-on-error
         --no-key-repeat
         --no-mipmaps
         --no-mouse-hover

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -64,6 +64,7 @@ arguments=(
     '--no-audio-playback[Disable audio playback]'
     '--no-cleanup[Disable device cleanup actions on exit]'
     '--no-clipboard-autosync[Disable automatic clipboard synchronization]'
+    '--no-downsize-on-error[Disable lowering definition on MediaCodec error]'
     '--no-key-repeat[Do not forward repeated key events when a key is held down]'
     '--no-mipmaps[Disable the generation of mipmaps]'
     '--no-mouse-hover[Do not forward mouse hover events]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -399,6 +399,12 @@ By default, scrcpy automatically synchronizes the computer clipboard to the devi
 This option disables this automatic synchronization.
 
 .TP
+.B \-\-no\-downsize\-on\-error
+By default, on MediaCodec error, scrcpy automatically tries again with a lower definition.
+
+This option disables this behavior.
+
+.TP
 .B \-\-no\-key\-repeat
 Do not forward repeated key events when a key is held down.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -51,6 +51,7 @@ enum {
     OPT_NO_CLIPBOARD_AUTOSYNC,
     OPT_TCPIP,
     OPT_RAW_KEY_EVENTS,
+    OPT_NO_DOWNSIZE_ON_ERROR,
     OPT_OTG,
     OPT_NO_CLEANUP,
     OPT_PRINT_FPS,
@@ -627,6 +628,13 @@ static const struct sc_option options[] = {
                 "and the device clipboard to the computer clipboard whenever "
                 "it changes.\n"
                 "This option disables this automatic synchronization."
+    },
+    {
+        .longopt_id = OPT_NO_DOWNSIZE_ON_ERROR,
+        .longopt = "no-downsize-on-error",
+        .text = "By default, on MediaCodec error, scrcpy automatically tries "
+                "again with a lower definition.\n"
+                "This option disables this behavior.",
     },
     {
         .longopt_id = OPT_NO_KEY_REPEAT,
@@ -2707,6 +2715,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 opts->tcpip = true;
                 opts->tcpip_dst = optarg;
                 break;
+            case OPT_NO_DOWNSIZE_ON_ERROR:
+                opts->downsize_on_error = false;
+                break;
             case OPT_NO_VIDEO:
                 opts->video = false;
                 break;
@@ -3006,6 +3017,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                  "not support resizing");
             return false;
         }
+
+        // V4L2 could not handle size change.
+        // Do not log because downsizing on error is the default behavior,
+        // not an explicit request from the user.
+        opts->downsize_on_error = false;
     }
 
     if (opts->v4l2_buffer && !opts->v4l2_device) {

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -96,6 +96,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .legacy_paste = false,
     .power_off_on_close = false,
     .clipboard_autosync = true,
+    .downsize_on_error = true,
     .tcpip = false,
     .tcpip_dst = NULL,
     .select_tcpip = false,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -313,6 +313,7 @@ struct scrcpy_options {
     bool legacy_paste;
     bool power_off_on_close;
     bool clipboard_autosync;
+    bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
     bool select_usb;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -391,6 +391,7 @@ scrcpy(struct scrcpy_options *options) {
         .force_adb_forward = options->force_adb_forward,
         .power_off_on_close = options->power_off_on_close,
         .clipboard_autosync = options->clipboard_autosync,
+        .downsize_on_error = options->downsize_on_error,
         .tcpip = options->tcpip,
         .tcpip_dst = options->tcpip_dst,
         .cleanup = options->cleanup,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -401,6 +401,10 @@ execute_server(struct sc_server *server,
         // By default, clipboard_autosync is true
         ADD_PARAM("clipboard_autosync=false");
     }
+    if (!params->downsize_on_error) {
+        // By default, downsize_on_error is true
+        ADD_PARAM("downsize_on_error=false");
+    }
     if (!params->cleanup) {
         // By default, cleanup is true
         ADD_PARAM("cleanup=false");

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -61,6 +61,7 @@ struct sc_server_params {
     bool force_adb_forward;
     bool power_off_on_close;
     bool clipboard_autosync;
+    bool downsize_on_error;
     bool tcpip;
     const char *tcpip_dst;
     bool select_usb;

--- a/doc/video.md
+++ b/doc/video.md
@@ -25,6 +25,9 @@ The other dimension is computed so that the Android device aspect ratio is
 preserved (except for flex displays). That way, a device in 1920×1080 will be
 mirrored at 1024×576.
 
+If encoding fails, scrcpy automatically tries again with a lower definition
+(unless `--no-downsize-on-error` is enabled).
+
 For camera mirroring, the `--max-size` value is used to select the camera source
 size instead (among the available resolutions).
 

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -60,6 +60,7 @@ public class Options {
     private String audioEncoder;
     private boolean powerOffScreenOnClose;
     private boolean clipboardAutosync = true;
+    private boolean downsizeOnError = true;
     private boolean cleanup = true;
     private boolean powerOn = true;
 
@@ -231,6 +232,10 @@ public class Options {
 
     public boolean getClipboardAutosync() {
         return clipboardAutosync;
+    }
+
+    public boolean getDownsizeOnError() {
+        return downsizeOnError;
     }
 
     public boolean getCleanup() {
@@ -448,6 +453,9 @@ public class Options {
                     break;
                 case "clipboard_autosync":
                     options.clipboardAutosync = Boolean.parseBoolean(value);
+                    break;
+                case "downsize_on_error":
+                    options.downsizeOnError = Boolean.parseBoolean(value);
                     break;
                 case "cleanup":
                     options.cleanup = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -377,6 +377,16 @@ public class CameraCapture extends SurfaceCapture {
         return videoSize;
     }
 
+    @Override
+    protected boolean applyNewVideoConstraints(VideoConstraints videoConstraints) {
+        if (explicitSize != null) {
+            return false;
+        }
+
+        this.videoConstraints = videoConstraints;
+        return true;
+    }
+
     @SuppressLint("MissingPermission")
     @TargetApi(AndroidVersions.API_31_ANDROID_12)
     private CameraDevice openCamera(String id) throws CameraAccessException, InterruptedException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/NewDisplayCapture.java
@@ -314,6 +314,12 @@ public class NewDisplayCapture extends SurfaceCapture {
         return videoSize;
     }
 
+    @Override
+    protected boolean applyNewVideoConstraints(VideoConstraints videoConstraints) {
+        setVideoConstraints(videoConstraints); // with synchronization
+        return true;
+    }
+
     private static int scaleDpi(Size initialSize, int initialDpi, Size size) {
         int den = initialSize.getMax();
         int num = size.getMax();
@@ -349,6 +355,7 @@ public class NewDisplayCapture extends SurfaceCapture {
 
     private synchronized void triggerResize(Size size) {
         if (virtualDisplay != null) {
+            size = size.constrain(videoConstraints); // in case the constraints have changed
             int displayId = virtualDisplay.getDisplay().getDisplayId();
             DisplayInfo displayInfo = ServiceManager.getDisplayManager().getDisplayInfo(displayId);
             int displayRotation = displayInfo.getRotation();

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -191,6 +191,12 @@ public class ScreenCapture extends SurfaceCapture {
         return videoSize;
     }
 
+    @Override
+    protected boolean applyNewVideoConstraints(VideoConstraints videoConstraints) {
+        this.videoConstraints = videoConstraints;
+        return true;
+    }
+
     private static IBinder createDisplay() throws Exception {
         // Since Android 12 (preview), secure displays could not be created with shell permissions anymore.
         // On Android 12 preview, SDK_INT is still R (not S), but CODENAME is "S".

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceCapture.java
@@ -74,4 +74,12 @@ public abstract class SurfaceCapture {
     public boolean isClosed() {
         return false;
     }
+
+    /**
+     * Set new video constraints (called by the encoder to retry when encoding fails)
+     *
+     * @param videoConstraints the video constraints
+     * @return {@code true} if the implementation accepts the new constraints, {@code false} otherwise.
+     */
+    protected abstract boolean applyNewVideoConstraints(VideoConstraints videoConstraints);
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -32,6 +32,8 @@ public class SurfaceEncoder implements AsyncProcessor {
     private static final int REPEAT_FRAME_DELAY_US = 100_000; // repeat after 100ms
     private static final String KEY_MAX_FPS_TO_ENCODER = "max-fps-to-encoder";
 
+    // Keep the values in descending order
+    private static final int[] MAX_SIZE_FALLBACK = {2560, 1920, 1600, 1280, 1024, 800};
     private static final int MAX_CONSECUTIVE_ERRORS = 3;
 
     private final SurfaceCapture capture;
@@ -41,6 +43,7 @@ public class SurfaceEncoder implements AsyncProcessor {
     private final int videoBitRate;
     private final int maxSize;
     private final float maxFps;
+    private final boolean downsizeOnError;
     private final int minSizeAlignment;
 
     private boolean firstFrameSent;
@@ -59,6 +62,7 @@ public class SurfaceEncoder implements AsyncProcessor {
         this.maxFps = options.getMaxFps();
         this.codecOptions = options.getVideoCodecOptions();
         this.encoderName = options.getVideoEncoder();
+        this.downsizeOnError = options.getDownsizeOnError();
         this.minSizeAlignment = options.getMinSizeAlignment();
     }
 
@@ -102,11 +106,19 @@ public class SurfaceEncoder implements AsyncProcessor {
 
             streamer.writeVideoHeader();
 
+            int retainedResetReasons = 0;
+
             do {
                 int resetReasons = captureControl.consumeReset();
                 if ((resetReasons & CaptureControl.RESET_REASON_TERMINATED) != 0) {
                     break;
                 }
+                if (retainedResetReasons != 0) {
+                    // The reasons for the previous failed encoding must be preserved when retrying
+                    resetReasons |= retainedResetReasons;
+                    retainedResetReasons = 0;
+                }
+
                 capture.prepare();
                 Size size = capture.getSize();
 
@@ -151,9 +163,11 @@ public class SurfaceEncoder implements AsyncProcessor {
                         throw e;
                     }
                     Ln.e("Capture/encoding error: " + e.getClass().getName() + ": " + e.getMessage());
-                    if (!prepareRetry()) {
+                    if (!prepareRetry(constraints, size)) {
                         throw e;
                     }
+                    // Keep the current resetReasons flags for the retry
+                    retainedResetReasons = resetReasons;
                     alive = true;
                 } finally {
                     captureControl.setRunningMediaCodec(null);
@@ -179,7 +193,7 @@ public class SurfaceEncoder implements AsyncProcessor {
         }
     }
 
-    private boolean prepareRetry() {
+    private boolean prepareRetry(VideoConstraints videoConstraints, Size currentSize) {
         if (firstFrameSent) {
             ++consecutiveErrors;
             if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
@@ -192,7 +206,39 @@ public class SurfaceEncoder implements AsyncProcessor {
             return true;
         }
 
-        return false;
+        if (!downsizeOnError) {
+            // Must fail immediately
+            return false;
+        }
+
+        // Downsizing on error is only enabled if an encoding failure occurs before the first frame (downsizing later could be surprising)
+
+        int newMaxSize = chooseMaxSizeFallback(currentSize);
+        if (newMaxSize == 0) {
+            // Must definitively fail
+            return false;
+        }
+
+        boolean accepted = capture.applyNewVideoConstraints(videoConstraints.withMaxSize(newMaxSize));
+        if (!accepted) {
+            return false;
+        }
+
+        // Retry with a smaller size
+        Ln.i("Retrying with -m" + newMaxSize + "...");
+        return true;
+    }
+
+    private static int chooseMaxSizeFallback(Size failedSize) {
+        int currentMaxSize = Math.max(failedSize.getWidth(), failedSize.getHeight());
+        for (int value : MAX_SIZE_FALLBACK) {
+            if (value < currentMaxSize) {
+                // We found a smaller value to reduce the video size
+                return value;
+            }
+        }
+        // No fallback, fail definitively
+        return 0;
     }
 
     private void encode(MediaCodec codec, Streamer streamer) throws IOException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/SurfaceEncoder.java
@@ -18,6 +18,7 @@ import android.media.MediaCodecInfo;
 import android.media.MediaFormat;
 import android.os.Build;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.view.Surface;
 
 import java.io.IOException;
@@ -31,6 +32,8 @@ public class SurfaceEncoder implements AsyncProcessor {
     private static final int REPEAT_FRAME_DELAY_US = 100_000; // repeat after 100ms
     private static final String KEY_MAX_FPS_TO_ENCODER = "max-fps-to-encoder";
 
+    private static final int MAX_CONSECUTIVE_ERRORS = 3;
+
     private final SurfaceCapture capture;
     private final Streamer streamer;
     private final String encoderName;
@@ -39,6 +42,9 @@ public class SurfaceEncoder implements AsyncProcessor {
     private final int maxSize;
     private final float maxFps;
     private final int minSizeAlignment;
+
+    private boolean firstFrameSent;
+    private int consecutiveErrors;
 
     private Thread thread;
     private final AtomicBoolean stopped = new AtomicBoolean();
@@ -139,6 +145,16 @@ public class SurfaceEncoder implements AsyncProcessor {
                         // The capture might have been closed internally (for example if the camera is disconnected)
                         alive = !stopped.get() && !capture.isClosed();
                     }
+                } catch (IllegalStateException | IllegalArgumentException | IOException e) {
+                    if (IO.isBrokenPipe(e)) {
+                        // Do not retry on broken pipe, which is expected on close because the socket is closed by the client
+                        throw e;
+                    }
+                    Ln.e("Capture/encoding error: " + e.getClass().getName() + ": " + e.getMessage());
+                    if (!prepareRetry()) {
+                        throw e;
+                    }
+                    alive = true;
                 } finally {
                     captureControl.setRunningMediaCodec(null);
                     if (captureStarted) {
@@ -163,6 +179,22 @@ public class SurfaceEncoder implements AsyncProcessor {
         }
     }
 
+    private boolean prepareRetry() {
+        if (firstFrameSent) {
+            ++consecutiveErrors;
+            if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+                // Definitively fail
+                return false;
+            }
+
+            // Wait a bit to increase the probability that retrying will fix the problem
+            SystemClock.sleep(50);
+            return true;
+        }
+
+        return false;
+    }
+
     private void encode(MediaCodec codec, Streamer streamer) throws IOException {
         MediaCodec.BufferInfo bufferInfo = new MediaCodec.BufferInfo();
 
@@ -173,6 +205,13 @@ public class SurfaceEncoder implements AsyncProcessor {
                 eos = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0;
                 // On EOS, there might be data or not, depending on bufferInfo.size
                 if (outputBufferId >= 0 && bufferInfo.size > 0) {
+                    boolean isConfig = (bufferInfo.flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0;
+                    if (!isConfig) {
+                        // If this is not a config packet, then it contains a frame
+                        firstFrameSent = true;
+                        consecutiveErrors = 0;
+                    }
+
                     ByteBuffer codecBuffer = codec.getOutputBuffer(outputBufferId);
                     streamer.writePacket(codecBuffer, bufferInfo);
                 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoConstraints.java
@@ -73,4 +73,14 @@ public class VideoConstraints {
     public int getMinCodecSize() {
         return minCodecSize;
     }
+
+    /**
+     * Return the video constraints with the provided max size.
+     *
+     * @param maxSize the max requested size
+     * @return the new video constraints
+     */
+    public VideoConstraints withMaxSize(int maxSize) {
+        return new VideoConstraints(maxSize, alignment, maxCodecLandscapeSize, maxCodecPortraitSize, minCodecSize);
+    }
 }


### PR DESCRIPTION
First, restore retry on spurious error.
    
MediaCodec may fail spuriously, typically when stopping an encoding and starting a new one immediately (for example on device rotation).
    
This was initially fixed by 07806ba9159b1f4dbd2ede77b110e254af1fd7f6 (#3693), but the fix was removed by 4f97e2e30b9b02ff43d64e940165acafd7512a23 (#6766), along with the removal of the mechanism to retry capture at a lower resolution on error.

---

Then, restore retry capture at lower resolution.
    
The mechanism to retry capture at a lower resolution on error (#2947) was removed in favor of using video encoder capabilities instead (#6766).
    
However, an encoder configuration that is compatible with the declared capabilities may still fail, either because the declared capabilities are incorrect or because some resources are unavailable.

Restore the downsize-on-error behavior for such cases.

This reverts commit 4f97e2e30b9b02ff43d64e940165acafd7512a23 (#6766).