### PR TITLE
fix(audio): separate --no-audio-playback from audio capture

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -2977,11 +2977,6 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         opts->video = false;
     }
 
-    if (opts->audio && !opts->audio_playback && !opts->record_filename) {
-        LOGI("No audio playback, no recording: audio disabled");
-        opts->audio = false;
-    }
-
     if (!opts->video && !opts->audio && !opts->control && !otg) {
         LOGE("No video, no audio, no control, no OTG: nothing to do");
         return false;


### PR DESCRIPTION
Fixes #6846. When --no-audio-playback is specified, only local playback should be disabled - audio capture must still function for use cases like AI processing.