### PR TITLE
fix: silence discarded-qualifiers warnings in adb/cli/str

### DIFF
--- a/app/src/adb/adb.c
+++ b/app/src/adb/adb.c
@@ -483,7 +483,7 @@ sc_adb_accept_device(const struct sc_adb_device *device,
             char *device_serial_colon = strchr(device->serial, ':');
             if (device_serial_colon) {
                 // The device serial is an IP:port...
-                char *serial_colon = strchr(selector->serial, ':');
+                const char *serial_colon = strchr(selector->serial, ':');
                 if (!serial_colon) {
                     // But the requested serial has no ':', so only consider
                     // the IP part of the device serial. This allows to use

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -1917,7 +1917,7 @@ parse_shortcut_mods(const char *s, uint8_t *shortcut_mods) {
     // A list of shortcut modifiers, for example "lctrl,rctrl,rsuper"
 
     for (;;) {
-        char *comma = strchr(s, ',');
+        const char *comma = strchr(s, ',');
         assert(!comma || comma > s);
         size_t limit = comma ? (size_t) (comma - s) : strlen(s);
 

--- a/app/src/util/str.c
+++ b/app/src/util/str.c
@@ -154,7 +154,7 @@ sc_str_parse_integer_with_suffix(const char *s, long *out) {
 
 bool
 sc_str_list_contains(const char *list, char sep, const char *s) {
-    char *p;
+    const char *p;
     do {
         p = strchr(list, sep);
 


### PR DESCRIPTION
Use const char * for results of strchr() so we don't discard const qualifiers and can build with -Werror more reliably.