### PR TITLE
Add Windows ARM 64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,25 +172,62 @@ jobs:
           name: build-win32-intermediate
           path: release/work/build-win32/dist-tar/
 
-  build-win64:
-    runs-on: ubuntu-latest
+  build-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: '64'
+            target: win64
+            runs-on: ubuntu-latest
+            shell: bash
+          - arch: arm64
+            target: winarm64
+            runs-on: windows-11-arm
+            shell: 'msys2 {0}'
+    runs-on: ${{ matrix.runs-on }}
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install dependencies
+      - name: Install dependencies (Linux cross-build)
+        if: matrix.target == 'win64'
         run: |
           sudo apt update
           sudo apt install -y meson ninja-build nasm \
              mingw-w64 mingw-w64-tools libz-mingw-w64-dev
 
+      - name: Setup MSYS2 (native Windows ARM64 build)
+        if: matrix.target == 'winarm64'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: >-
+            base-devel
+            unzip
+            wget
+            autoconf
+            automake
+            libtool
+            make
+            mingw-w64-clang-aarch64-toolchain
+            mingw-w64-clang-aarch64-meson
+            mingw-w64-clang-aarch64-ninja
+            mingw-w64-clang-aarch64-cmake
+            mingw-w64-clang-aarch64-pkgconf
+            mingw-w64-clang-aarch64-zlib
+
       - name: Build
-        run: release/build_windows.sh 64
+        run: release/build_windows.sh ${{ matrix.arch }}
 
       # upload-artifact does not preserve permissions
       - name: Tar
         run: |
-            cd release/work/build-win64
+            cd release/work/build-${{ matrix.target }}
             mkdir dist-tar
             cd dist-tar
             tar -C .. -cvf dist.tar.gz dist/
@@ -198,8 +235,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
-          name: build-win64-intermediate
-          path: release/work/build-win64/dist-tar/
+          name: build-${{ matrix.target }}-intermediate
+          path: release/work/build-${{ matrix.target }}/dist-tar/
 
   build-macos-aarch64:
     runs-on: macos-latest
@@ -362,7 +399,7 @@ jobs:
   package-win64:
     needs:
       - build-scrcpy-server
-      - build-win64
+      - build-windows
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -393,6 +430,42 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: release-win64
+          path: release/output
+
+  package-winarm64:
+    needs:
+      - build-scrcpy-server
+      - build-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download scrcpy-server
+        uses: actions/download-artifact@v8
+        with:
+          name: scrcpy-server
+          path: release/work/build-server/server/
+
+      - name: Download build-winarm64
+        uses: actions/download-artifact@v8
+        with:
+          name: build-winarm64-intermediate
+          path: release/work/build-winarm64/dist-tar/
+
+      # upload-artifact does not preserve permissions
+      - name: Detar
+        run: |
+            cd release/work/build-winarm64
+            tar xf dist-tar/dist.tar.gz
+
+      - name: Package
+        run: release/package_client.sh winarm64 zip
+
+      - name: Upload release
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-winarm64
           path: release/output
 
   package-macos-aarch64:
@@ -473,6 +546,7 @@ jobs:
       - package-linux-x86_64
       - package-win32
       - package-win64
+      - package-winarm64
       - package-macos-aarch64
       - package-macos-x86_64
     runs-on: ubuntu-latest
@@ -502,6 +576,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: release-win64
+          path: release/output/
+
+      - name: Download release-winarm64
+        uses: actions/download-artifact@v8
+        with:
+          name: release-winarm64
           path: release/output/
 
       - name: Download release-macos-aarch64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,6 +201,53 @@ jobs:
           name: build-win64-intermediate
           path: release/work/build-win64/dist-tar/
 
+  build-winarm64:
+    runs-on: windows-11-arm
+    defaults:
+      run:
+        shell: 'msys2 {0}'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: >-
+            base-devel
+            unzip
+            wget
+            autoconf
+            automake
+            libtool
+            make
+            mingw-w64-clang-aarch64-toolchain
+            mingw-w64-clang-aarch64-gcc-compat
+            mingw-w64-clang-aarch64-meson
+            mingw-w64-clang-aarch64-ninja
+            mingw-w64-clang-aarch64-cmake
+            mingw-w64-clang-aarch64-pkgconf
+            mingw-w64-clang-aarch64-zlib
+
+      - name: Build
+        run: release/build_windows.sh arm64
+
+      # upload-artifact does not preserve permissions
+      - name: Tar
+        run: |
+            cd release/work/build-winarm64
+            mkdir dist-tar
+            cd dist-tar
+            tar -C .. -cvf dist.tar.gz dist/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: build-winarm64-intermediate
+          path: release/work/build-winarm64/dist-tar/
+
   build-macos-aarch64:
     runs-on: macos-latest
     steps:
@@ -395,6 +442,42 @@ jobs:
           name: release-win64
           path: release/output
 
