### PR TITLE
Fix data race

### DIFF
--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -244,6 +244,12 @@ run_demuxer(void *data) {
         session = &session_data;
         sc_demuxer_parse_session(header, session);
 
+        if (!session_data.video.width || !session_data.video.height) {
+            LOGE("Invalid session video size: %" PRIu32 "x%" PRIu32,
+                 session_data.video.width, session_data.video.height);
+            goto finally_free_context;
+        }
+
         codec_ctx->width = session_data.video.width;
         codec_ctx->height = session_data.video.height;
         codec_ctx->pix_fmt = AV_PIX_FMT_YUV420P;

--- a/app/src/events.c
+++ b/app/src/events.c
@@ -26,6 +26,11 @@ sc_push_event_impl(uint32_t type, void *ptr, const char *name) {
 }
 
 bool
+sc_dequeue_event(uint32_t type, SDL_Event *event) {
+    return SDL_PeepEvents(event, 1, SDL_GETEVENT, type, type) == 1;
+}
+
+bool
 sc_main_thread_init(void) {
     stopped = false;
     return sc_mutex_init(&mutex);

--- a/app/src/events.h
+++ b/app/src/events.h
@@ -29,6 +29,8 @@ sc_push_event_impl(uint32_t type, void *ptr, const char *name);
 #define sc_push_event(TYPE) sc_push_event_impl(TYPE, NULL, # TYPE)
 #define sc_push_event_with_data(TYPE, PTR) sc_push_event_impl(TYPE, PTR, # TYPE)
 
+bool sc_dequeue_event(uint32_t type, SDL_Event *event);
+
 typedef SDL_MainThreadCallback sc_runnable_fn;
 
 bool

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -403,6 +403,7 @@ sc_screen_frame_sink_open(struct sc_frame_sink *sink,
 
     screen->current_session = *session;
 
+    assert(session->video.width && session->video.height);
     if (session->video.width > 0xFFFF || session->video.height > 0xFFFF) {
         LOGE("Size too large: %" PRIu32 "x%" PRIu32, session->video.width,
                                                      session->video.height);
@@ -920,6 +921,12 @@ sc_screen_apply_frame(struct sc_screen *screen, bool can_resize) {
 
     AVFrame *frame = screen->frame;
     struct sc_size new_frame_size = {frame->width, frame->height};
+
+    if (!new_frame_size.width || !new_frame_size.height) {
+        LOGE("Invalid frame size: %" PRIu32 "x%" PRIu32,
+             new_frame_size.width, new_frame_size.height);
+        return false;
+    }
 
     if (screen->frame_size.width != new_frame_size.width
             || screen->frame_size.height != new_frame_size.height) {

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -811,10 +811,9 @@ sc_screen_destroy(struct sc_screen *screen) {
     sc_mutex_destroy(&screen->mutex);
 
     SDL_Event event;
-    int nevents = SDL_PeepEvents(&event, 1, SDL_GETEVENT,
-                                 SC_EVENT_DISCONNECTED_ICON_LOADED,
-                                 SC_EVENT_DISCONNECTED_ICON_LOADED);
-    if (nevents == 1) {
+    bool has_event =
+        sc_dequeue_event(SC_EVENT_DISCONNECTED_ICON_LOADED, &event);
+    if (has_event) {
         assert(event.type == SC_EVENT_DISCONNECTED_ICON_LOADED);
         // The event was posted, but not handled, the icon must be freed
         SDL_Surface *dangling_icon = event.user.data1;

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -401,18 +401,25 @@ sc_screen_frame_sink_open(struct sc_frame_sink *sink,
         return false;
     }
 
-    // content_size can be written from this thread, because it is never read
-    // from the main thread before handling SC_EVENT_OPEN_WINDOW (which acts as
-    // a synchronization point) when video is enabled
-    screen->frame_size.width = session->video.width;
-    screen->frame_size.height = session->video.height;
-    screen->content_size = get_oriented_size(screen->frame_size,
-                                             screen->orientation);
-
     screen->current_session = *session;
 
-    bool ok = sc_push_event(SC_EVENT_OPEN_WINDOW);
+    if (session->video.width > 0xFFFF || session->video.height > 0xFFFF) {
+        LOGE("Size too large: %" PRIu32 "x%" PRIu32, session->video.width,
+                                                     session->video.height);
+        return false;
+    }
+
+    struct sc_size *size = malloc(sizeof(*size));
+    if (!size) {
+        LOG_OOM();
+        return false;
+    }
+    size->width = session->video.width;
+    size->height = session->video.height;
+
+    bool ok = sc_push_event_with_data(SC_EVENT_OPEN_WINDOW, size);
     if (!ok) {
+        free(size);
         return false;
     }
 
@@ -819,6 +826,14 @@ sc_screen_destroy(struct sc_screen *screen) {
         SDL_Surface *dangling_icon = event.user.data1;
         sc_icon_destroy(dangling_icon);
     }
+
+    has_event = sc_dequeue_event(SC_EVENT_OPEN_WINDOW, &event);
+    if (has_event) {
+        assert(event.type == SC_EVENT_OPEN_WINDOW);
+        // The event was posted, but not handled, the size must be freed
+        struct sc_size * size = event.user.data1;
+        free(size);
+    }
 }
 
 static void
@@ -1112,7 +1127,14 @@ sc_disconnect_on_timeout(struct sc_disconnect *d, void *userdata) {
 void
 sc_screen_handle_event(struct sc_screen *screen, const SDL_Event *event) {
     switch (event->type) {
-        case SC_EVENT_OPEN_WINDOW:
+        case SC_EVENT_OPEN_WINDOW: {
+            struct sc_size *size = event->user.data1;
+            assert(size);
+
+            screen->frame_size = *size;
+            free(size);
+            screen->content_size = get_oriented_size(screen->frame_size,
+                                                     screen->orientation);
             sc_screen_show_initial_window(screen);
 
             if (sc_screen_is_relative_mode(screen)) {
@@ -1122,6 +1144,7 @@ sc_screen_handle_event(struct sc_screen *screen, const SDL_Event *event) {
 
             sc_screen_render(screen, false);
             return;
+        }
         case SC_EVENT_NEW_FRAME: {
             bool ok = sc_screen_update_frame(screen);
             if (!ok) {


### PR DESCRIPTION
Fields in `struct sc_screen` were written from the decoder thread and read from the main thread without proper synchronization.
    
Contrary to what the comment stated, pushing an SDL event does not provide the synchronization required to make these writes visible to the main thread.
    
Pass the session size as data attached to the SDL event to fix the issue.

CI: https://github.com/rom1v/scrcpy/actions/runs/27986960479