### PR TITLE
Capture more audio usages with --audio-dup

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -8,6 +8,7 @@ _scrcpy() {
         --audio-codec=
         --audio-codec-options=
         --audio-dup
+        --audio-dup=
         --audio-encoder=
         --audio-source=
         --audio-output-buffer=
@@ -169,6 +170,11 @@ _scrcpy() {
             ;;
         --pause-on-exit)
             COMPREPLY=($(compgen -W 'true false if-error' -- "$cur"))
+            return
+            ;;
+        --audio-dup)
+            # Only auto-complete a single usage
+            COMPREPLY=($(compgen -W 'all media unknown game alarm notification assistant sonification accessibility navigation voice-communication' -- "$cur"))
             return
             ;;
         -r|--record)

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -14,7 +14,7 @@ arguments=(
     '--audio-buffer=[Configure the audio buffering delay \(in milliseconds\)]'
     '--audio-codec=[Select the audio codec]:codec:(opus aac flac raw)'
     '--audio-codec-options=[Set a list of comma-separated key\:type=value options for the device audio encoder]'
-    '--audio-dup=[Duplicate audio]'
+    '--audio-dup=-[Duplicate audio, with an optional comma-separated list of extra usages to capture]:usages:(all media unknown game alarm notification assistant sonification accessibility navigation voice-communication)'
     '--audio-encoder=[Use a specific MediaCodec audio encoder]'
     '--audio-source=[Select the audio source]:source:(output playback mic mic-unprocessed mic-camcorder mic-voice-recognition mic-voice-communication voice-call voice-call-uplink voice-call-downlink voice-performance)'
     '--audio-output-buffer=[Configure the size of the SDL audio output buffer (in milliseconds)]'

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -198,9 +198,33 @@ static const struct sc_option options[] = {
     {
         .longopt_id = OPT_AUDIO_DUP,
         .longopt = "audio-dup",
+        .argdesc = "usages",
+        .optional_arg = true,
         .text = "Duplicate audio (capture and keep playing on the device).\n"
-                "This feature is only available with --audio-source=playback."
-
+                "This feature is only available with --audio-source=playback.\n"
+                "Audio playback capture matches each player by its audio usage, "
+                "and only \"media\" is captured by default. Games using an audio "
+                "engine such as Wwise declare \"game\" instead, so their sound is "
+                "not captured unless it is requested explicitly.\n"
+                "An optional comma-separated list of extra usages to capture may "
+                "be provided. Possible values are:\n"
+                " - \"all\": every usage listed below.\n"
+                " - \"unknown\": players not declaring any usage.\n"
+                " - \"game\": game audio engines (Wwise, FMOD, Unity, Unreal…).\n"
+                " - \"alarm\"\n"
+                " - \"notification\"\n"
+                " - \"assistant\"\n"
+                " - \"sonification\": UI sounds and other system feedback.\n"
+                " - \"accessibility\"\n"
+                " - \"navigation\"\n"
+                " - \"voice-communication\": voice calls and in-game voice chat.\n"
+                "The \"media\" usage is always captured, so passing no value "
+                "behaves exactly like upstream scrcpy.\n"
+                "Examples:\n"
+                "    --audio-dup             # media only\n"
+                "    --audio-dup=game        # media + game\n"
+                "    --audio-dup=game,voice-communication\n"
+                "    --audio-dup=all"
     },
     {
         .longopt_id = OPT_AUDIO_ENCODER,
@@ -2145,6 +2169,62 @@ parse_audio_source(const char *optarg, enum sc_audio_source *source) {
     return false;
 }
 
+// The names are resolved to AudioAttributes usages by the server
+static const char *const sc_audio_dup_usages[] = {
+    "all",
+    "media",
+    "unknown",
+    "game",
+    "alarm",
+    "notification",
+    "assistant",
+    "sonification",
+    "accessibility",
+    "navigation",
+    "voice-communication",
+};
+
+static bool
+parse_audio_dup_usages(const char *optarg) {
+    if (!*optarg) {
+        LOGE("--audio-dup requires at least one audio usage");
+        return false;
+    }
+
+    const char *p = optarg;
+    for (;;) {
+        const char *sep = strchr(p, ',');
+        size_t len = sep ? (size_t) (sep - p) : strlen(p);
+
+        if (!len) {
+            LOGE("Empty audio usage in --audio-dup list: '%s'", optarg);
+            return false;
+        }
+
+        bool found = false;
+        for (size_t i = 0; i < ARRAY_LEN(sc_audio_dup_usages); ++i) {
+            const char *name = sc_audio_dup_usages[i];
+            if (!strncmp(p, name, len) && !name[len]) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            LOGE("Unsupported audio usage: '%.*s' (expected all, media, "
+                 "unknown, game, alarm, notification, assistant, sonification, "
+                 "accessibility, navigation or voice-communication)",
+                 (int) len, p);
+            return false;
+        }
+
+        if (!sep) {
+            return true;
+        }
+        p = sep + 1;
+    }
+}
+
 static bool
 parse_camera_facing(const char *optarg, enum sc_camera_facing *facing) {
     if (!strcmp(optarg, "front")) {
@@ -2878,6 +2958,12 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_AUDIO_DUP:
                 opts->audio_dup = true;
+                if (optarg) {
+                    if (!parse_audio_dup_usages(optarg)) {
+                        return false;
+                    }
+                    opts->audio_dup_usages = optarg;
+                }
                 break;
             case 'G':
                 opts->gamepad_input_mode = SC_GAMEPAD_INPUT_MODE_UHID_OR_AOA;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -113,6 +113,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .window = true,
     .mouse_hover = true,
     .audio_dup = false,
+    .audio_dup_usages = NULL,
     .new_display = NULL,
     .start_app = NULL,
     .angle = NULL,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -337,6 +337,9 @@ struct scrcpy_options {
     bool window;
     bool mouse_hover;
     bool audio_dup;
+    // Comma-separated list of extra audio usages to capture, parsed by the
+    // server. NULL means USAGE_MEDIA only (the historical behavior).
+    const char *audio_dup_usages;
     const char *new_display; // [<width>x<height>][/<dpi>] parsed by the server
     const char *start_app;
     bool vd_destroy_content;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -393,6 +393,7 @@ scrcpy(struct scrcpy_options *options) {
         .video = options->video,
         .audio = options->audio,
         .audio_dup = options->audio_dup,
+        .audio_dup_usages = options->audio_dup_usages,
         .show_touches = options->show_touches,
         .stay_awake = options->stay_awake,
         .video_codec_options = options->video_codec_options,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -302,6 +302,10 @@ execute_server(struct sc_server *server,
     if (params->audio_dup) {
         ADD_PARAM("audio_dup=true");
     }
+    if (params->audio_dup_usages) {
+        VALIDATE_STRING(params->audio_dup_usages);
+        ADD_PARAM("audio_dup_usages=%s", params->audio_dup_usages);
+    }
     if (params->max_size) {
         ADD_PARAM("max_size=%" PRIu16, params->max_size);
     }

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -56,6 +56,7 @@ struct sc_server_params {
     bool video;
     bool audio;
     bool audio_dup;
+    const char *audio_dup_usages; // comma-separated list parsed by the server
     bool show_touches;
     bool stay_awake;
     bool force_adb_forward;

--- a/doc/audio.md
+++ b/doc/audio.md
@@ -105,6 +105,47 @@ captured).
 See [#4380](https://github.com/Genymobile/scrcpy/issues/4380).
 
 
+#### Audio usages
+
+Unlike `--audio-source=output`, which captures the final mix at the device
+level, playback capture selects each player individually by its _audio usage_.
+A matching rule compares the usage for strict equality (there is no notion of
+category), and only `media` is captured by default.
+
+This matters for games: the Android [low latency audio] guidelines instruct
+games to declare the `game` usage, which audio engines such as Wwise, FMOD,
+Unity and Unreal do. Their sound is therefore _not_ captured by default, while
+other sounds from the very same app (a cutscene played by `MediaPlayer`, for
+example) are.
+
+[low latency audio]: https://developer.android.com/games/sdk/oboe/low-latency-audio
+
+To capture more, pass a comma-separated list of extra usages:
+
+```bash
+scrcpy --audio-dup=game                    # media + game
+scrcpy --audio-dup=game,voice-communication
+scrcpy --audio-dup=all                     # everything below
+```
+
+Possible values are `all`, `unknown`, `game`, `alarm`, `notification`,
+`assistant`, `sonification` (UI sounds), `accessibility`, `navigation` and
+`voice-communication`. The `media` usage is always captured, so `--audio-dup`
+without any value behaves exactly like upstream _scrcpy_.
+
+To find out which usage a specific sound uses, run the following command while
+it is playing, then look for `state:started` entries in the `players:` section:
+
+```bash
+adb shell dumpsys audio
+```
+
+If a sound is still not captured after requesting its usage, it may be using
+the AAudio MMAP exclusive low latency path, which bypasses the mixer and cannot
+be intercepted by a dynamic audio policy. In that case, only
+`--audio-source=output` can capture it (at the cost of muting the device).
+
+
 ## Codec
 
 The audio codec can be selected. The possible values are `opus` (default),

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy;
 
 import com.genymobile.scrcpy.audio.AudioCodec;
 import com.genymobile.scrcpy.audio.AudioSource;
+import com.genymobile.scrcpy.audio.AudioUsage;
 import com.genymobile.scrcpy.device.Device;
 import com.genymobile.scrcpy.model.CodecOption;
 import com.genymobile.scrcpy.model.NewDisplay;
@@ -17,8 +18,10 @@ import com.genymobile.scrcpy.wrappers.WindowManager;
 import android.graphics.Rect;
 import android.util.Pair;
 
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 public class Options {
 
@@ -33,6 +36,7 @@ public class Options {
     private VideoSource videoSource = VideoSource.DISPLAY;
     private AudioSource audioSource = AudioSource.OUTPUT;
     private boolean audioDup;
+    private Set<AudioUsage> audioDupUsages = EnumSet.of(AudioUsage.MEDIA);
     private int videoBitRate = 8000000;
     private int audioBitRate = 128000;
     private float maxFps;
@@ -129,6 +133,10 @@ public class Options {
 
     public boolean getAudioDup() {
         return audioDup;
+    }
+
+    public Set<AudioUsage> getAudioDupUsages() {
+        return audioDupUsages;
     }
 
     public int getVideoBitRate() {
@@ -389,6 +397,9 @@ public class Options {
                 case "audio_dup":
                     options.audioDup = Boolean.parseBoolean(value);
                     break;
+                case "audio_dup_usages":
+                    options.audioDupUsages = parseAudioDupUsages(value);
+                    break;
                 case "max_size":
                     options.maxSize = Integer.parseInt(value);
                     break;
@@ -637,6 +648,25 @@ public class Options {
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid float value for " + key + ": \"" + value + "\"");
         }
+    }
+
+    private static Set<AudioUsage> parseAudioDupUsages(String value) {
+        // MEDIA is always captured, so that an empty list behaves like upstream scrcpy
+        Set<AudioUsage> usages = EnumSet.of(AudioUsage.MEDIA);
+
+        for (String name : value.split(",", -1)) {
+            if ("all".equals(name)) {
+                return EnumSet.allOf(AudioUsage.class);
+            }
+
+            AudioUsage usage = AudioUsage.findByName(name);
+            if (usage == null) {
+                throw new IllegalArgumentException("Audio usage \"" + name + "\" not supported");
+            }
+            usages.add(usage);
+        }
+
+        return usages;
     }
 
     private static NewDisplay parseNewDisplay(String newDisplay) {

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -123,7 +123,7 @@ public final class Server {
                 if (audioSource.isDirect()) {
                     audioCapture = new AudioDirectCapture(audioSource);
                 } else {
-                    audioCapture = new AudioPlaybackCapture(options.getAudioDup());
+                    audioCapture = new AudioPlaybackCapture(options.getAudioDup(), options.getAudioDupUsages());
                 }
 
                 Streamer audioStreamer = new Streamer(connection.getAudioFd(), audioCodec, options.getSendStreamMeta(), options.getSendFrameMeta());

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
@@ -16,16 +16,19 @@ import android.os.Build;
 
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.Set;
 
 public final class AudioPlaybackCapture implements AudioCapture {
 
     private final boolean keepPlayingOnDevice;
+    private final Set<AudioUsage> usages;
 
     private AudioRecord recorder;
     private AudioRecordReader reader;
 
-    public AudioPlaybackCapture(boolean keepPlayingOnDevice) {
+    public AudioPlaybackCapture(boolean keepPlayingOnDevice, Set<AudioUsage> usages) {
         this.keepPlayingOnDevice = keepPlayingOnDevice;
+        this.usages = usages;
     }
 
     @SuppressLint("PrivateApi")
@@ -44,7 +47,7 @@ public final class AudioPlaybackCapture implements AudioCapture {
             setTargetMixRoleMethod.invoke(audioMixingRuleBuilder, mixRolePlayersConstant);
 
             // audioMixingRuleBuilder.voiceCommunicationCaptureAllowed(true);
-            // Must be called before build(), otherwise it only mutates the builder and has no effect on the rule
+            // Must be called before build(), and is required for USAGE_VOICE_COMMUNICATION to be captured at all
             try {
                 Method voiceCommunicationCaptureAllowedMethod = audioMixingRuleBuilderClass.getMethod("voiceCommunicationCaptureAllowed",
                         boolean.class);
@@ -53,12 +56,14 @@ public final class AudioPlaybackCapture implements AudioCapture {
                 Ln.w("Voice communication capture not supported on this device");
             }
 
-            AudioAttributes attributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build();
-
             // audioMixingRuleBuilder.addMixRule(AudioMixingRule.RULE_MATCH_ATTRIBUTE_USAGE, attributes);
+            // A rule matches a usage exactly, and several "match" rules of the same kind are OR-ed together by the audio policy
             int ruleMatchAttributeUsageConstant = audioMixingRuleClass.getField("RULE_MATCH_ATTRIBUTE_USAGE").getInt(null);
             Method addMixRuleMethod = audioMixingRuleBuilderClass.getMethod("addMixRule", int.class, Object.class);
-            addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant, attributes);
+            for (AudioUsage usage : usages) {
+                AudioAttributes attributes = new AudioAttributes.Builder().setUsage(usage.getAttributesUsage()).build();
+                addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant, attributes);
+            }
 
             // AudioMixingRule audioMixingRule = builder.build();
             Object audioMixingRule = audioMixingRuleBuilderClass.getMethod("build").invoke(audioMixingRuleBuilder);

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioPlaybackCapture.java
@@ -43,6 +43,16 @@ public final class AudioPlaybackCapture implements AudioCapture {
             Method setTargetMixRoleMethod = audioMixingRuleBuilderClass.getMethod("setTargetMixRole", int.class);
             setTargetMixRoleMethod.invoke(audioMixingRuleBuilder, mixRolePlayersConstant);
 
+            // audioMixingRuleBuilder.voiceCommunicationCaptureAllowed(true);
+            // Must be called before build(), otherwise it only mutates the builder and has no effect on the rule
+            try {
+                Method voiceCommunicationCaptureAllowedMethod = audioMixingRuleBuilderClass.getMethod("voiceCommunicationCaptureAllowed",
+                        boolean.class);
+                voiceCommunicationCaptureAllowedMethod.invoke(audioMixingRuleBuilder, true);
+            } catch (NoSuchMethodException e) {
+                Ln.w("Voice communication capture not supported on this device");
+            }
+
             AudioAttributes attributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build();
 
             // audioMixingRuleBuilder.addMixRule(AudioMixingRule.RULE_MATCH_ATTRIBUTE_USAGE, attributes);
@@ -52,10 +62,6 @@ public final class AudioPlaybackCapture implements AudioCapture {
 
             // AudioMixingRule audioMixingRule = builder.build();
             Object audioMixingRule = audioMixingRuleBuilderClass.getMethod("build").invoke(audioMixingRuleBuilder);
-
-            // audioMixingRuleBuilder.voiceCommunicationCaptureAllowed(true);
-            Method voiceCommunicationCaptureAllowedMethod = audioMixingRuleBuilderClass.getMethod("voiceCommunicationCaptureAllowed", boolean.class);
-            voiceCommunicationCaptureAllowedMethod.invoke(audioMixingRuleBuilder, true);
 
             Class<?> audioMixClass = Class.forName("android.media.audiopolicy.AudioMix");
             Class<?> audioMixBuilderClass = Class.forName("android.media.audiopolicy.AudioMix$Builder");

--- a/server/src/main/java/com/genymobile/scrcpy/audio/AudioUsage.java
+++ b/server/src/main/java/com/genymobile/scrcpy/audio/AudioUsage.java
@@ -1,0 +1,46 @@
+package com.genymobile.scrcpy.audio;
+
+import android.media.AudioAttributes;
+
+/**
+ * Audio usages which may be routed to the playback capture mixing rule.
+ * <p>
+ * A mixing rule matches a usage exactly (there is no notion of category), so every usage to capture must be requested explicitly. MEDIA is always
+ * captured; the others are opt-in through {@code --audio-dup=<usages>}.
+ */
+public enum AudioUsage {
+    MEDIA("media", AudioAttributes.USAGE_MEDIA),
+    UNKNOWN("unknown", AudioAttributes.USAGE_UNKNOWN),
+    GAME("game", AudioAttributes.USAGE_GAME),
+    ALARM("alarm", AudioAttributes.USAGE_ALARM),
+    NOTIFICATION("notification", AudioAttributes.USAGE_NOTIFICATION),
+    ASSISTANT("assistant", AudioAttributes.USAGE_ASSISTANT),
+    SONIFICATION("sonification", AudioAttributes.USAGE_ASSISTANCE_SONIFICATION),
+    ACCESSIBILITY("accessibility", AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY),
+    NAVIGATION("navigation", AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE),
+    VOICE_COMMUNICATION("voice-communication", AudioAttributes.USAGE_VOICE_COMMUNICATION);
+
+    // USAGE_VIRTUAL_SOURCE is deliberately absent: it would capture the loopback itself
+
+    private final String name;
+    private final int attributesUsage;
+
+    AudioUsage(String name, int attributesUsage) {
+        this.name = name;
+        this.attributesUsage = attributesUsage;
+    }
+
+    public int getAttributesUsage() {
+        return attributesUsage;
+    }
+
+    public static AudioUsage findByName(String name) {
+        for (AudioUsage usage : AudioUsage.values()) {
+            if (name.equals(usage.name)) {
+                return usage;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

`--audio-dup` (audio playback capture) only captures players declaring
`USAGE_MEDIA`. This silently drops game audio, which declares `USAGE_GAME`.
This PR makes the set of captured usages configurable via an optional argument,
keeping the current behavior when no value is passed.

## Problem

While mirroring a game, sounds going through the audio engine were missing from
the forwarded stream, while other sounds from the very same app were forwarded
correctly. Using the default `--audio-source=output` captured everything.

`adb shell dumpsys audio` shows the app (same uid/pid) playing two streams that
differ only by their usage:

```
AudioPlaybackConfiguration piid:16695 deviceIds:[3] type:OpenSL ES AudioPlayer (Buffer Queue) u/pid:10499/3001 state:started attr:AudioAttributes: usage=USAGE_MEDIA ...
AudioPlaybackConfiguration piid:16711 deviceIds:[3] type:AAudio                              u/pid:10499/3001 state:started attr:AudioAttributes: usage=USAGE_GAME  ...
```

Only the first one was captured.

## Root cause

`AudioPlaybackCapture` adds a single mixing rule:

```java
AudioAttributes attributes = new AudioAttributes.Builder().setUsage(AudioAttributes.USAGE_MEDIA).build();
addMixRuleMethod.invoke(audioMixingRuleBuilder, ruleMatchAttributeUsageConstant, attributes);
```

`RULE_MATCH_ATTRIBUTE_USAGE` compares the usage for strict equality, and there
is no notion of category, so `USAGE_GAME` does not match `USAGE_MEDIA` (they are
only grouped together for *volume* control, both mapping to `STREAM_MUSIC`,
which makes this easy to miss).

Games are expected to declare `USAGE_GAME`: the Android
[low latency audio guidelines][1] require `AAUDIO_USAGE_GAME` for latency
optimizations, and audio engines such as Wwise, FMOD, Unity and Unreal follow
that. So they are doing the right thing and get filtered out.

For reference, Android's own public playback capture API documents that only
`USAGE_UNKNOWN`, `USAGE_GAME` and `USAGE_MEDIA` can ever be captured by
non-privileged apps, i.e. `USAGE_GAME` is one of the three main cases. scrcpy
registers its policy as shell (with `MODIFY_AUDIO_ROUTING`), so it is not
restricted to those three.

[1]: https://developer.android.com/games/sdk/oboe/low-latency-audio

## Changes

`--audio-dup` now accepts an optional comma-separated list of extra usages:

```bash
scrcpy --audio-dup                           # media only (unchanged)
scrcpy --audio-dup=game                      # media + game
scrcpy --audio-dup=game,voice-communication
scrcpy --audio-dup=all
```

Possible values are `all`, `unknown`, `game`, `alarm`, `notification`,
`assistant`, `sonification`, `accessibility`, `navigation` and
`voice-communication`. `USAGE_MEDIA` is always captured, so passing no value is
strictly identical to the current behavior. `USAGE_VIRTUAL_SOURCE` is not
exposed, since it would capture the loopback itself.

Several "match" rules of the same kind are OR-ed together by the audio policy,
so this is just a matter of calling `addMixRule()` once per usage. Names are
validated client-side, so a typo fails immediately instead of on the device.

A separate commit fixes `voiceCommunicationCaptureAllowed(true)`, which was
called *after* `AudioMixingRule.Builder.build()` and therefore only mutated the
builder, leaving the built rule untouched. It is required for
`USAGE_VOICE_COMMUNICATION` to be captured at all. Its absence on ROMs that do
not expose the hidden method is now tolerated with a warning instead of failing
the whole audio capture.

Related to #4380.

## Testing

- Verified on a OnePlus PJZ110 (Android 16) that `--audio-dup=game` captures the
  `USAGE_GAME` AAudio stream shown above, which was silent before.
- Checked that plain `--audio-dup` still produces the same result as before.
- Unit-tested the option parser against valid lists, unknown names, wrong case,
  empty values and malformed separators (leading, trailing and doubled commas).

## Notes

Some players may still not be captured after requesting their usage if they use
the AAudio MMAP exclusive low latency path, which bypasses the mixer and cannot
be intercepted by a dynamic audio policy. This is documented in `doc/audio.md`
along with how to identify a player's usage via `dumpsys audio`.