### PR TITLE
Fix AbstractMethodError on Android 16 (IDisplayWindowListener)

### DIFF
--- a/server/src/main/aidl/android/view/IDisplayWindowListener.aidl
+++ b/server/src/main/aidl/android/view/IDisplayWindowListener.aidl
@@ -48,4 +48,9 @@ oneway interface IDisplayWindowListener {
      * Called when a display is removed from the hierarchy.
      */
     void onDisplayRemoved(int displayId);
+
+    /**
+     * Called when display animations disabled state changes (added in Android 16).
+     */
+    void onDisplayAnimationsDisabledChanged(int displayId, boolean disabled);
 }

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayWindowListener.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayWindowListener.java
@@ -24,6 +24,11 @@ public class DisplayWindowListener extends IDisplayWindowListener.Stub {
     }
 
     @Override
+    public void onDisplayAnimationsDisabledChanged(int displayId, boolean disabled) {
+        // empty default implementation for Android 16+
+    }
+
+    @Override
     public boolean onTransact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
         try {
             return super.onTransact(code, data, reply, flags);


### PR DESCRIPTION
Android 16 added onDisplayAnimationsDisabledChanged(int, boolean) to IDisplayWindowListener. Without an implementation, the binder dispatches to an abstract method and throws AbstractMethodError, crashing the server.

Add the method to the AIDL stub and provide an empty implementation in DisplayWindowListener to keep it compatible with Android 16+.

Tested on Pixel 6 Pro (Android 16).