+  package-winarm64:
+    needs:
+      - build-scrcpy-server
+      - build-winarm64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Download scrcpy-server
+        uses: actions/download-artifact@v8
+        with:
+          name: scrcpy-server
+          path: release/work/build-server/server/
+
+      - name: Download build-winarm64
+        uses: actions/download-artifact@v8
+        with:
+          name: build-winarm64-intermediate
+          path: release/work/build-winarm64/dist-tar/
+
+      # upload-artifact does not preserve permissions
+      - name: Detar
+        run: |
+            cd release/work/build-winarm64
+            tar xf dist-tar/dist.tar.gz
+
+      - name: Package
+        run: release/package_client.sh winarm64 zip
+
+      - name: Upload release
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-winarm64
+          path: release/output
+
   package-macos-aarch64:
     needs:
       - build-scrcpy-server
@@ -473,6 +556,7 @@ jobs:
       - package-linux-x86_64
       - package-win32
       - package-win64
+      - package-winarm64
       - package-macos-aarch64
       - package-macos-x86_64
     runs-on: ubuntu-latest
@@ -502,6 +586,12 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: release-win64
+          path: release/output/
+
+      - name: Download release-winarm64
+        uses: actions/download-artifact@v8
+        with:
+          name: release-winarm64
           path: release/output/
 
       - name: Download release-macos-aarch64

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -134,6 +134,14 @@ else
                 echo "Unsupported host: $HOST" >&2
                 exit 1
         esac
+    elif [[ "$HOST" == winarm64 ]]
+    then
+        # Native Windows ARM64 build (MSYS2 CLANGARM64 provides clang, not gcc)
+        conf+=(
+            --target-os=mingw32
+            --arch=aarch64
+            --cc=clang
+        )
     fi
 
     "$SOURCES_DIR/$PROJECT_DIR"/configure "${conf[@]}"

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -134,6 +134,13 @@ else
                 echo "Unsupported host: $HOST" >&2
                 exit 1
         esac
+    elif [[ "$HOST" == winarm64 ]]
+    then
+        # Native Windows ARM64 build (MSYS2 CLANGARM64)
+        conf+=(
+            --target-os=mingw32
+            --arch=aarch64
+        )
     fi
 
     "$SOURCES_DIR/$PROJECT_DIR"/configure "${conf[@]}"

--- a/release/build_windows.sh
+++ b/release/build_windows.sh
@@ -4,12 +4,18 @@ set -ex
 case "$1" in
     32)
         WINXX=win32
+        BUILD_TYPE=cross
         ;;
     64)
         WINXX=win64
+        BUILD_TYPE=cross
+        ;;
+    arm64)
+        WINXX=winarm64
+        BUILD_TYPE=native
         ;;
     *)
-        echo "ERROR: $0 must be called with one argument: 32 or 64" >&2
+        echo "ERROR: $0 must be called with one argument: 32, 64 or arm64" >&2
         exit 1
         ;;
 esac
@@ -20,29 +26,46 @@ cd .. # root project dir
 
 WINXX_BUILD_DIR="$WORK_DIR/build-$WINXX"
 
-app/deps/adb_windows.sh
-app/deps/sdl.sh $WINXX cross shared
-app/deps/dav1d.sh $WINXX cross shared
-app/deps/ffmpeg.sh $WINXX cross shared
-app/deps/libusb.sh $WINXX cross shared
+# Prefer Ninja for CMake-based deps on MSYS2 (avoids "MSYS Makefiles" quirks).
+# MSYS2 CLANGARM64 provides clang, not gcc — make autotools/cmake/configure
+# pick it up by default.
+if [[ "$BUILD_TYPE" == native ]]
+then
+    export CMAKE_GENERATOR=Ninja
+    export CC=clang
+    export CXX=clang++
+fi
 
-DEPS_INSTALL_DIR="$PWD/app/deps/work/install/$WINXX-cross-shared"
+app/deps/adb_windows.sh
+app/deps/sdl.sh $WINXX $BUILD_TYPE shared
+app/deps/dav1d.sh $WINXX $BUILD_TYPE shared
+app/deps/ffmpeg.sh $WINXX $BUILD_TYPE shared
+app/deps/libusb.sh $WINXX $BUILD_TYPE shared
+
+DEPS_INSTALL_DIR="$PWD/app/deps/work/install/$WINXX-$BUILD_TYPE-shared"
 ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-windows"
 
 # Never fall back to system libs
 unset PKG_CONFIG_PATH
 export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig"
 
-rm -rf "$WINXX_BUILD_DIR"
-meson setup "$WINXX_BUILD_DIR" \
-    -Dc_args="-I$DEPS_INSTALL_DIR/include" \
-    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
-    --cross-file=cross_$WINXX.txt \
-    --buildtype=release \
-    --strip \
-    -Db_lto=true \
-    -Dcompile_server=false \
+meson_args=(
+    -Dc_args="-I$DEPS_INSTALL_DIR/include"
+    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib"
+    --buildtype=release
+    --strip
+    -Db_lto=true
+    -Dcompile_server=false
     -Dportable=true
+)
+
+if [[ "$BUILD_TYPE" == cross ]]
+then
+    meson_args+=(--cross-file=cross_$WINXX.txt)
+fi
+
+rm -rf "$WINXX_BUILD_DIR"
+meson setup "$WINXX_BUILD_DIR" "${meson_args[@]}"
 ninja -C "$WINXX_BUILD_DIR"
 
 # Group intermediate outputs into a 'dist' directory

