### PR TITLE
Fix initial gamepad open with SDL joystick IDs

### DIFF
--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -1048,7 +1048,7 @@ sc_input_manager_process_gamepad_device(struct sc_input_manager *im,
     if (event->type == SDL_EVENT_GAMEPAD_ADDED) {
         SDL_Gamepad *sdl_gamepad = SDL_OpenGamepad(event->which);
         if (!sdl_gamepad) {
-            LOGW("Could not open gamepad");
+            LOGW("Could not open gamepad: %s", SDL_GetError());
             return;
         }
 

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -296,7 +296,7 @@ init_sdl_gamepads(void) {
         if (SDL_IsGamepad(joystick)) {
             SDL_Event event;
             event.gdevice.type = SDL_EVENT_GAMEPAD_ADDED;
-            event.gdevice.which = i;
+            event.gdevice.which = joystick;
             SDL_PushEvent(&event);
         }
     }


### PR DESCRIPTION
`SDL_GetJoysticks()` returns `SDL_JoystickID` values, but the initial gamepad-added event used the loop index as event.gdevice.which.

When joystick IDs differ from their array index, scrcpy may try to open the wrong device at startup, causing `SDL_OpenGamepad()` to fail with errors like "Couldn't find mapping for device (0)".

Use the actual `SDL_JoystickID` when pushing the synthetic `SDL_EVENT_GAMEPAD_ADDED` event.