### PR TITLE
Fix gamepad

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -1048,13 +1048,13 @@ sc_input_manager_process_gamepad_device(struct sc_input_manager *im,
     if (event->type == SDL_EVENT_GAMEPAD_ADDED) {
         SDL_Gamepad *sdl_gamepad = SDL_OpenGamepad(event->which);
         if (!sdl_gamepad) {
-            LOGW("Could not open gamepad");
+            LOGW("Could not open gamepad: %s", SDL_GetError());
             return;
         }
 
         SDL_Joystick *joystick = SDL_GetGamepadJoystick(sdl_gamepad);
         if (!joystick) {
-            LOGW("Could not get gamepad joystick");
+            LOGW("Could not get gamepad joystick: %s", SDL_GetError());
             SDL_CloseGamepad(sdl_gamepad);
             return;
         }

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -300,6 +300,8 @@ init_sdl_gamepads(void) {
             SDL_PushEvent(&event);
         }
     }
+
+    SDL_free(joysticks);
 }
 
 enum scrcpy_exit_code

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -296,7 +296,7 @@ init_sdl_gamepads(void) {
         if (SDL_IsGamepad(joystick)) {
             SDL_Event event;
             event.gdevice.type = SDL_EVENT_GAMEPAD_ADDED;
-            event.gdevice.which = i;
+            event.gdevice.which = joystick;
             SDL_PushEvent(&event);
         }
     }


### PR DESCRIPTION
In SDL2, the `which` field in `SDL_ControllerDeviceEvent` contained the device index. In SDL3, the `which` field in `SDL_GamepadDeviceEvent` is the joystick instance id directly.
    
This was not properly migrated from SDL2 to SDL3 in commit 02989249f6a992090a70c4d61e0834a990f004fa.

Refs #6216
Refs https://github.com/libsdl-org/SDL/issues/15616
Fixes #6843