### PR TITLE
Add mjpeg video codec as a MediaCodec-free fallback

### DIFF
--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -982,8 +982,11 @@ static const struct sc_option options[] = {
         .longopt_id = OPT_VIDEO_CODEC,
         .longopt = "video-codec",
         .argdesc = "name",
-        .text = "Select a video codec (h264, h265, av1, vp8 or vp9).\n"
-                "Default is h264.",
+        .text = "Select a video codec (h264, h265, av1, vp8, vp9 or mjpeg).\n"
+                "Default is h264.\n"
+                "The mjpeg codec does not use MediaCodec at all: it captures "
+                "raw frames and compresses them to JPEG on the CPU. Use it as "
+                "a fallback on devices where MediaCodec is broken.",
     },
     {
         .longopt_id = OPT_VIDEO_CODEC_OPTIONS,
@@ -2038,7 +2041,11 @@ parse_video_codec(const char *optarg, enum sc_codec *codec) {
         *codec = SC_CODEC_VP9;
         return true;
     }
-    LOGE("Unsupported video codec: %s (expected h264, h265, av1, vp8 or vp9)", optarg);
+    if (!strcmp(optarg, "mjpeg")) {
+        *codec = SC_CODEC_MJPEG;
+        return true;
+    }
+    LOGE("Unsupported video codec: %s (expected h264, h265, av1, vp8, vp9 or mjpeg)", optarg);
     return false;
 }
 
