### PR TITLE
Fix display capture regression on original Oculus Quest

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -134,7 +134,7 @@ public class ScreenCapture extends SurfaceCapture {
                     .createVirtualDisplay("scrcpy", inputSize.getWidth(), inputSize.getHeight(), displayId, surface);
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
-            if (Build.BRAND.equalsIgnoreCase("oculus") && Build.MODEL.startsWith("quest") && !Build.MODEL.equalsIgnoreCase("quest")) {
+            if (Build.BRAND.equalsIgnoreCase("oculus") && Build.MODEL.toLowerCase(Locale.ROOT).startsWith("quest ")) {
                 // Workaround for buggy createVirtualDisplay on Quest
                 // Extra workaround to fix the original Quest
                 try {

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -134,8 +134,9 @@ public class ScreenCapture extends SurfaceCapture {
                     .createVirtualDisplay("scrcpy", inputSize.getWidth(), inputSize.getHeight(), displayId, surface);
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
-            if (Build.BRAND.equalsIgnoreCase("oculus") && Build.MODEL.toLowerCase(Locale.ROOT).startsWith("quest")) {
+            if (Build.BRAND.equalsIgnoreCase("oculus") && Build.MODEL.startsWith("quest") && !Build.MODEL.equalsIgnoreCase("quest")) {
                 // Workaround for buggy createVirtualDisplay on Quest
+                // Extra workaround to fix the original Quest
                 try {
                     virtualDisplay = (VirtualDisplay) VirtualDisplay.class.getDeclaredConstructors()[0].newInstance(null, null, null, surface);
                 } catch (ReflectiveOperationException e) {


### PR DESCRIPTION
The workaround that @rom1v implemented in d3ffab9d7489af6cc0533adeb43e3cfa5b128c81 to fix #5913 broke the original Quest as it has not received updates from Meta in multiple years.

This PR restricts the workaround so it only applies to newer device generations (e.g. the Quest Pro, Quest 2, Quest 3/S) by excluding legacy hardware whose model identifier lacks a numerical suffix.