### PR TITLE
feat: add --shortcut-key option to customize shortcut key bindings

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -88,6 +88,7 @@ _scrcpy() {
         -s --serial=
         -S --turn-screen-off
         --screen-off-timeout=
+        --shortcut-key=
         --shortcut-mod=
         --start-app=
         -t --show-touches
@@ -183,6 +184,10 @@ _scrcpy() {
             ;;
         --render-fit)
             COMPREPLY=($(compgen -W 'letterbox stretched unscaled' -- "$cur"))
+            return
+            ;;
+        --shortcut-key)
+            COMPREPLY=($(compgen -W 'home= back= app-switch= menu= power= screen-power= pause= volume-down= volume-up= rotate-left= rotate-right= copy= cut= paste= fullscreen= resize-to-fit= pixel-perfect= fps-counter= panels= rotate-device= open-keyboard-settings=' -- "$cur"))
             return
             ;;
         --shortcut-mod)

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -93,6 +93,7 @@ arguments=(
     {-s,--serial=}'[The device serial number \(mandatory for multiple devices only\)]:serial:($("${ADB-adb}" devices | awk '\''$2 == "device" {print $1}'\''))'
     {-S,--turn-screen-off}'[Turn the device screen off immediately]'
     '--screen-off-timeout=[Set the screen off timeout in seconds]'
+    '--shortcut-key=[Override one keyboard shortcut key]:shortcut action:(home= back= app-switch= menu= power= screen-power= pause= volume-down= volume-up= rotate-left= rotate-right= copy= cut= paste= fullscreen= resize-to-fit= pixel-perfect= fps-counter= panels= rotate-device= open-keyboard-settings=)'
     '--shortcut-mod=[\[key1,key2+key3,...\] Specify the modifiers to use for scrcpy shortcuts]:shortcut mod:(lctrl rctrl lalt ralt lsuper rsuper)'
     '--start-app=[Start an Android app]'
     {-t,--show-touches}'[Show physical touches]'

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -2,11 +2,13 @@
 
 #include <assert.h>
 #include <getopt.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <SDL3/SDL_keyboard.h>
 
 #include "options.h"
 #include "util/log.h"