@@ -3397,6 +3404,11 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
         if (opts->record_format == SC_RECORD_FORMAT_MP4
                 && opts->video_codec == SC_CODEC_VP8) {
             LOGE("Recording to MP4 container does not support VP8 video");
+            return false;
+        }
+
+        if (opts->video_codec == SC_CODEC_MJPEG) {
+            LOGE("Recording is not supported with the mjpeg video codec");
             return false;
         }
     }

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -23,6 +23,7 @@ sc_demuxer_to_avcodec_id(uint32_t codec_id) {
 #define SC_CODEC_ID_AV1 UINT32_C(0x00617631) // "av1" in ASCII
 #define SC_CODEC_ID_VP8 UINT32_C(0x00767038) // "vp8" in ASCII
 #define SC_CODEC_ID_VP9 UINT32_C(0x00767039) // "vp9" in ASCII
+#define SC_CODEC_ID_MJPEG UINT32_C(0x6d6a7067) // "mjpg" in ASCII
 #define SC_CODEC_ID_OPUS UINT32_C(0x6f707573) // "opus" in ASCII
 #define SC_CODEC_ID_AAC UINT32_C(0x00616163) // "aac" in ASCII
 #define SC_CODEC_ID_FLAC UINT32_C(0x666c6163) // "flac" in ASCII
@@ -43,6 +44,8 @@ sc_demuxer_to_avcodec_id(uint32_t codec_id) {
             return AV_CODEC_ID_VP8;
         case SC_CODEC_ID_VP9:
             return AV_CODEC_ID_VP9;
+        case SC_CODEC_ID_MJPEG:
+            return AV_CODEC_ID_MJPEG;
         case SC_CODEC_ID_OPUS:
             return AV_CODEC_ID_OPUS;
         case SC_CODEC_ID_AAC:

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -49,6 +49,7 @@ enum sc_codec {
     SC_CODEC_AAC,
     SC_CODEC_FLAC,
     SC_CODEC_RAW,
+    SC_CODEC_MJPEG,
 };
 
 enum sc_video_source {

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -115,6 +115,8 @@ sc_server_get_codec_name(enum sc_codec codec) {
             return "vp8";
         case SC_CODEC_VP9:
             return "vp9";
+        case SC_CODEC_MJPEG:
+            return "mjpeg";
         case SC_CODEC_OPUS:
             return "opus";
         case SC_CODEC_AAC:

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -18,10 +18,12 @@ import com.genymobile.scrcpy.opengl.OpenGLRunner;
 import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.util.LogUtils;
 import com.genymobile.scrcpy.video.CameraCapture;
+import com.genymobile.scrcpy.video.JpegEncoder;
 import com.genymobile.scrcpy.video.NewDisplayCapture;
 import com.genymobile.scrcpy.video.ScreenCapture;
 import com.genymobile.scrcpy.video.SurfaceCapture;
 import com.genymobile.scrcpy.video.SurfaceEncoder;
+import com.genymobile.scrcpy.video.VideoCodec;
 import com.genymobile.scrcpy.video.VideoSource;
 
 import android.annotation.SuppressLint;
@@ -151,8 +153,10 @@ public final class Server {
                 } else {
                     surfaceCapture = new CameraCapture(options);
                 }
-                SurfaceEncoder surfaceEncoder = new SurfaceEncoder(surfaceCapture, videoStreamer, options);
-                asyncProcessors.add(surfaceEncoder);
+                AsyncProcessor videoEncoder = options.getVideoCodec() == VideoCodec.MJPEG
+                        ? new JpegEncoder(surfaceCapture, videoStreamer, options)
+                        : new SurfaceEncoder(surfaceCapture, videoStreamer, options);
+                asyncProcessors.add(videoEncoder);
 
                 if (controller != null) {
                     controller.setSurfaceCapture(surfaceCapture);

--- a/server/src/main/java/com/genymobile/scrcpy/video/JpegEncoder.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/JpegEncoder.java
@@ -1,0 +1,187 @@
+package com.genymobile.scrcpy.video;
+
+import com.genymobile.scrcpy.AsyncProcessor;
+import com.genymobile.scrcpy.Options;
+import com.genymobile.scrcpy.device.Streamer;
+import com.genymobile.scrcpy.model.CodecOption;
+import com.genymobile.scrcpy.model.ConfigurationException;
+import com.genymobile.scrcpy.model.Size;
+import com.genymobile.scrcpy.util.IO;
+import com.genymobile.scrcpy.util.Ln;
+
+import android.graphics.Bitmap;
+import android.graphics.PixelFormat;
+import android.media.Image;
+import android.media.ImageReader;
+import android.os.SystemClock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Software video "encoder" which does not use MediaCodec at all: it periodically polls a raw screen frame from an
+ * {@link ImageReader} (fed by the same virtual display mechanism as {@link SurfaceEncoder}) and compresses it to
+ * JPEG, so the result can be streamed as Motion JPEG. This is much less efficient than a real video codec, but it
+ * works even on devices where MediaCodec is broken or unusable.
+ */
+public class JpegEncoder implements AsyncProcessor {
+
+    private static final int DEFAULT_QUALITY = 80;
+    private static final int DEFAULT_FPS = 4;
+
+    private final SurfaceCapture capture;
+    private final Streamer streamer;
+    private final int maxSize;
+    private final int minSizeAlignment;
+    private final long frameIntervalMs;
+    private final int quality;
+
+    private final CaptureControl captureControl = new CaptureControl();
+
+    private Thread thread;
+    private final AtomicBoolean stopped = new AtomicBoolean();
+
+    public JpegEncoder(SurfaceCapture capture, Streamer streamer, Options options) {
+        this.capture = capture;
+        this.streamer = streamer;
+        this.maxSize = options.getMaxSize();
+        this.minSizeAlignment = options.getMinSizeAlignment();
+        float fps = options.getMaxFps() > 0 ? options.getMaxFps() : DEFAULT_FPS;
+        this.frameIntervalMs = (long) (1000 / fps);
+        this.quality = findQuality(options.getVideoCodecOptions());
+    }
+
+    private static int findQuality(List<CodecOption> codecOptions) {
+        if (codecOptions != null) {
+            for (CodecOption option : codecOptions) {
+                if ("quality".equals(option.getKey()) && option.getValue() instanceof Integer) {
+                    return (Integer) option.getValue();
+                }
+            }
+        }
+        return DEFAULT_QUALITY;
+    }
+
+    private void streamCapture() throws IOException, ConfigurationException {
+        VideoConstraints videoConstraints = new VideoConstraints(maxSize, minSizeAlignment, null);
+        capture.init(captureControl, videoConstraints);
+
+        long startNanos = System.nanoTime();
+
+        try {
+            streamer.writeVideoHeader();
+
+            boolean alive;
+            do {
+                int resetReasons = captureControl.consumeReset();
+                if ((resetReasons & CaptureControl.RESET_REASON_TERMINATED) != 0) {
+                    break;
+                }
+
+                capture.prepare();
+                Size size = capture.getSize();
+                ImageReader imageReader = ImageReader.newInstance(size.getWidth(), size.getHeight(), PixelFormat.RGBA_8888, 2);
+
+                boolean captureStarted = false;
+                try {
+                    capture.start(imageReader.getSurface());
+                    captureStarted = true;
+
+                    boolean isClientResize = (resetReasons & CaptureControl.RESET_REASON_CLIENT_RESIZED) != 0
+                            && (resetReasons & CaptureControl.RESET_REASON_DISPLAY_PROPERTIES_CHANGED) == 0;
+                    streamer.writeSessionMeta(size.getWidth(), size.getHeight(), isClientResize);
+
+                    while (!stopped.get() && !captureControl.isResetRequested()) {
+                        Image image = imageReader.acquireLatestImage();
+                        if (image != null) {
+                            try {
+                                sendFrame(image, System.nanoTime() - startNanos);
+                            } finally {
+                                image.close();
+                            }
+                        }
+                        SystemClock.sleep(frameIntervalMs);
+                    }
+
+                    alive = !stopped.get() && !capture.isClosed();
+                } finally {
+                    if (captureStarted) {
+                        capture.stop();
+                    }
+                    imageReader.close();
+                }
+            } while (alive);
+        } finally {
+            capture.release();
+        }
+    }
+
+    private void sendFrame(Image image, long ptsNanos) throws IOException {
+        byte[] jpeg = toJpeg(image, quality);
+        // Every JPEG frame is fully self-contained, so it can always be considered a key frame, and there is no config packet
+        streamer.writePacket(ByteBuffer.wrap(jpeg), ptsNanos / 1000, false, true);
+    }
+
+    private static byte[] toJpeg(Image image, int quality) {
+        Image.Plane plane = image.getPlanes()[0];
+        ByteBuffer buffer = plane.getBuffer();
+        int pixelStride = plane.getPixelStride();
+        int rowStride = plane.getRowStride();
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        if (rowStride == pixelStride * width) {
+            // Tightly packed: the buffer can be copied directly, without any intermediate allocation
+            bitmap.copyPixelsFromBuffer(buffer);
+        } else {
+            // Padded rows: let Bitmap#setPixels() skip the padding directly via its stride parameter, instead of
+            // allocating an oversized bitmap just to crop it right after
+            int stride = rowStride / pixelStride;
+            int[] pixels = new int[stride * height];
+            buffer.asIntBuffer().get(pixels);
+            bitmap.setPixels(pixels, 0, stride, 0, 0, width, height);
+        }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        bitmap.compress(Bitmap.CompressFormat.JPEG, quality, baos);
+        return baos.toByteArray();
+    }
+
+    @Override
+    public void start(TerminationListener listener) {
+        thread = new Thread(() -> {
+            try {
+                streamCapture();
+            } catch (ConfigurationException e) {
+                // Do not print stack trace, a user-friendly error-message has already been logged
+            } catch (IOException e) {
+                if (!IO.isBrokenPipe(e)) {
+                    Ln.e("JPEG encoding error", e);
+                }
+            } finally {
+                Ln.d("Screen streaming stopped");
+                listener.onTerminated(true);
+            }
+        }, "jpeg-video");
+        thread.start();
+    }
+
+    @Override
+    public void stop() {
+        if (thread != null) {
+            stopped.set(true);
+            captureControl.reset(CaptureControl.RESET_REASON_TERMINATED);
+        }
+    }
+
+    @Override
+    public void join() throws InterruptedException {
+        if (thread != null) {
+            thread.join();
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/video/VideoCodec.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/VideoCodec.java
@@ -11,7 +11,10 @@ public enum VideoCodec implements Codec {
     @SuppressLint("InlinedApi") // introduced in API 29
     AV1(0x00_61_76_31, "av1", MediaFormat.MIMETYPE_VIDEO_AV1),
     VP8(0x00_76_70_38, "vp8", MediaFormat.MIMETYPE_VIDEO_VP8),
-    VP9(0x00_76_70_39, "vp9", MediaFormat.MIMETYPE_VIDEO_VP9);
+    VP9(0x00_76_70_39, "vp9", MediaFormat.MIMETYPE_VIDEO_VP9),
+    // Software fallback which does not use MediaCodec at all: raw screen captures are individually JPEG-compressed
+    // and sent as a Motion JPEG stream. Useful on devices where MediaCodec is broken or unavailable.
+    MJPEG(0x6d_6a_70_67, "mjpeg", "video/mjpeg");
 
     private final int id; // 4-byte ASCII representation of the name
     private final String name;


### PR DESCRIPTION
## Why

On some devices MediaCodec is simply broken and scrcpy cannot mirror at all. 
Concrete example: Bliss OS (x86) running as a Dell Inc. 08NPPY (Android 13) guest. Both video and audio MediaCodec calls fail, and scrcpy dies with a fairly cryptic error:

```
/home/twaik/Downloads/scrcpy-linux-x86_64-v3.3.3/scrcpy-server: 1 file pushed, 0 skipped. 629.3 MB/s (732226 bytes in 0.001s)
[server] INFO: Device: [Dell Inc.] Dell Inc. 08NPPY (Android 13)
[server] INFO: Retrying with -m1600...
[server] ERROR: Exception on thread Thread[audio-in,5,main]
android.media.MediaCodec$CodecException: Error 0xe
        at android.media.MediaCodec.native_queueInputBuffer(Native Method)
        at android.media.MediaCodec.queueInputBuffer(MediaCodec.java:2671)
        at com.genymobile.scrcpy.audio.AudioEncoder.inputThread(AudioEncoder.java:113)
        at com.genymobile.scrcpy.audio.AudioEncoder.lambda$encode$1$com-genymobile-scrcpy-audio-AudioEncoder(AudioEncoder.java:240)
        at com.genymobile.scrcpy.audio.AudioEncoder$$ExternalSyntheticLambda2.run(D8$$SyntheticClass:0)
        at java.lang.Thread.run(Thread.java:1012)
[server] ERROR: MediaCodec error
android.media.MediaCodec$CodecException: Error 0xffffffe0
[server] ERROR: Capture/encoding error: java.lang.IllegalStateException: null
Killed 
ERROR: Could not retrieve device information
ERROR: Server connection failed
```

There's no working combination of `--video-codec`/`--video-encoder` that avoids MediaCodec entirely, so on this kind of device scrcpy currently just can't be used, period.

## What

Adds a new `mjpeg` video codec that never touches `MediaCodec`. It reuses the exact same capture pipeline as `SurfaceEncoder` (`ScreenCapture`/`VirtualDisplay`, crop/rotation, `PositionMapper` for touch mapping), but instead of feeding a MediaCodec input `Surface`, it targets an `ImageReader` (RGBA_8888), grabs raw frames, and JPEG-compresses them on the CPU (`JpegEncoder`). Frames are streamed with a new `mjpg` fourcc that the client demuxes as `AV_CODEC_ID_MJPEG` — FFmpeg already decodes Motion JPEG natively, so no client-side rendering changes were needed.

This is deliberately a last-resort fallback, not a replacement for a real video codec:

- No RFB/VNC, no extra native `.so`, no new protocol — just one more codec option that reuses scrcpy's existing streaming/control infrastructure end to end (touch/key injection keeps working unchanged).
- JPEG per frame instead of raw ARGB8888 specifically so it stays usable over a slow/remote link, not just on localhost — quality is tunable (`--video-codec-options=quality=NN`, default 80), and frame rate is throttled via the existing `--max-fps` (default 4 fps if unset), so bandwidth/CPU stay bounded on weak devices too.
- Usage: `--video-codec=mjpeg` (optionally with `--max-fps=` and `--video-codec-options=quality=`).

## Limitations

- Recording (`--record`) with `mjpeg` is rejected for now, not tested against the muxers.
- JPEG-per-frame is obviously far less efficient than H264/H265/AV1 — this is only meant for devices where those aren't an option at all.

Tested manually against a real device with `--video-codec=mjpeg --max-fps=2 --video-codec-options=quality=70`: mirrors correctly and touch input keeps working.