### PR TITLE
Fix size constraints for camera capture

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -152,7 +152,7 @@ public class CameraCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
-        videoSize = filter.getOutputSize().constrain(videoConstraints);
+        videoSize = filter.getOutputSize().align(videoConstraints.getAlignment());
     }
 
     private static String selectCamera(String explicitCameraId, CameraFacing cameraFacing) throws CameraAccessException, ConfigurationException {

--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -153,6 +153,12 @@ public class CameraCapture extends SurfaceCapture {
 
         transform = filter.getInverseTransform();
         videoSize = filter.getOutputSize().align(videoConstraints.getAlignment());
+
+        if (!videoSize.equals(captureSize) && transform == null) {
+            // The camera stream can only be rendered on a surface matching the input size.
+            // If the video constraints change the size, an intermediate OpenGL filter is required.
+            transform = AffineMatrix.IDENTITY;
+        }
     }
 
     private static String selectCamera(String explicitCameraId, CameraFacing cameraFacing) throws CameraAccessException, ConfigurationException {


### PR DESCRIPTION
**Only apply alignment constraint for camera**
    
Once the camera size has been selected, do not apply any encoder maximum size constraints. Only adjust the size for alignment.

---

**Use OpenGL for camera to adapt to the target size**

The camera stream can only be rendered on a surface matching the input size. If the video constraints change the size, an intermediate OpenGL filter is required.
    
For example, since 1080 is not a multiple of 16, running scrcpy as follows:

```
scrcpy --video-source=camera --camera-size=1920x1080 --min-size-alignment=16
```
    
resulted in:
    
    ERROR: Camera configuration error
    
An intermediate OpenGL filter allows adapting the size without error.

---

Binaries: https://github.com/rom1v/scrcpy/actions/runs/28297540213

Fixes #6919