@@ -39,6 +41,7 @@ enum {
     OPT_FORCE_ADB_FORWARD,
     OPT_DISABLE_SCREENSAVER,
     OPT_SHORTCUT_MOD,
+    OPT_SHORTCUT_KEY,
     OPT_NO_KEY_REPEAT,
     OPT_LEGACY_PASTE,
     OPT_VIDEO_ENCODER,
@@ -859,6 +862,25 @@ static const struct sc_option options[] = {
                 "For example, to use either LCtrl or LSuper for scrcpy "
                 "shortcuts, pass \"lctrl,lsuper\".\n"
                 "Default is \"lalt,lsuper\" (left-Alt or left-Super).",
+    },
+    {
+        .longopt_id = OPT_SHORTCUT_KEY,
+        .longopt = "shortcut-key",
+        .argdesc = "action=key",
+        .text = "Override one keyboard shortcut key while preserving the "
+                "associated MOD/Shift/repeated-key behavior.\n"
+                "The option may be passed several times.\n"
+                "Supported actions are \"home\", \"back\", \"app-switch\", "
+                "\"menu\", \"power\", \"screen-power\", \"pause\", "
+                "\"volume-down\", \"volume-up\", \"rotate-left\", "
+                "\"rotate-right\", \"copy\", \"cut\", \"paste\", "
+                "\"fullscreen\", \"resize-to-fit\", \"pixel-perfect\", "
+                "\"fps-counter\", \"panels\", \"rotate-device\" and "
+                "\"open-keyboard-settings\".\n"
+                "Examples:\n"
+                "    --shortcut-key=home=j\n"
+                "    --shortcut-key=panels=comma\n"
+                "    --shortcut-key=rotate-left=a",
     },
     {
         .longopt_id = OPT_START_APP,
@@ -1934,6 +1956,190 @@ sc_parse_shortcut_mods(const char *s, uint8_t *mods) {
 }
 #endif
 
+struct sc_shortcut_key_option {
+    const char *action;
+    size_t action_len;
+    size_t offset;
+};
+
+static const struct sc_shortcut_key_option shortcut_key_options[] = {
+    { "home", 4, offsetof(struct sc_shortcut_key_bindings, home) },
+    { "back", 4, offsetof(struct sc_shortcut_key_bindings, back) },
+    { "app-switch", 10,
+      offsetof(struct sc_shortcut_key_bindings, app_switch) },
+    { "menu", 4, offsetof(struct sc_shortcut_key_bindings, menu) },
+    { "power", 5, offsetof(struct sc_shortcut_key_bindings, power) },
+    { "screen-power", 12,
+      offsetof(struct sc_shortcut_key_bindings, screen_power) },
+    { "pause", 5, offsetof(struct sc_shortcut_key_bindings, pause) },
+    { "volume-down", 11,
+      offsetof(struct sc_shortcut_key_bindings, volume_down) },
+    { "volume-up", 9, offsetof(struct sc_shortcut_key_bindings, volume_up) },
+    { "rotate-left", 11,
+      offsetof(struct sc_shortcut_key_bindings, rotate_left) },
+    { "rotate-right", 12,
+      offsetof(struct sc_shortcut_key_bindings, rotate_right) },
+    { "copy", 4, offsetof(struct sc_shortcut_key_bindings, copy) },
+    { "cut", 3, offsetof(struct sc_shortcut_key_bindings, cut) },
+    { "paste", 5, offsetof(struct sc_shortcut_key_bindings, paste) },
+    { "fullscreen", 10,
+      offsetof(struct sc_shortcut_key_bindings, fullscreen) },
+    { "resize-to-fit", 13,
+      offsetof(struct sc_shortcut_key_bindings, resize_to_fit) },
+    { "pixel-perfect", 13,
+      offsetof(struct sc_shortcut_key_bindings, pixel_perfect) },
+    { "fps-counter", 11,
+      offsetof(struct sc_shortcut_key_bindings, fps_counter) },
+    { "panels", 6, offsetof(struct sc_shortcut_key_bindings, panels) },
+    { "rotate-device", 13,
+      offsetof(struct sc_shortcut_key_bindings, rotate_device) },
+    { "open-keyboard-settings", 22,
+      offsetof(struct sc_shortcut_key_bindings, open_keyboard_settings) },
+};
+
+static int32_t *
+shortcut_key_option_target(struct sc_shortcut_key_bindings *bindings,
+                           const char *action, size_t action_len) {
+    for (size_t i = 0; i < ARRAY_LEN(shortcut_key_options); ++i) {
+        const struct sc_shortcut_key_option *opt = &shortcut_key_options[i];
+        if (opt->action_len == action_len
+                && !memcmp(opt->action, action, action_len)) {
+            return (int32_t *) ((char *) bindings + opt->offset);
+        }
+    }
+
+    return NULL;
+}
+
+static bool
+parse_shortcut_key_name(const char *name, SDL_Keycode *keycode) {
+#define STREQ(literal, s) (!strcmp(literal, s))
+    if (STREQ("comma", name)) {
+        *keycode = SDLK_COMMA;
+        return true;
+    }
+    if (STREQ("backspace", name)) {
+        *keycode = SDLK_BACKSPACE;
+        return true;
+    }
+    if (STREQ("left", name)) {
+        *keycode = SDLK_LEFT;
+        return true;
+    }
+    if (STREQ("right", name)) {
+        *keycode = SDLK_RIGHT;
+        return true;
+    }
+    if (STREQ("up", name)) {
+        *keycode = SDLK_UP;
+        return true;
+    }
+    if (STREQ("down", name)) {
+        *keycode = SDLK_DOWN;
+        return true;
+    }
+#undef STREQ
+
+    SDL_Keycode parsed = SDL_GetKeyFromName(name);
+    if (parsed == SDLK_UNKNOWN) {
+        return false;
+    }
+
+    *keycode = parsed;
+    return true;
+}
+
+static bool
+parse_shortcut_key(const char *s, struct sc_shortcut_key_bindings *bindings) {
+    const char *equal = strchr(s, '=');
+    if (!equal || equal == s || !equal[1]) {
+        LOGE("Could not parse shortcut key: %s (expected action=key)", s);
+        return false;
+    }
+
+    size_t action_len = (size_t) (equal - s);
+    int32_t *target =
+        shortcut_key_option_target(bindings, s, action_len);
+    if (!target) {
+        LOGE("Unknown shortcut action: %.*s", (int) action_len, s);
+        return false;
+    }
+
+    SDL_Keycode keycode;
+    if (!parse_shortcut_key_name(equal + 1, &keycode)) {
+        LOGE("Unknown shortcut key: %s", equal + 1);
+        return false;
+    }
+
+    *target = (int32_t) keycode;
+    return true;
+}
+
+static bool
+validate_shortcut_keys(const struct sc_shortcut_key_bindings *bindings) {
+    static const struct {
+        const char *name;
+        size_t offset;
+    } items[] = {
+        { "home", offsetof(struct sc_shortcut_key_bindings, home) },
+        { "back", offsetof(struct sc_shortcut_key_bindings, back) },
+        { "app-switch", offsetof(struct sc_shortcut_key_bindings, app_switch) },
+        { "menu", offsetof(struct sc_shortcut_key_bindings, menu) },
+        { "power", offsetof(struct sc_shortcut_key_bindings, power) },
+        { "screen-power",
+          offsetof(struct sc_shortcut_key_bindings, screen_power) },
+        { "pause", offsetof(struct sc_shortcut_key_bindings, pause) },
+        { "volume-down",
+          offsetof(struct sc_shortcut_key_bindings, volume_down) },
+        { "volume-up", offsetof(struct sc_shortcut_key_bindings, volume_up) },
+        { "rotate-left",
+          offsetof(struct sc_shortcut_key_bindings, rotate_left) },
+        { "rotate-right",
+          offsetof(struct sc_shortcut_key_bindings, rotate_right) },
+        { "copy", offsetof(struct sc_shortcut_key_bindings, copy) },
+        { "cut", offsetof(struct sc_shortcut_key_bindings, cut) },
+        { "paste", offsetof(struct sc_shortcut_key_bindings, paste) },
+        { "fullscreen", offsetof(struct sc_shortcut_key_bindings, fullscreen) },
+        { "resize-to-fit",
+          offsetof(struct sc_shortcut_key_bindings, resize_to_fit) },
+        { "pixel-perfect",
+          offsetof(struct sc_shortcut_key_bindings, pixel_perfect) },
+        { "fps-counter",
+          offsetof(struct sc_shortcut_key_bindings, fps_counter) },
+        { "panels", offsetof(struct sc_shortcut_key_bindings, panels) },
+        { "rotate-device",
+          offsetof(struct sc_shortcut_key_bindings, rotate_device) },
+        { "open-keyboard-settings",
+          offsetof(struct sc_shortcut_key_bindings, open_keyboard_settings) },
+    };
+
+    for (size_t i = 0; i < ARRAY_LEN(items); ++i) {
+        int32_t keycode = *(const int32_t *) ((const char *) bindings
+                                             + items[i].offset);
+        if (keycode == SDLK_BACKSPACE && strcmp(items[i].name, "back")) {
+            LOGE("Shortcut key conflict: \"%s\" cannot use \"Backspace\" "
+                 "because it is reserved for BACK", items[i].name);
+            return false;
+        }
+    }
+
+    for (size_t i = 0; i < ARRAY_LEN(items); ++i) {
+        int32_t lhs = *(const int32_t *) ((const char *) bindings
+                                         + items[i].offset);
+        for (size_t j = i + 1; j < ARRAY_LEN(items); ++j) {
+            int32_t rhs = *(const int32_t *) ((const char *) bindings
+                                             + items[j].offset);
+            if (lhs == rhs) {
+                LOGE("Shortcut key conflict: \"%s\" and \"%s\" both use \"%s\"",
+                     items[i].name, items[j].name, SDL_GetKeyName(lhs));
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
 static enum sc_record_format
 get_record_format(const char *name) {
     if (!strcmp(name, "mp4")) {
@@ -2697,6 +2903,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                     return false;
                 }
                 break;
+            case OPT_SHORTCUT_KEY:
+                if (!parse_shortcut_key(optarg, &opts->shortcut_keys)) {
+                    return false;
+                }
+                break;
             case OPT_LEGACY_PASTE:
                 opts->legacy_paste = true;
                 break;
@@ -2926,6 +3137,10 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     int index = optind;
     if (index < argc) {
         LOGE("Unexpected additional argument: %s", argv[index]);
+        return false;
+    }
+
+    if (!validate_shortcut_keys(&opts->shortcut_keys)) {
         return false;
     }
 

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -599,6 +599,13 @@ sc_input_manager_process_key(struct sc_input_manager *im,
             return;
         }
 
+        // If the key itself is a shortcut modifier (e.g., the Win key when
+        // Super is a shortcut modifier), do not forward it to the device,
+        // since it is consumed as a modifier for scrcpy shortcuts.
+        if (sc_shortcut_mods_is_shortcut_key(im->sdl_shortcut_mods,
+                                             sdl_keycode)) {
+            return;
+        }
     }
 
     if (!im->kp || paused) {

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -305,43 +305,6 @@ reset_video(struct sc_input_manager *im) {
 }
 
 static void
-camera_set_torch(struct sc_input_manager *im, bool on) {
-    assert(im->controller && im->camera);
-
-    struct sc_control_msg msg;
-    msg.type = SC_CONTROL_MSG_TYPE_CAMERA_SET_TORCH;
-    msg.camera_set_torch.on = on;
-
-    if (!sc_controller_push_msg(im->controller, &msg)) {
-        LOGW("Could not request setting camera torch");
-    }
-}
-
-static void
-camera_zoom_in(struct sc_input_manager *im) {
-    assert(im->controller && im->camera);
-
-    struct sc_control_msg msg;
-    msg.type = SC_CONTROL_MSG_TYPE_CAMERA_ZOOM_IN;
-
-    if (!sc_controller_push_msg(im->controller, &msg)) {
-        LOGW("Could not request camera zoom in");
-    }
-}
-
-static void
-camera_zoom_out(struct sc_input_manager *im) {
-    assert(im->controller && im->camera);
-
-    struct sc_control_msg msg;
-    msg.type = SC_CONTROL_MSG_TYPE_CAMERA_ZOOM_OUT;
-
-    if (!sc_controller_push_msg(im->controller, &msg)) {
-        LOGW("Could not request camera zoom out");
-    }
-}
-
-static void
 apply_orientation_transform(struct sc_input_manager *im,
                             enum sc_orientation transform) {
     struct sc_screen *screen = im->screen;
@@ -423,7 +386,7 @@ sc_input_manager_process_key(struct sc_input_manager *im,
     bool video = im->screen->video;
     bool disconnected = im->disconnected;
 
-    SDL_Keycode sdl_keycode = event->key;
+    int32_t sdl_keycode = (int32_t) event->key;
     uint16_t mod = event->mod;
     bool down = event->type == SDL_EVENT_KEY_DOWN;
     bool ctrl = event->mod & SDL_KMOD_CTRL;
@@ -439,7 +402,7 @@ sc_input_manager_process_key(struct sc_input_manager *im,
                     || sc_shortcut_mods_is_shortcut_key(mods, sdl_keycode);
 
     if (down && !repeat && !disconnected) {
-        if (sdl_keycode == im->last_keycode && mod == im->last_mod) {
+        if (sdl_keycode == (int32_t) im->last_keycode && mod == im->last_mod) {
             ++im->key_repeat;
         } else {
             im->key_repeat = 0;

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -35,6 +35,7 @@ sc_input_manager_init(struct sc_input_manager *im,
     im->clipboard_autosync = params->clipboard_autosync;
 
     im->sdl_shortcut_mods = sc_shortcut_mods_to_sdl(params->shortcut_mods);
+    im->shortcut_keys = params->shortcut_keys;
 
     im->vfinger_down = false;
     im->vfinger_invert_x = false;
@@ -462,213 +463,179 @@ sc_input_manager_process_key(struct sc_input_manager *im,
 
     if (is_shortcut) {
         enum sc_action action = down ? SC_ACTION_DOWN : SC_ACTION_UP;
-        switch (sdl_keycode) {
-            case SDLK_Z:
-                if (video && down && !repeat) {
-                    sc_screen_set_paused(im->screen, !shift);
-                }
-                return;
-            case SDLK_DOWN:
-                // Only capture if shift is set
-                if (shift) {
-                    if (video && !repeat && down) {
-                        apply_orientation_transform(im,
-                                                    SC_ORIENTATION_FLIP_180);
-                    }
-                    return;
-                }
-                break;
-            case SDLK_UP:
-                // Only capture if shift is set
-                if (shift) {
-                    if (video && !repeat && down) {
-                        apply_orientation_transform(im, SC_ORIENTATION_FLIP_180);
-                    }
-                    return;
-                }
-                break;
-            case SDLK_LEFT:
-                if (video && !repeat && down) {
-                    if (shift) {
-                        apply_orientation_transform(im, SC_ORIENTATION_FLIP_0);
-                    } else {
-                        apply_orientation_transform(im, SC_ORIENTATION_270);
-                    }
-                }
-                return;
-            case SDLK_RIGHT:
-                if (video && !repeat && down) {
-                    if (shift) {
-                        apply_orientation_transform(im, SC_ORIENTATION_FLIP_0);
-                    } else {
-                        apply_orientation_transform(im, SC_ORIENTATION_90);
-                    }
-                }
-                return;
-            case SDLK_F:
-                if (video && !shift && !repeat && down) {
-                    sc_screen_toggle_fullscreen(im->screen);
-                }
-                return;
-            case SDLK_W:
-                if (video && !shift && !repeat && down) {
-                    sc_screen_resize_to_fit(im->screen);
-                }
-                return;
-            case SDLK_G:
-                if (video && !shift && !repeat && down) {
-                    sc_screen_resize_to_pixel_perfect(im->screen);
-                }
-                return;
-            case SDLK_I:
-                if (video && !shift && !repeat && down) {
-                    switch_fps_counter_state(im);
-                }
-                return;
-            case SDLK_Q:
-                sc_push_event(SDL_EVENT_QUIT);
-                return;
-        }
+        const struct sc_shortcut_key_bindings *keys = &im->shortcut_keys;
 
-        if (disconnected) {
-            // Only handle shortcuts that do not interact with the device (since
-            // it is disconnected)
+        if (sdl_keycode == keys->home) {
+            if (im->kp && !shift && !repeat && !paused) {
+                action_home(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->back || sdl_keycode == SDLK_BACKSPACE) {
+            if (im->kp && !shift && !repeat && !paused) {
+                action_back(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->app_switch) {
+            if (im->kp && !shift && !repeat && !paused) {
+                action_app_switch(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->menu) {
+            if (im->kp && !shift && !repeat && !paused) {
+                action_menu(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->power) {
+            if (im->kp && !shift && !repeat && !paused) {
+                action_power(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->screen_power) {
+            if (control && !repeat && down && !paused) {
+                bool on = shift;
+                set_display_power(im, on);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->pause) {
+            if (video && down && !repeat) {
+                sc_screen_set_paused(im->screen, !shift);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->volume_down) {
+            if (shift) {
+                if (video && !repeat && down) {
+                    apply_orientation_transform(im,
+                                                SC_ORIENTATION_FLIP_180);
+                }
+            } else if (im->kp && !paused) {
+                // forward repeated events
+                action_volume_down(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->volume_up) {
+            if (shift) {
+                if (video && !repeat && down) {
+                    apply_orientation_transform(im,
+                                                SC_ORIENTATION_FLIP_180);
+                }
+            } else if (im->kp && !paused) {
+                // forward repeated events
+                action_volume_up(im, action);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->rotate_left) {
+            if (video && !repeat && down) {
+                if (shift) {
+                    apply_orientation_transform(im,
+                                                SC_ORIENTATION_FLIP_0);
+                } else {
+                    apply_orientation_transform(im,
+                                                SC_ORIENTATION_270);
+                }
+            }
+            return;
+        }
+        if (sdl_keycode == keys->rotate_right) {
+            if (video && !repeat && down) {
+                if (shift) {
+                    apply_orientation_transform(im,
+                                                SC_ORIENTATION_FLIP_0);
+                } else {
+                    apply_orientation_transform(im,
+                                                SC_ORIENTATION_90);
+                }
+            }
+            return;
+        }
+        if (sdl_keycode == keys->copy) {
+            if (im->kp && !shift && !repeat && down && !paused) {
+                get_device_clipboard(im, SC_COPY_KEY_COPY);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->cut) {
+            if (im->kp && !shift && !repeat && down && !paused) {
+                get_device_clipboard(im, SC_COPY_KEY_CUT);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->paste) {
+            if (im->kp && !repeat && down && !paused) {
+                if (shift || im->legacy_paste) {
+                    // inject the text as input events
+                    clipboard_paste(im);
+                } else {
+                    // store the text in the device clipboard and paste,
+                    // without requesting an acknowledgment
+                    set_device_clipboard(im, true, SC_SEQUENCE_INVALID);
+                }
+            }
+            return;
+        }
+        if (sdl_keycode == keys->fullscreen) {
+            if (video && !shift && !repeat && down) {
+                sc_screen_toggle_fullscreen(im->screen);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->resize_to_fit) {
+            if (video && !shift && !repeat && down) {
+                sc_screen_resize_to_fit(im->screen);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->pixel_perfect) {
+            if (video && !shift && !repeat && down) {
+                sc_screen_resize_to_pixel_perfect(im->screen);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->fps_counter) {
+            if (video && !shift && !repeat && down) {
+                switch_fps_counter_state(im);
+            }
+            return;
+        }
+        if (sdl_keycode == keys->panels) {
+            if (control && !repeat && down && !paused) {
+                if (shift) {
+                    collapse_panels(im);
+                } else if (im->key_repeat == 0) {
+                    expand_notification_panel(im);
+                } else {
+                    expand_settings_panel(im);
+                }
+            }
+            return;
+        }
+        if (sdl_keycode == keys->rotate_device) {
+            if (control && !repeat && down && !paused) {
+                if (shift) {
+                    reset_video(im);
+                } else {
+                    rotate_device(im);
+                }
+            }
+            return;
+        }
+        if (sdl_keycode == keys->open_keyboard_settings) {
+            if (control && !shift && !repeat && down && !paused
+                    && im->kp && im->kp->hid) {
+                // Only if the current keyboard is hid
+                open_hard_keyboard_settings(im);
+            }
             return;
         }
 
-        // Flatten conditions to avoid additional indentation levels
-        if (control) {
-            // Controls for all sources
-            switch (sdl_keycode) {
-                case SDLK_R:
-                    // Only capture if shift is set
-                    if (shift) {
-                        if (!repeat && down && !paused) {
-                            reset_video(im);
-                        }
-                        return;
-                    }
-                    break;
-            }
-        }
-
-        if (control && !im->camera) {
-            switch (sdl_keycode) {
-                case SDLK_H:
-                    if (im->kp && !shift && !repeat && !paused) {
-                        action_home(im, action);
-                    }
-                    return;
-                case SDLK_B: // fall-through
-                case SDLK_BACKSPACE:
-                    if (im->kp && !shift && !repeat && !paused) {
-                        action_back(im, action);
-                    }
-                    return;
-                case SDLK_S:
-                    if (im->kp && !shift && !repeat && !paused) {
-                        action_app_switch(im, action);
-                    }
-                    return;
-                case SDLK_M:
-                    if (im->kp && !shift && !repeat && !paused) {
-                        action_menu(im, action);
-                    }
-                    return;
-                case SDLK_P:
-                    if (im->kp && !shift && !repeat && !paused) {
-                        action_power(im, action);
-                    }
-                    return;
-                case SDLK_O:
-                    if (control && !repeat && down && !paused) {
-                        bool on = shift;
-                        set_display_power(im, on);
-                    }
-                    return;
-                case SDLK_DOWN:
-                    if (im->kp && !shift && !paused) {
-                        // forward repeated events
-                        action_volume_down(im, action);
-                    }
-                    return;
-                case SDLK_UP:
-                    if (im->kp && !shift && !paused) {
-                        // forward repeated events
-                        action_volume_up(im, action);
-                    }
-                    return;
-                case SDLK_C:
-                    if (im->kp && !shift && !repeat && down && !paused) {
-                        get_device_clipboard(im, SC_COPY_KEY_COPY);
-                    }
-                    return;
-                case SDLK_X:
-                    if (im->kp && !shift && !repeat && down && !paused) {
-                        get_device_clipboard(im, SC_COPY_KEY_CUT);
-                    }
-                    return;
-                case SDLK_V:
-                    if (im->kp && !repeat && down && !paused) {
-                        if (shift || im->legacy_paste) {
-                            // inject the text as input events
-                            clipboard_paste(im);
-                        } else {
-                            // store the text in the device clipboard and paste,
-                            // without requesting an acknowledgment
-                            set_device_clipboard(im, true, SC_SEQUENCE_INVALID);
-                        }
-                    }
-                    return;
-                case SDLK_N:
-                    if (!repeat && down && !paused) {
-                        if (shift) {
-                            collapse_panels(im);
-                        } else if (im->key_repeat == 0) {
-                            expand_notification_panel(im);
-                        } else {
-                            expand_settings_panel(im);
-                        }
-                    }
-                    return;
-                case SDLK_R:
-                    if (!repeat && !shift && down && !paused) {
-                        rotate_device(im);
-                    }
-                    return;
-                case SDLK_K:
-                    if (!shift && !repeat && down && !paused
-                            && im->kp && im->kp->hid) {
-                        // Only if the current keyboard is hid
-                        open_hard_keyboard_settings(im);
-                    }
-                    return;
-            }
-        }
-
-        if (control && im->camera) {
-            switch (sdl_keycode) {
-                case SDLK_T:
-                    if (!repeat && down) {
-                        camera_set_torch(im, !shift);
-                    }
-                    return;
-                case SDLK_DOWN:
-                    if (!shift && down && !paused) {
-                        // forward repeated events
-                        camera_zoom_out(im);
-                    }
-                    return;
-                case SDLK_UP:
-                    if (!shift && down && !paused) {
-                        // forward repeated events
-                        camera_zoom_in(im);
-                    }
-                    return;
-            }
-        }
-
-        return;
     }
 
     if (!im->kp || paused) {

--- a/app/src/input_manager.h
+++ b/app/src/input_manager.h
@@ -31,6 +31,7 @@ struct sc_input_manager {
     bool clipboard_autosync;
 
     uint16_t sdl_shortcut_mods;
+    struct sc_shortcut_key_bindings shortcut_keys;
 
     bool vfinger_down;
     bool vfinger_invert_x;
@@ -63,6 +64,7 @@ struct sc_input_manager_params {
     bool legacy_paste;
     bool clipboard_autosync;
     uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
+    struct sc_shortcut_key_bindings shortcut_keys;
 };
 
 void

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -1,6 +1,7 @@
 #include "options.h"
 
 #include <stddef.h>
+#include <SDL3/SDL_keycode.h>
 
 const struct scrcpy_options scrcpy_options_default = {
     .serial = NULL,
@@ -49,6 +50,29 @@ const struct scrcpy_options scrcpy_options_default = {
     .tunnel_host = 0,
     .tunnel_port = 0,
     .shortcut_mods = SC_SHORTCUT_MOD_LALT | SC_SHORTCUT_MOD_LSUPER,
+    .shortcut_keys = {
+        .home = SDLK_H,
+        .back = SDLK_B,
+        .app_switch = SDLK_S,
+        .menu = SDLK_M,
+        .power = SDLK_P,
+        .screen_power = SDLK_O,
+        .pause = SDLK_Z,
+        .volume_down = SDLK_DOWN,
+        .volume_up = SDLK_UP,
+        .rotate_left = SDLK_LEFT,
+        .rotate_right = SDLK_RIGHT,
+        .copy = SDLK_C,
+        .cut = SDLK_X,
+        .paste = SDLK_V,
+        .fullscreen = SDLK_F,
+        .resize_to_fit = SDLK_W,
+        .pixel_perfect = SDLK_G,
+        .fps_counter = SDLK_I,
+        .panels = SDLK_N,
+        .rotate_device = SDLK_R,
+        .open_keyboard_settings = SDLK_K,
+    },
     .min_size_alignment = 1,
     .max_size = 0,
     .video_bit_rate = 0,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -232,6 +232,30 @@ struct sc_port_range {
     uint16_t last;
 };
 
+struct sc_shortcut_key_bindings {
+    int32_t home;
+    int32_t back;
+    int32_t app_switch;
+    int32_t menu;
+    int32_t power;
+    int32_t screen_power;
+    int32_t pause;
+    int32_t volume_down;
+    int32_t volume_up;
+    int32_t rotate_left;
+    int32_t rotate_right;
+    int32_t copy;
+    int32_t cut;
+    int32_t paste;
+    int32_t fullscreen;
+    int32_t resize_to_fit;
+    int32_t pixel_perfect;
+    int32_t fps_counter;
+    int32_t panels;
+    int32_t rotate_device;
+    int32_t open_keyboard_settings;
+};
+
 #define SC_WINDOW_POSITION_UNDEFINED (-0x8000)
 
 struct scrcpy_options {
@@ -265,6 +289,7 @@ struct scrcpy_options {
     uint32_t tunnel_host;
     uint16_t tunnel_port;
     uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
+    struct sc_shortcut_key_bindings shortcut_keys;
     uint8_t min_size_alignment;
     uint16_t max_size;
     uint32_t video_bit_rate;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -746,6 +746,7 @@ aoa_complete:
             .legacy_paste = options->legacy_paste,
             .clipboard_autosync = options->clipboard_autosync,
             .shortcut_mods = options->shortcut_mods,
+            .shortcut_keys = options->shortcut_keys,
             .window_title = window_title,
             .always_on_top = options->always_on_top,
             .window_x = options->window_x,

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -658,6 +658,7 @@ sc_screen_init(struct sc_screen *screen,
         .legacy_paste = params->legacy_paste,
         .clipboard_autosync = params->clipboard_autosync,
         .shortcut_mods = params->shortcut_mods,
+        .shortcut_keys = params->shortcut_keys,
     };
 
     sc_input_manager_init(&screen->im, &im_params);

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -124,6 +124,7 @@ struct sc_screen_params {
     bool legacy_paste;
     bool clipboard_autosync;
     uint8_t shortcut_mods; // OR of enum sc_shortcut_mod values
+    struct sc_shortcut_key_bindings shortcut_keys;
 
     const char *window_title;
     bool always_on_top;

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <string.h>
+#include <SDL3/SDL_keycode.h>
 
 #include "cli.h"
 #include "options.h"
@@ -149,6 +150,47 @@ static void test_parse_shortcut_mods(void) {
     assert(!ok);
 }
 
+static void test_shortcut_key_options(void) {
+    struct scrcpy_cli_args args = {
+        .opts = scrcpy_options_default,
+        .help = false,
+        .version = false,
+    };
+
+    char *argv[] = {
+        "scrcpy",
+        "--shortcut-key=home=j",
+        "--shortcut-key=panels=comma",
+        "--shortcut-key=rotate-left=a",
+    };
+
+    bool ok = scrcpy_parse_args(&args, ARRAY_LEN(argv), argv);
+    assert(ok);
+
+    const struct sc_shortcut_key_bindings *keys = &args.opts.shortcut_keys;
+    assert(keys->home == SDLK_J);
+    assert(keys->panels == SDLK_COMMA);
+    assert(keys->rotate_left == SDLK_A);
+    assert(keys->fullscreen == SDLK_F);
+}
+
+static void test_shortcut_key_conflict(void) {
+    struct scrcpy_cli_args args = {
+        .opts = scrcpy_options_default,
+        .help = false,
+        .version = false,
+    };
+
+    char *argv[] = {
+        "scrcpy",
+        "--shortcut-key=home=j",
+        "--shortcut-key=back=j",
+    };
+
+    bool ok = scrcpy_parse_args(&args, ARRAY_LEN(argv), argv);
+    assert(!ok);
+}
+
 int main(int argc, char *argv[]) {
     (void) argc;
     (void) argv;
@@ -158,5 +200,7 @@ int main(int argc, char *argv[]) {
     test_options();
     test_options2();
     test_parse_shortcut_mods();
+    test_shortcut_key_options();
+    test_shortcut_key_conflict();
     return 0;
 }

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -17,6 +17,17 @@ scrcpy --shortcut-mod=rctrl
 scrcpy --shortcut-mod=lctrl,lsuper
 ```
 
+Individual shortcut keys can also be overridden with
+`--shortcut-key=action=key`. For example:
+
+```bash
+# use MOD+j for HOME instead of MOD+h
+scrcpy --shortcut-key=home=j
+
+# use MOD+, / MOD+Shift+, / MOD+,, for the panel shortcuts
+scrcpy --shortcut-key=panels=comma
+```
+
 _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
 
 [Super]: https://en.wikipedia.org/wiki/Super_key_(keyboard_button)


### PR DESCRIPTION
Introduce a new CLI option `--shortcut-key=action=key` that allows users
to override individual shortcut keys (e.g., `--shortcut-key=paste=d`,
`--shortcut-key=home=j`). This also solves the issue where shortcut keys
conflict with app shortcuts like Gboard's Alt+V — since an unmatched key
now falls through to the device instead of being swallowed by the catch-all
return.

Changes:
- Add `struct sc_shortcut_key_bindings` in options.h with per-action key fields
- Set default bindings in options.c matching the original hardcoded values
- Convert the large switch statement in input_manager.c to a chain of
  `if (sdl_keycode == keys->xxx)` blocks via `sc_shortcut_key_bindings`
- Remove the catch-all `return;` so unrecognized shortcut keys pass through
  to the device
- Add `--shortcut-key` parsing in cli.c with conflict detection
- Add tests in test_cli.c for the new option
- Update documentation in shortcuts.md and shell completions
