### PR TITLE
Add Keywords to desktop entries

### DIFF
--- a/app/data/scrcpy-console.desktop
+++ b/app/data/scrcpy-console.desktop
@@ -10,4 +10,5 @@ Icon=scrcpy
 Terminal=true
 Type=Application
 Categories=Utility;RemoteAccess;
+Keywords=adb;android;screen;mirroring;display;control;phone;device;console;
 StartupNotify=false

--- a/app/data/scrcpy.desktop
+++ b/app/data/scrcpy.desktop
@@ -10,4 +10,5 @@ Icon=scrcpy
 Terminal=false
 Type=Application
 Categories=Utility;RemoteAccess;
+Keywords=adb;android;screen;mirroring;display;control;phone;device;
 StartupNotify=false


### PR DESCRIPTION
Add search keywords to the .desktop files so users can find scrcpy more easily in application launchers.