--- a/release/build_windows.sh
+++ b/release/build_windows.sh
@@ -4,12 +4,18 @@ set -ex
 case "$1" in
     32)
         WINXX=win32
+        BUILD_TYPE=cross
         ;;
     64)
         WINXX=win64
+        BUILD_TYPE=cross
+        ;;
+    arm64)
+        WINXX=winarm64
+        BUILD_TYPE=native
         ;;
     *)
-        echo "ERROR: $0 must be called with one argument: 32 or 64" >&2
+        echo "ERROR: $0 must be called with one argument: 32, 64 or arm64" >&2
         exit 1
         ;;
 esac
@@ -20,29 +26,42 @@ cd .. # root project dir
 
 WINXX_BUILD_DIR="$WORK_DIR/build-$WINXX"
 
-app/deps/adb_windows.sh
-app/deps/sdl.sh $WINXX cross shared
-app/deps/dav1d.sh $WINXX cross shared
-app/deps/ffmpeg.sh $WINXX cross shared
-app/deps/libusb.sh $WINXX cross shared
+# Prefer Ninja for CMake-based deps on MSYS2 (avoids "MSYS Makefiles" quirks)
+if [[ "$BUILD_TYPE" == native ]]
+then
+    export CMAKE_GENERATOR=Ninja
+fi
 
-DEPS_INSTALL_DIR="$PWD/app/deps/work/install/$WINXX-cross-shared"
+app/deps/adb_windows.sh
+app/deps/sdl.sh $WINXX $BUILD_TYPE shared
+app/deps/dav1d.sh $WINXX $BUILD_TYPE shared
+app/deps/ffmpeg.sh $WINXX $BUILD_TYPE shared
+app/deps/libusb.sh $WINXX $BUILD_TYPE shared
+
+DEPS_INSTALL_DIR="$PWD/app/deps/work/install/$WINXX-$BUILD_TYPE-shared"
 ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-windows"
 
 # Never fall back to system libs
 unset PKG_CONFIG_PATH
 export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig"
 
-rm -rf "$WINXX_BUILD_DIR"
-meson setup "$WINXX_BUILD_DIR" \
-    -Dc_args="-I$DEPS_INSTALL_DIR/include" \
-    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib" \
-    --cross-file=cross_$WINXX.txt \
-    --buildtype=release \
-    --strip \
-    -Db_lto=true \
-    -Dcompile_server=false \
+meson_args=(
+    -Dc_args="-I$DEPS_INSTALL_DIR/include"
+    -Dc_link_args="-L$DEPS_INSTALL_DIR/lib"
+    --buildtype=release
+    --strip
+    -Db_lto=true
+    -Dcompile_server=false
     -Dportable=true
+)
+
+if [[ "$BUILD_TYPE" == cross ]]
+then
+    meson_args+=(--cross-file=cross_$WINXX.txt)
+fi
+
+rm -rf "$WINXX_BUILD_DIR"
+meson setup "$WINXX_BUILD_DIR" "${meson_args[@]}"
 ninja -C "$WINXX_BUILD_DIR"
 
 # Group intermediate outputs into a 'dist' directory

--- a/release/generate_checksums.sh
+++ b/release/generate_checksums.sh
@@ -8,6 +8,7 @@ sha256sum "scrcpy-server-$VERSION" \
     "scrcpy-linux-x86_64-$VERSION.tar.gz" \
     "scrcpy-win32-$VERSION.zip" \
     "scrcpy-win64-$VERSION.zip" \
+    "scrcpy-winarm64-$VERSION.zip" \
     "scrcpy-macos-aarch64-$VERSION.tar.gz" \
     "scrcpy-macos-x86_64-$VERSION.tar.gz" \
         | tee SHA256SUMS.txt


### PR DESCRIPTION
With the rising popularity of Windows ARM 64 devices, such as the latest Surface / Snapdragon X laptops, recently released Snapdragon X2 devices and soon to be released Nvidia N1X SOC users are increasingly expecting native applications.

Built and tested the GitHub build Windows ARM artifacts from my fork using my Snapdragon X2 Elite Extreme based Asus Zenbook A16 running Windows 11 ARM 26H1.

This should close off:
https://github.com/Genymobile/scrcpy/issues/5820

And supersede:
https://github.com/Genymobile/scrcpy/pull/3252

Here's a screenshot showing scrcpy.exe running natively on my system:
<img width="1089" height="745" alt="image" src="https://github.com/user-attachments/assets/51f60c09-6158-49c5-8627-a36cf6c5de68" />

