### PR TITLE
A more manageable scrcpy-noconsole.bat Windows batch script

### DIFF
--- a/app/data/scrcpy-noconsole.bat
+++ b/app/data/scrcpy-noconsole.bat
@@ -1,0 +1,2 @@
+@echo off & setlocal
+powershell -NoProfile -ExecutionPolicy Bypass -Command "& { $params = @{ FilePath = '%~dp0scrcpy.exe'; WindowStyle = 'Hidden' }; if ($args.Count -gt 0) { $params['ArgumentList'] = $args }; Start-Process @params }" %*


### PR DESCRIPTION
A more manageable scrcpy-noconsole.bat Windows batch script has been attached.