### PR TITLE
Set terminal tab title to scrcpy and device name

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -63,6 +63,7 @@ _scrcpy() {
         --no-mipmaps
         --no-mouse-hover
         --no-power-on
+        --no-terminal-title
         --no-vd-destroy-content
         --no-vd-system-decorations
         --no-video

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -69,6 +69,7 @@ arguments=(
     '--no-mipmaps[Disable the generation of mipmaps]'
     '--no-mouse-hover[Do not forward mouse hover events]'
     '--no-power-on[Do not power on the device on start]'
+    '--no-terminal-title[Disable automatic terminal title updates]'
     '--no-vd-destroy-content[Disable virtual display "destroy content on removal" flag]'
     '--no-vd-system-decorations[Disable virtual display system decorations flag]'
     '--no-video[Disable video forwarding]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -421,6 +421,10 @@ Do not forward mouse hover (mouse motion without any clicks) events.
 Do not power on the device on start.
 
 .TP
+.B \-\-no\-terminal\-title
+Disable automatic terminal title updates.
+
+.TP
 .B \-\-no\-vd\-destroy\-content
 Disable virtual display "destroy content on removal" flag.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -106,6 +106,7 @@ enum {
     OPT_CAMERA_ZOOM,
     OPT_MIN_SIZE_ALIGNMENT,
     OPT_NO_WINDOW_ASPECT_RATIO_LOCK,
+    OPT_NO_TERMINAL_TITLE,
     OPT_KEEP_ACTIVE,
     OPT_BACKGROUND_COLOR,
     OPT_RENDER_FIT,
@@ -658,6 +659,11 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_NO_POWER_ON,
         .longopt = "no-power-on",
         .text = "Do not power on the device on start.",
+    },
+    {
+        .longopt_id = OPT_NO_TERMINAL_TITLE,
+        .longopt = "no-terminal-title",
+        .text = "Disable automatic terminal title updates.",
     },
     {
         .longopt_id = OPT_NO_VD_DESTROY_CONTENT,
@@ -2900,6 +2906,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_WINDOW_ASPECT_RATIO_LOCK:
                 opts->window_aspect_ratio_lock = false;
+                break;
+            case OPT_NO_TERMINAL_TITLE:
+                opts->terminal_title = false;
                 break;
             case OPT_KEEP_ACTIVE:
                 opts->keep_active = true;

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -16,6 +16,7 @@
 #endif
 #include "util/log.h"
 #include "util/net.h"
+#include "util/term.h"
 #include "version.h"
 
 #ifdef _WIN32
@@ -31,6 +32,8 @@ main_scrcpy(int argc, char *argv[]) {
     setbuf(stdout, NULL);
     setbuf(stderr, NULL);
 #endif
+
+    sc_term_set_title("scrcpy");
 
     printf("scrcpy " SCRCPY_VERSION
            " <https://github.com/Genymobile/scrcpy>\n");
@@ -107,6 +110,8 @@ end:
         printf("Press Enter to continue...\n");
         getchar();
     }
+
+    sc_term_set_title("");
 
     return ret;
 }

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -33,8 +33,6 @@ main_scrcpy(int argc, char *argv[]) {
     setbuf(stderr, NULL);
 #endif
 
-    sc_term_set_title("scrcpy");
-
     printf("scrcpy " SCRCPY_VERSION
            " <https://github.com/Genymobile/scrcpy>\n");
 
@@ -57,6 +55,10 @@ main_scrcpy(int argc, char *argv[]) {
     }
 
     sc_set_log_level(args.opts.log_level);
+
+    if (args.opts.terminal_title) {
+        sc_term_set_title("scrcpy");
+    }
 
     if (args.help) {
         scrcpy_print_usage(argv[0]);
@@ -111,7 +113,9 @@ end:
         getchar();
     }
 
-    sc_term_set_title("");
+    if (args.opts.terminal_title) {
+        sc_term_set_title("");
+    }
 
     return ret;
 }

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -87,6 +87,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .turn_screen_off = false,
     .key_inject_mode = SC_KEY_INJECT_MODE_MIXED,
     .window_aspect_ratio_lock = true,
+    .terminal_title = true,
     .window_borderless = false,
     .mipmaps = true,
     .stay_awake = false,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -304,6 +304,7 @@ struct scrcpy_options {
     bool turn_screen_off;
     enum sc_key_inject_mode key_inject_mode;
     bool window_aspect_ratio_lock;
+    bool terminal_title;
     bool window_borderless;
     bool mipmaps;
     bool stay_awake;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -40,6 +40,7 @@
 #include "util/acksync.h"
 #include "util/log.h"
 #include "util/rand.h"
+#include "util/term.h"
 #include "util/timeout.h"
 #include "util/tick.h"
 #ifdef HAVE_V4L2
@@ -492,6 +493,14 @@ scrcpy(struct scrcpy_options *options) {
 
     const char *serial = s->server.serial;
     assert(serial);
+
+    // Update the terminal tab title now that we know the device name.
+    // Use --window-title if provided, otherwise fall back to the device name.
+    const char *title_suffix =
+        options->window_title ? options->window_title : info->device_name;
+    char term_title[256];
+    snprintf(term_title, sizeof(term_title), "scrcpy - %s", title_suffix);
+    sc_term_set_title(term_title);
 
     struct sc_file_pusher *fp = NULL;
 
@@ -1008,6 +1017,8 @@ end:
     }
 
     sc_server_destroy(&s->server);
+
+    sc_term_set_title("");
 
     return ret;
 }

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -496,11 +496,13 @@ scrcpy(struct scrcpy_options *options) {
 
     // Update the terminal tab title now that we know the device name.
     // Use --window-title if provided, otherwise fall back to the device name.
-    const char *title_suffix =
-        options->window_title ? options->window_title : info->device_name;
-    char term_title[256];
-    snprintf(term_title, sizeof(term_title), "scrcpy - %s", title_suffix);
-    sc_term_set_title(term_title);
+    if (options->terminal_title) {
+        const char *title_suffix =
+            options->window_title ? options->window_title : info->device_name;
+        char term_title[256];
+        snprintf(term_title, sizeof(term_title), "scrcpy - %s", title_suffix);
+        sc_term_set_title(term_title);
+    }
 
     struct sc_file_pusher *fp = NULL;
 
@@ -1018,7 +1020,9 @@ end:
 
     sc_server_destroy(&s->server);
 
-    sc_term_set_title("");
+    if (options->terminal_title) {
+        sc_term_set_title("");
+    }
 
     return ret;
 }

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <SDL3/SDL.h>
 
@@ -16,6 +17,7 @@
 #include "usb/keyboard_aoa.h"
 #include "usb/mouse_aoa.h"
 #include "util/log.h"
+#include "util/term.h"
 
 struct scrcpy_otg {
     struct sc_usb usb;
@@ -182,6 +184,13 @@ scrcpy_otg(struct scrcpy_options *options) {
         window_title = usb_device.product ? usb_device.product : "scrcpy";
     }
 
+    // Update the terminal tab title now that we know the device name.
+    if (options->window_title || usb_device.product) {
+        char term_title[256];
+        snprintf(term_title, sizeof(term_title), "scrcpy - %s", window_title);
+        sc_term_set_title(term_title);
+    }
+
     struct sc_screen_params params = {
         .video = false,
         .camera = false,
@@ -269,6 +278,8 @@ end:
         sc_screen_join(&s->screen);
         sc_screen_destroy(&s->screen);
     }
+
+    sc_term_set_title("");
 
     return ret;
 }

--- a/app/src/usb/scrcpy_otg.c
+++ b/app/src/usb/scrcpy_otg.c
@@ -185,7 +185,7 @@ scrcpy_otg(struct scrcpy_options *options) {
     }
 
     // Update the terminal tab title now that we know the device name.
-    if (options->window_title || usb_device.product) {
+    if (options->terminal_title && (options->window_title || usb_device.product)) {
         char term_title[256];
         snprintf(term_title, sizeof(term_title), "scrcpy - %s", window_title);
         sc_term_set_title(term_title);
@@ -279,7 +279,9 @@ end:
         sc_screen_destroy(&s->screen);
     }
 
-    sc_term_set_title("");
+    if (options->terminal_title) {
+        sc_term_set_title("");
+    }
 
     return ret;
 }

--- a/app/src/util/term.c
+++ b/app/src/util/term.c
@@ -1,8 +1,10 @@
 #include "term.h"
 
 #include <assert.h>
+#include <stdio.h>
 
 #ifdef _WIN32
+# include <io.h>
 # include <windows.h>
 #else
 # include <unistd.h>
@@ -48,4 +50,25 @@ sc_term_get_size(unsigned *rows, unsigned *cols) {
 
     return true;
 #endif
+}
+
+void
+sc_term_set_title(const char *title) {
+#ifdef _WIN32
+    // Fallback for legacy Windows console hosts (cmd.exe / conhost) that do
+    // not process VT escape sequences.
+    SetConsoleTitleA(title);
+
+    if (!_isatty(_fileno(stdout))) {
+        return;
+    }
+#else
+    if (!isatty(STDOUT_FILENO)) {
+        return;
+    }
+#endif
+    // OSC 0 sets both the icon name and the window/tab title; recognized by
+    // Windows Terminal, macOS Terminal, xterm, and most modern emulators.
+    printf("\033]0;%s\007", title);
+    fflush(stdout);
 }

--- a/app/src/util/term.h
+++ b/app/src/util/term.h
@@ -18,4 +18,18 @@
 bool
 sc_term_get_size(unsigned *rows, unsigned *cols);
 
+/**
+ * Set the terminal tab/window title.
+ *
+ * Emits an OSC 0 escape sequence (\033]0;<title>\007) recognized by Windows
+ * Terminal, macOS Terminal, xterm, and most modern terminal emulators.
+ * On Windows, also calls SetConsoleTitleA() as a fallback for legacy hosts
+ * (cmd.exe, conhost) that do not process VT sequences.
+ *
+ * Pass an empty string ("") to clear the title and let the shell restore its
+ * own title on the next prompt.
+ */
+void
+sc_term_set_title(const char *title);
+
 #endif


### PR DESCRIPTION
# Summary

Set the terminal tab/window title to `scrcpy` when the program starts, and update it to `scrcpy - <device name>` once a device is connected. This makes it easy to identify scrcpy tabs when multiple tabs are open in a terminal multiplexer or tabbed terminal emulator (e.g. Windows Terminal, macOS Terminal, tmux).

<img width="290" height="49" alt="scrcpy_title" src="https://github.com/user-attachments/assets/d2f3d744-0190-4d4c-a36a-53587e82dd6e" />  

The title respects `--window-title`: if a custom window title is provided, the terminal tab title becomes `scrcpy - <custom title>` instead of using the device name.

The original terminal title is restored (cleared) when scrcpy exits, allowing the shell to reset its own title on the next prompt.

# Changes

- **`app/src/util/term.h`** — declared new function `sc_term_set_title(const char *title)`
- **`app/src/util/term.c`** — implemented `sc_term_set_title()`: only emits output when stdout is a TTY (`isatty()` on Unix/macOS, `_isatty()` on Windows), so piping (e.g. `scrcpy | tee logs.txt`) is not affected; emits an OSC 0 escape sequence (`\033]0;<title>\007`) to stdout, supported by all modern terminal emulators; on Windows additionally calls `SetConsoleTitleA()` unconditionally as a fallback for legacy console hosts (`cmd.exe`, `conhost`) that do not process VT sequences
- **`app/src/main.c`** — calls `sc_term_set_title("scrcpy")` immediately on startup; calls `sc_term_set_title("")` on exit to restore the terminal title
- **`app/src/scrcpy.c`** — calls `sc_term_set_title("scrcpy - <name>")` after the device handshake completes (using `--window-title` if provided, otherwise the device name reported by the server); calls `sc_term_set_title("")` on exit
- **`app/src/usb/scrcpy_otg.c`** — same behaviour in OTG mode: updates the terminal tab title to `scrcpy - <USB product name>` once the device is known; calls `sc_term_set_title("")` on exit