### PR TITLE
Add keyboard shortcuts for scrolling

### DIFF
--- a/app/meson.build
+++ b/app/meson.build
@@ -22,6 +22,7 @@ src = [
     'src/fps_counter.c',
     'src/frame_buffer.c',
     'src/input_manager.c',
+    'src/keyboard_shortcuts.c',
     'src/keyboard_sdk.c',
     'src/mouse_capture.c',
     'src/mouse_sdk.c',
@@ -260,6 +261,10 @@ if get_option('buildtype') == 'debug'
             'src/control_msg.c',
             'src/util/str.c',
             'src/util/strbuf.c',
+        ]],
+        ['test_keyboard_shortcuts', [
+            'tests/test_keyboard_shortcuts.c',
+            'src/keyboard_shortcuts.c',
         ]],
         ['test_device_msg_deserialize', [
             'tests/test_device_msg_deserialize.c',

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -1125,6 +1125,14 @@ static const struct sc_shortcut shortcuts[] = {
         .text = "Click on VOLUME_DOWN",
     },
     {
+        .shortcuts = { "MOD+PageUp" },
+        .text = "Scroll up",
+    },
+    {
+        .shortcuts = { "MOD+PageDown" },
+        .text = "Scroll down",
+    },
+    {
         .shortcuts = { "MOD+p" },
         .text = "Click on POWER (turn screen on/off)",
     },

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -9,6 +9,7 @@
 #include "android/keycodes.h"
 #include "events.h"
 #include "input_events.h"
+#include "keyboard_shortcuts.h"
 #include "screen.h"
 #include "shortcut_mod.h"
 #include "util/log.h"
@@ -411,6 +412,10 @@ inverse_point(struct sc_point point, struct sc_size size,
 }
 
 static void
+sc_input_manager_process_keyboard_scroll(struct sc_input_manager *im,
+                                         float hscroll, float vscroll);
+
+static void
 sc_input_manager_process_key(struct sc_input_manager *im,
                              const SDL_KeyboardEvent *event) {
     // some key events do not interact with the device, so process the event
@@ -596,6 +601,22 @@ sc_input_manager_process_key(struct sc_input_manager *im,
                     if (im->kp && !shift && !paused) {
                         // forward repeated events
                         action_volume_up(im, action);
+                    }
+                    return;
+                case SDLK_PAGEUP:
+                case SDLK_PAGEDOWN:
+                    if (down && !paused) {
+                        float hscroll;
+                        float vscroll;
+                        bool ok = sc_keyboard_shortcut_to_scroll(sdl_keycode,
+                                                                 shift,
+                                                                 &hscroll,
+                                                                 &vscroll);
+                        if (ok) {
+                            sc_input_manager_process_keyboard_scroll(im,
+                                                                     hscroll,
+                                                                     vscroll);
+                        }
                     }
                     return;
                 case SDLK_C:
@@ -1030,6 +1051,28 @@ sc_input_manager_process_mouse_wheel(struct sc_input_manager *im,
         .position = sc_input_manager_get_position(im, mouse_x, mouse_y),
         .hscroll = event->x,
         .vscroll = event->y,
+        .buttons_state = im->mouse_buttons_state,
+    };
+
+    im->mp->ops->process_mouse_scroll(im->mp, &evt);
+}
+
+static void
+sc_input_manager_process_keyboard_scroll(struct sc_input_manager *im,
+                                         float hscroll, float vscroll) {
+    if (!im->mp || !im->mp->ops->process_mouse_scroll) {
+        return;
+    }
+
+    float mouse_x;
+    float mouse_y;
+    uint32_t buttons = SDL_GetMouseState(&mouse_x, &mouse_y);
+    (void) buttons; // Actual buttons are tracked manually to ignore shortcuts
+
+    struct sc_mouse_scroll_event evt = {
+        .position = sc_input_manager_get_position(im, mouse_x, mouse_y),
+        .hscroll = hscroll,
+        .vscroll = vscroll,
         .buttons_state = im->mouse_buttons_state,
     };
 

--- a/app/src/keyboard_shortcuts.c
+++ b/app/src/keyboard_shortcuts.c
@@ -1,0 +1,27 @@
+#include "keyboard_shortcuts.h"
+
+#include <assert.h>
+
+bool
+sc_keyboard_shortcut_to_scroll(SDL_Keycode keycode, bool shift,
+                               float *hscroll, float *vscroll) {
+    assert(hscroll);
+    assert(vscroll);
+
+    if (shift) {
+        return false;
+    }
+
+    *hscroll = 0.0f;
+
+    switch (keycode) {
+        case SDLK_PAGEUP:
+            *vscroll = 1.0f;
+            return true;
+        case SDLK_PAGEDOWN:
+            *vscroll = -1.0f;
+            return true;
+        default:
+            return false;
+    }
+}

--- a/app/src/keyboard_shortcuts.h
+++ b/app/src/keyboard_shortcuts.h
@@ -1,0 +1,11 @@
+#ifndef SC_KEYBOARD_SHORTCUTS_H
+#define SC_KEYBOARD_SHORTCUTS_H
+
+#include <stdbool.h>
+#include <SDL3/SDL_keycode.h>
+
+bool
+sc_keyboard_shortcut_to_scroll(SDL_Keycode keycode, bool shift,
+                               float *hscroll, float *vscroll);
+
+#endif

--- a/app/tests/test_keyboard_shortcuts.c
+++ b/app/tests/test_keyboard_shortcuts.c
@@ -1,0 +1,43 @@
+#include <assert.h>
+#include <stdbool.h>
+
+#include "keyboard_shortcuts.h"
+
+static void
+test_page_up_down_scroll_shortcuts(void) {
+    float hscroll;
+    float vscroll;
+
+    bool ok = sc_keyboard_shortcut_to_scroll(SDLK_PAGEUP, false,
+                                             &hscroll, &vscroll);
+    assert(ok);
+    assert(hscroll == 0.0f);
+    assert(vscroll == 1.0f);
+
+    ok = sc_keyboard_shortcut_to_scroll(SDLK_PAGEDOWN, false,
+                                        &hscroll, &vscroll);
+    assert(ok);
+    assert(hscroll == 0.0f);
+    assert(vscroll == -1.0f);
+}
+
+static void
+test_scroll_shortcuts_ignore_shift(void) {
+    float hscroll;
+    float vscroll;
+
+    bool ok = sc_keyboard_shortcut_to_scroll(SDLK_PAGEUP, true,
+                                             &hscroll, &vscroll);
+    assert(!ok);
+
+    ok = sc_keyboard_shortcut_to_scroll(SDLK_PAGEDOWN, true,
+                                        &hscroll, &vscroll);
+    assert(!ok);
+}
+
+int
+main(void) {
+    test_page_up_down_scroll_shortcuts();
+    test_scroll_shortcuts_ignore_shift();
+    return 0;
+}

--- a/doc/shortcuts.md
+++ b/doc/shortcuts.md
@@ -40,6 +40,8 @@ _<kbd>[Super]</kbd> is typically the <kbd>Windows</kbd> or <kbd>Cmd</kbd> key._
  | Click on `MENU` (unlock screen)⁴            | <kbd>MOD</kbd>+<kbd>m</kbd>
  | Click on `VOLUME_UP`                        | <kbd>MOD</kbd>+<kbd>↑</kbd> _(up)_
  | Click on `VOLUME_DOWN`                      | <kbd>MOD</kbd>+<kbd>↓</kbd> _(down)_
+ | Scroll up                                   | <kbd>MOD</kbd>+<kbd>PageUp</kbd>
+ | Scroll down                                 | <kbd>MOD</kbd>+<kbd>PageDown</kbd>
  | Click on `POWER`                            | <kbd>MOD</kbd>+<kbd>p</kbd>
  | Power on                                    | _Right-click²_
  | Turn device screen off (keep mirroring)     | <kbd>MOD</kbd>+<kbd>o</kbd>


### PR DESCRIPTION
## Summary

- add MOD+PageUp and MOD+PageDown shortcuts to inject vertical scroll events
- document the new shortcuts in CLI help and shortcuts.md
- add a focused unit test for the keyboard shortcut to scroll mapping

Fixes #6891

## Validation

- RED: `cc -Iapp/src app/tests/test_keyboard_shortcuts.c -o build-test-keyboard-shortcuts` failed with `fatal error: 'keyboard_shortcuts.h' file not found`
- GREEN: focused compile/run with a temporary SDL keycode stub passed:
  `cc -I"$tmpdir" -Iapp/src app/tests/test_keyboard_shortcuts.c app/src/keyboard_shortcuts.c -o "$tmpdir/test_keyboard_shortcuts" && "$tmpdir/test_keyboard_shortcuts"`
- `git diff --check`

Full Meson build was not run locally because this environment lacks `meson` and the required SDL3/FFmpeg pkg-config dependencies.
