### PR TITLE
feat: add --app-only option to mirror a specific app

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -23,6 +23,7 @@ enum {
     OPT_WINDOW_TITLE = 1000,
     OPT_PUSH_TARGET,
     OPT_ALWAYS_ON_TOP,
+    OPT_APP_ONLY,
     OPT_CROP,
     OPT_RECORD_FORMAT,
     OPT_PREFER_TEXT,
@@ -149,6 +150,12 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_ALWAYS_ON_TOP,
         .longopt = "always-on-top",
         .text = "Make scrcpy window always on top (above other windows).",
+    },
+    {
+        .longopt_id = OPT_APP_ONLY,
+        .longopt = "app-only",
+        .argdesc = "package",
+        .text = "Mirror only a specific Android application package.",
     },
     {
         .longopt_id = OPT_ANGLE,
@@ -2592,6 +2599,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             case OPT_ALWAYS_ON_TOP:
                 opts->always_on_top = true;
                 break;
+            case OPT_APP_ONLY:
+                opts->app_only = optarg;
+                break;
             case 'v':
                 args->version = true;
                 break;
@@ -3179,6 +3189,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     }
 
     if (opts->video_source == SC_VIDEO_SOURCE_CAMERA) {
+        if (opts->app_only) {
+            LOGE("--app-only is only available with --video-source=display");
+            return false;
+        }
+
         if (opts->display_id) {
             LOGE("--display-id is only available with --video-source=display");
             return false;
@@ -3429,6 +3444,10 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
     if (otg) {
         // OTG mode is compatible with only very few options.
         // Only report obvious errors.
+        if (opts->app_only) {
+            LOGE("OTG mode: --app-only is not supported");
+            return false;
+        }
         if (opts->record_filename) {
             LOGE("OTG mode: cannot record");
             return false;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -115,6 +115,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .audio_dup = false,
     .new_display = NULL,
     .start_app = NULL,
+    .app_only = NULL,
     .angle = NULL,
     .vd_destroy_content = true,
     .vd_system_decorations = true,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -337,6 +337,7 @@ struct scrcpy_options {
     bool audio_dup;
     const char *new_display; // [<width>x<height>][/<dpi>] parsed by the server
     const char *start_app;
+    const char *app_only;
     bool vd_destroy_content;
     bool vd_system_decorations;
     bool camera_torch;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -405,6 +405,7 @@ scrcpy(struct scrcpy_options *options) {
         .keep_active = options->keep_active,
         .flex_display = options->flex_display,
         .list = options->list,
+        .app_only = options->app_only,
     };
 
     static const struct sc_server_callbacks cbs = {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -448,6 +448,10 @@ execute_server(struct sc_server *server,
     if (params->list & SC_OPTION_LIST_APPS) {
         ADD_PARAM("list_apps=true");
     }
+    if (params->app_only) {
+        VALIDATE_STRING(params->app_only);
+        ADD_PARAM("app_only=%s", params->app_only);
+    }
 
 #undef ADD_PARAM
 

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -76,6 +76,7 @@ struct sc_server_params {
     bool keep_active;
     bool flex_display;
     uint8_t list;
+    const char *app_only;
 };
 
 struct sc_server {

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -79,12 +79,18 @@ public class Options {
     private boolean listCameras;
     private boolean listCameraSizes;
     private boolean listApps;
+    private String appOnly;
 
-    // Options not used by the scrcpy client, but useful to use scrcpy-server directly
+    // Options not used by the scrcpy client, but useful to use scrcpy-server
+    // directly
     private boolean sendDeviceMeta = true; // send device name and size
     private boolean sendFrameMeta = true; // send PTS so that the client may record properly
     private boolean sendDummyByte = true; // write a byte on start to detect connection issues
     private boolean sendStreamMeta = true; // write the stream metadata (codec and session)
+
+    public String getAppOnly() {
+        return appOnly;
+    }
 
     public Ln.Level getLogLevel() {
         return logLevel;
@@ -323,7 +329,8 @@ public class Options {
         String clientVersion = args[0];
         if (!clientVersion.equals(BuildConfig.VERSION_NAME)) {
             throw new IllegalArgumentException(
-                    "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "(" + clientVersion + ")");
+                    "The server version (" + BuildConfig.VERSION_NAME + ") does not match the client " + "("
+                            + clientVersion + ")");
         }
 
         Options options = new Options();
@@ -390,7 +397,8 @@ public class Options {
                 case "min_size_alignment":
                     int align = Integer.parseInt(value);
                     if (align < 1 || align > 16 || (align & (align - 1)) != 0) {
-                        throw new IllegalArgumentException("min_size_alignment (" + align + ") must be 1, 2, 4, 8 or 16");
+                        throw new IllegalArgumentException(
+                                "min_size_alignment (" + align + ") must be 1, 2, 4, 8 or 16");
                     }
                     options.minSizeAlignment = align;
                     break;
@@ -528,6 +536,9 @@ public class Options {
                 case "flex_display":
                     options.flexDisplay = Boolean.parseBoolean(value);
                     break;
+                case "app_only":
+                    options.appOnly = value;
+                    break;
                 case "capture_orientation":
                     Pair<Orientation.Lock, Orientation> pair = parseCaptureOrientation(value);
                     options.captureOrientationLock = pair.first;
@@ -633,10 +644,10 @@ public class Options {
 
     private static NewDisplay parseNewDisplay(String newDisplay) {
         // Possible inputs:
-        //  - "" (empty string)
-        //  - "<width>x<height>/<dpi>"
-        //  - "<width>x<height>"
-        //  - "/<dpi>"
+        // - "" (empty string)
+        // - "<width>x<height>/<dpi>"
+        // - "<width>x<height>"
+        // - "/<dpi>"
         if (newDisplay.isEmpty()) {
             return new NewDisplay();
         }

--- a/server/src/main/java/com/genymobile/scrcpy/opengl/OpenGLRunner.java
+++ b/server/src/main/java/com/genymobile/scrcpy/opengl/OpenGLRunner.java
@@ -36,6 +36,13 @@ public final class OpenGLRunner {
     private int textureId;
 
     private boolean stopped;
+    private String appOnly;
+    private boolean appActive = true;
+    private Size outputSize;
+
+    public void setAppOnly(String appOnly) {
+        this.appOnly = appOnly;
+    }
 
     public OpenGLRunner(OpenGLFilter filter, float[] overrideTransformMatrix) {
         this.filter = filter;
@@ -90,6 +97,7 @@ public final class OpenGLRunner {
     }
 
     private void run(Size inputSize, Size outputSize, Surface outputSurface) throws OpenGLException {
+        this.outputSize = outputSize;
         eglDisplay = EGL14.eglGetDisplay(EGL14.EGL_DEFAULT_DISPLAY);
         if (eglDisplay == EGL14.EGL_NO_DISPLAY) {
             throw new OpenGLException("Unable to get EGL14 display");
@@ -175,6 +183,10 @@ public final class OpenGLRunner {
 
             render(outputSize);
         }, handler);
+
+        if (appOnly != null) {
+            handler.post(checkAppRunnable);
+        }
     }
 
     private void render(Size outputSize) {
@@ -182,6 +194,14 @@ public final class OpenGLRunner {
         GLUtils.checkGlError();
 
         surfaceTexture.updateTexImage();
+
+        if (appOnly != null && !appActive) {
+            GLES20.glClearColor(0f, 0f, 0f, 1f);
+            GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+            EGLExt.eglPresentationTimeANDROID(eglDisplay, eglSurface, surfaceTexture.getTimestamp());
+            EGL14.eglSwapBuffers(eglDisplay, eglSurface);
+            return;
+        }
 
         float[] matrix;
         if (overrideTransformMatrix != null) {
@@ -228,5 +248,42 @@ public final class OpenGLRunner {
             // Behave as if this method call was synchronous
             Thread.currentThread().interrupt();
         }
+    }
+
+    private final Runnable checkAppRunnable = new Runnable() {
+        @Override
+        public void run() {
+            if (stopped) {
+                return;
+            }
+            checkActiveApp();
+            handler.postDelayed(this, 200);
+        }
+    };
+
+    private void checkActiveApp() {
+        String topPackage = com.genymobile.scrcpy.wrappers.ServiceManager.getActivityManager().getTopPackage();
+        if (topPackage != null) {
+            boolean active = topPackage.equals(appOnly);
+            if (active != appActive) {
+                appActive = active;
+                com.genymobile.scrcpy.util.Ln.i("App active state changed: " + active + " (top package: " + topPackage + ")");
+                if (!active) {
+                    renderBlack(this.outputSize);
+                }
+            }
+        }
+    }
+
+    private void renderBlack(Size outputSize) {
+        if (eglDisplay == EGL14.EGL_NO_DISPLAY || eglSurface == EGL14.EGL_NO_SURFACE) {
+            return;
+        }
+        GLES20.glViewport(0, 0, outputSize.getWidth(), outputSize.getHeight());
+        GLUtils.checkGlError();
+        GLES20.glClearColor(0f, 0f, 0f, 1f);
+        GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT);
+        EGLExt.eglPresentationTimeANDROID(eglDisplay, eglSurface, System.nanoTime());
+        EGL14.eglSwapBuffers(eglDisplay, eglSurface);
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -48,6 +48,7 @@ public class ScreenCapture extends SurfaceCapture {
 
     private AffineMatrix transform;
     private OpenGLRunner glRunner;
+    private final String appOnly;
 
     public ScreenCapture(VirtualDisplayListener vdListener, Options options) {
         this.vdListener = vdListener;
@@ -59,6 +60,7 @@ public class ScreenCapture extends SurfaceCapture {
         assert captureOrientationLock != null;
         assert captureOrientation != null;
         this.angle = options.getAngle();
+        this.appOnly = options.getAppOnly();
     }
 
     @Override
@@ -101,6 +103,9 @@ public class ScreenCapture extends SurfaceCapture {
         filter.addAngle(angle);
 
         transform = filter.getInverseTransform();
+        if (transform == null && appOnly != null) {
+            transform = com.genymobile.scrcpy.util.AffineMatrix.IDENTITY;
+        }
         videoSize = filter.getOutputSize().constrain(videoConstraints);
     }
 
@@ -122,6 +127,7 @@ public class ScreenCapture extends SurfaceCapture {
             assert glRunner == null;
             OpenGLFilter glFilter = new AffineOpenGLFilter(transform);
             glRunner = new OpenGLRunner(glFilter);
+            glRunner.setAppOnly(appOnly);
             surface = glRunner.start(inputSize, videoSize, surface);
         } else {
             // If there is no filter, the display must be rendered at target video size directly

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ActivityManager.java
@@ -9,12 +9,14 @@ import android.annotation.TargetApi;
 import android.content.IContentProvider;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
 import android.os.IInterface;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.List;
 
 @SuppressLint("PrivateApi,DiscouragedPrivateApi")
 public final class ActivityManager {
@@ -161,5 +163,52 @@ public final class ActivityManager {
         } catch (Throwable e) {
             Ln.e("Could not invoke method", e);
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    public String getTopPackage() {
+        try {
+            List<android.app.ActivityManager.RunningTaskInfo> tasks = null;
+            IInterface target;
+            if (Build.VERSION.SDK_INT >= 29) {
+                target = ServiceManager.getService("activity_task", "android.app.IActivityTaskManager");
+            } else {
+                target = manager;
+            }
+
+            Method getTasksMethod = null;
+            for (Method method : target.getClass().getMethods()) {
+                if (method.getName().equals("getTasks")) {
+                    getTasksMethod = method;
+                    break;
+                }
+            }
+
+            if (getTasksMethod != null) {
+                Class<?>[] paramTypes = getTasksMethod.getParameterTypes();
+                Object[] args = new Object[paramTypes.length];
+                for (int i = 0; i < paramTypes.length; i++) {
+                    Class<?> type = paramTypes[i];
+                    if (type == int.class) {
+                        args[i] = (i == 0) ? 1 : 0;
+                    } else if (type == boolean.class) {
+                        args[i] = false;
+                    } else {
+                        args[i] = null;
+                    }
+                }
+                tasks = (List<android.app.ActivityManager.RunningTaskInfo>) getTasksMethod.invoke(target, args);
+            }
+
+            if (tasks != null && !tasks.isEmpty()) {
+                android.app.ActivityManager.RunningTaskInfo task = tasks.get(0);
+                if (task != null && task.topActivity != null) {
+                    return task.topActivity.getPackageName();
+                }
+            }
+        } catch (Throwable e) {
+            Ln.e("Could not get top package name", e);
+        }
+        return null;
     }
 }


### PR DESCRIPTION
### Description
This PR introduces a new command-line option `--app-only <package>` to restrict mirroring to a specific Android application. 

When active, the chosen app displays normally, but the stream is automatically replaced with a black screen whenever the user switches away to a different application (e.g., the launcher or settings). Mirroring resumes immediately once the target application comes back to the foreground.

### Key Changes
- **Client (C)**:
  - Adds the `--app-only` CLI argument and structure fields.
  - Implements argument validation: ensures it is only allowed with `--video-source=display` and rejects it in OTG mode.
  - Passes the parameter value down to the scrcpy server.
- **Server (Java)**:
  - Parses the `app_only` startup parameter.
  - Adds a dynamic/robust reflection wrapper around `getTasks` in `ActivityManager.java` supporting different API signatures (API >= 29 and < 29).
  - Starts a lightweight periodic check (every 200ms) on the EGL context thread to monitor the top active package name.
  - Modifies `OpenGLRunner` to clear the rendering surface to black (`glClear`) if the current top package name does not match the target package name.

### Verification & Testing
Tested on a physical device (Nothing A001 running Android 16):
- Checked standard display mirroring of custom app `apps.trippsee.com`: **Success**.
- Verified switching to home launcher or different apps renders a black screen: **Success**.
- Verified returning to target app immediately restores the stream: **Success**.
- Ran local build checks: `./gradlew -p server check` passes checkstyle and lint checks without issues.
