### PR TITLE
Add voice communication playback capture option

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -8,6 +8,7 @@ _scrcpy() {
         --audio-codec=
         --audio-codec-options=
         --audio-dup
+        --audio-playback-capture-voice
         --audio-encoder=
         --audio-source=
         --audio-output-buffer=

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -60,6 +60,12 @@ Duplicate audio (capture and keep playing on the device).
 This feature is only available with --audio-source=playback.
 
 .TP
+.B \-\-audio\-playback\-capture\-voice
+Also capture voice communication playback audio.
+
+This feature is only available with --audio-source=playback and requires device support and permission.
+
+.TP
 .BI "\-\-audio\-encoder " name
 Use a specific MediaCodec audio encoder (depending on the codec provided by \fB\-\-audio\-codec\fR).
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -92,6 +92,7 @@ enum {
     OPT_MOUSE_BIND,
     OPT_NO_MOUSE_HOVER,
     OPT_AUDIO_DUP,
+    OPT_AUDIO_PLAYBACK_CAPTURE_VOICE,
     OPT_GAMEPAD,
     OPT_NEW_DISPLAY,
     OPT_LIST_APPS,
@@ -199,6 +200,13 @@ static const struct sc_option options[] = {
         .text = "Duplicate audio (capture and keep playing on the device).\n"
                 "This feature is only available with --audio-source=playback."
 
+    },
+    {
+        .longopt_id = OPT_AUDIO_PLAYBACK_CAPTURE_VOICE,
+        .longopt = "audio-playback-capture-voice",
+        .text = "Also capture voice communication playback audio.\n"
+                "This feature is only available with --audio-source=playback "
+                "and requires device support and permission.",
     },
     {
         .longopt_id = OPT_AUDIO_ENCODER,
@@ -2865,6 +2873,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_AUDIO_DUP:
                 opts->audio_dup = true;
                 break;
+            case OPT_AUDIO_PLAYBACK_CAPTURE_VOICE:
+                opts->audio_playback_capture_voice = true;
+                break;
             case 'G':
                 opts->gamepad_input_mode = SC_GAMEPAD_INPUT_MODE_UHID_OR_AOA;
                 break;
@@ -3283,6 +3294,10 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 LOGI("Audio duplication enabled: audio source switched to "
                      "\"playback\"");
                 opts->audio_source = SC_AUDIO_SOURCE_PLAYBACK;
+            } else if (opts->audio_playback_capture_voice) {
+                LOGI("Voice communication playback capture enabled: audio "
+                     "source switched to \"playback\"");
+                opts->audio_source = SC_AUDIO_SOURCE_PLAYBACK;
             } else {
                 opts->audio_source = SC_AUDIO_SOURCE_OUTPUT;
             }
@@ -3300,6 +3315,20 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
 
         if (opts->audio_source != SC_AUDIO_SOURCE_PLAYBACK) {
             LOGE("--audio-dup is specific to --audio-source=playback");
+            return false;
+        }
+    }
+
+    if (opts->audio_playback_capture_voice) {
+        if (!opts->audio) {
+            LOGE("--audio-playback-capture-voice not supported if audio is "
+                 "disabled");
+            return false;
+        }
+
+        if (opts->audio_source != SC_AUDIO_SOURCE_PLAYBACK) {
+            LOGE("--audio-playback-capture-voice is specific to "
+                 "--audio-source=playback");
             return false;
         }
     }

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -113,6 +113,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .window = true,
     .mouse_hover = true,
     .audio_dup = false,
+    .audio_playback_capture_voice = false,
     .new_display = NULL,
     .start_app = NULL,
     .angle = NULL,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -337,6 +337,7 @@ struct scrcpy_options {
     bool window;
     bool mouse_hover;
     bool audio_dup;
+    bool audio_playback_capture_voice;
     const char *new_display; // [<width>x<height>][/<dpi>] parsed by the server
     const char *start_app;
     bool vd_destroy_content;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -380,6 +380,7 @@ scrcpy(struct scrcpy_options *options) {
         .video = options->video,
         .audio = options->audio,
         .audio_dup = options->audio_dup,
+        .audio_playback_capture_voice = options->audio_playback_capture_voice,
         .show_touches = options->show_touches,
         .stay_awake = options->stay_awake,
         .video_codec_options = options->video_codec_options,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -302,6 +302,9 @@ execute_server(struct sc_server *server,
     if (params->audio_dup) {
         ADD_PARAM("audio_dup=true");
     }
+    if (params->audio_playback_capture_voice) {
+        ADD_PARAM("audio_playback_capture_voice=true");
+    }
     if (params->max_size) {
         ADD_PARAM("max_size=%" PRIu16, params->max_size);
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -56,6 +56,7 @@ struct sc_server_params {
     bool video;
     bool audio;
     bool audio_dup;
+    bool audio_playback_capture_voice;
     bool show_touches;
     bool stay_awake;
     bool force_adb_forward;

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -121,6 +121,26 @@ static void test_options2(void) {
     assert(opts->record_format == SC_RECORD_FORMAT_MP4);
 }
 
+static void test_audio_playback_capture_voice(void) {
+    struct scrcpy_cli_args args = {
+        .opts = scrcpy_options_default,
+        .help = false,
+        .version = false,
+    };
+
+    char *argv[] = {
+        "scrcpy",
+        "--audio-playback-capture-voice",
+    };
+
+    bool ok = scrcpy_parse_args(&args, ARRAY_LEN(argv), argv);
+    assert(ok);
+
+    const struct scrcpy_options *opts = &args.opts;
+    assert(opts->audio_playback_capture_voice);
+    assert(opts->audio_source == SC_AUDIO_SOURCE_PLAYBACK);
+}
+
 static void test_parse_shortcut_mods(void) {
     uint8_t mods;
     bool ok;
@@ -157,6 +177,7 @@ int main(int argc, char *argv[]) {
     test_flag_help();
     test_options();
     test_options2();
+    test_audio_playback_capture_voice();
     test_parse_shortcut_mods();
     return 0;
 }

--- a/doc/audio.md
+++ b/doc/audio.md
@@ -98,6 +98,15 @@ scrcpy --audio-source=playback --audio-dup
 scrcpy --audio-dup  # --audio-source=playback is implied
 ```
 
+It can also request voice communication playback capture, if supported and
+permitted by the device:
+
+```bash
+scrcpy --audio-source=playback --audio-playback-capture-voice
+# or simply:
+scrcpy --audio-playback-capture-voice  # --audio-source=playback is implied
+```
+
 However, it requires Android 13, and Android apps can opt-out (so they are not
 captured).
 

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -33,6 +33,7 @@ public class Options {
     private VideoSource videoSource = VideoSource.DISPLAY;
     private AudioSource audioSource = AudioSource.OUTPUT;
     private boolean audioDup;
+    private boolean audioPlaybackCaptureVoice;
     private int videoBitRate = 8000000;
     private int audioBitRate = 128000;
     private float maxFps;
@@ -128,6 +129,10 @@ public class Options {
 
     public boolean getAudioDup() {
         return audioDup;
+    }
+
+    public boolean getAudioPlaybackCaptureVoice() {
+        return audioPlaybackCaptureVoice;
     }
 
     public int getVideoBitRate() {
@@ -383,6 +388,9 @@ public class Options {
                     break;
                 case "audio_dup":
                     options.audioDup = Boolean.parseBoolean(value);
+                    break;
+                case "audio_playback_capture_voice":
+                    options.audioPlaybackCaptureVoice = Boolean.parseBoolean(value);
                     break;
                 case "max_size":
                     options.maxSize = Integer.parseInt(value);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -123,7 +123,8 @@ public final class Server {
                 if (audioSource.isDirect()) {
                     audioCapture = new AudioDirectCapture(audioSource);
                 } else {
-                    audioCapture = new AudioPlaybackCapture(options.getAudioDup());
+                    audioCapture = new AudioPlaybackCapture(options.getAudioDup(),
+                            options.getAudioPlaybackCaptureVoice());
                 }
 
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendStreamMeta(), options.getSendFrameMeta());

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
@@ -20,12 +20,14 @@ import java.nio.ByteBuffer;
 public final class AudioPlaybackCapture implements AudioCapture {
 
     private final boolean keepPlayingOnDevice;
+    private final boolean captureVoiceCommunication;
 
     private AudioRecord recorder;
     private AudioRecordReader reader;
 
-    public AudioPlaybackCapture(boolean keepPlayingOnDevice) {
+    public AudioPlaybackCapture(boolean keepPlayingOnDevice, boolean captureVoiceCommunication) {
         this.keepPlayingOnDevice = keepPlayingOnDevice;
+        this.captureVoiceCommunication = captureVoiceCommunication;
     }
 
     @SuppressLint("PrivateApi")
@@ -43,19 +45,28 @@ public final class AudioPlaybackCapture implements AudioCapture {
             Method setTargetMixRoleMethod = audioMixingRuleBuilderClass.getMethod("setTargetMixRole", int.class);
             setTargetMixRoleMethod.invoke(audioMixingRuleBuilder, mixRolePlayersConstant);
 
-            AudioAttributes attributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build();
+            AudioAttributes mediaAttributes =
+                    new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build();
 
-            // audioMixingRuleBuilder.addMixRule(AudioMixingRule.RULE_MATCH_ATTRIBUTE_USAGE, attributes);
+            // audioMixingRuleBuilder.addMixRule(AudioMixingRule.RULE_MATCH_ATTRIBUTE_USAGE, mediaAttributes);
             int ruleMatchAttributeUsageConstant = audioMixingRuleClass.getField("RULE_MATCH_ATTRIBUTE_USAGE").getInt(null);
             Method addMixRuleMethod = audioMixingRuleBuilderClass.getMethod("addMixRule", int.class, Object.class);
-            addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant, attributes);
+            addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant, mediaAttributes);
+
+            if (captureVoiceCommunication) {
+                AudioAttributes voiceCommunicationAttributes =
+                        new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_VOICE_COMMUNICATION).build();
+                addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant,
+                        voiceCommunicationAttributes);
+
+                // audioMixingRuleBuilder.voiceCommunicationCaptureAllowed(true);
+                Method voiceCommunicationCaptureAllowedMethod =
+                        audioMixingRuleBuilderClass.getMethod("voiceCommunicationCaptureAllowed", boolean.class);
+                voiceCommunicationCaptureAllowedMethod.invoke(audioMixingRuleBuilder, true);
+            }
 
             // AudioMixingRule audioMixingRule = builder.build();
             Object audioMixingRule = audioMixingRuleBuilderClass.getMethod("build").invoke(audioMixingRuleBuilder);
-
-            // audioMixingRuleBuilder.voiceCommunicationCaptureAllowed(true);
-            Method voiceCommunicationCaptureAllowedMethod = audioMixingRuleBuilderClass.getMethod("voiceCommunicationCaptureAllowed", boolean.class);
-            voiceCommunicationCaptureAllowedMethod.invoke(audioMixingRuleBuilder, true);
 
             Class<?> audioMixClass = Class.forName("android.media.audiopolicy.AudioMix");
             Class<?> audioMixBuilderClass = Class.forName("android.media.audiopolicy.AudioMix$Builder");
@@ -95,6 +106,10 @@ public final class AudioPlaybackCapture implements AudioCapture {
             registerAudioPolicyStaticMethod.setAccessible(true);
             int result = (int) registerAudioPolicyStaticMethod.invoke(null, audioPolicy);
             if (result != 0) {
+                if (captureVoiceCommunication) {
+                    Ln.e("Could not register audio policy for voice communication playback capture. "
+                            + "It requires CAPTURE_VOICE_COMMUNICATION_OUTPUT permission and device support.");
+                }
                 throw new RuntimeException("registerAudioPolicy() returned " + result);
             }
 


### PR DESCRIPTION
This adds an explicit opt-in option to include voice communication playback audio in the Android 13+ playback capture path:

```bash
scrcpy --audio-source=playback --audio-playback-capture-voice
```

`--audio-playback-capture-voice` implies `--audio-source=playback` when the audio source is left to auto, like `--audio-dup`. If the audio source is explicitly set to another source, scrcpy rejects the combination.

The default behavior is unchanged: playback capture still only matches `USAGE_MEDIA` unless the new option is passed. When enabled, the server also matches `USAGE_VOICE_COMMUNICATION` and calls `AudioMixingRule.Builder.voiceCommunicationCaptureAllowed(true)` before building the mixing rule.

This requires device support and the privileged `CAPTURE_VOICE_COMMUNICATION_OUTPUT` permission; if policy registration fails with the option enabled, the server logs that requirement explicitly.

Related: #5246, #4380.

Tests:
- `ANDROID_SDK_ROOT=$HOME/Android/Sdk ./gradlew :server:assembleDebug :server:checkstyle`
- `app/tests/test_cli` run standalone in this environment (full app Meson test runner unavailable because SDL3/FFmpeg development packages are not installed).