### PR TITLE
feat: keep server binary while restoring device state

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -58,6 +58,7 @@ _scrcpy() {
         --no-audio
         --no-audio-playback
         --no-cleanup
+        --no-server-cleanup
         --no-clipboard-autosync
         --no-downsize-on-error
         --no-key-repeat

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -64,6 +64,7 @@ arguments=(
     '--no-audio[Disable audio forwarding]'
     '--no-audio-playback[Disable audio playback]'
     '--no-cleanup[Disable device cleanup actions on exit]'
+    '--no-server-cleanup[Keep the server binary on the device while restoring device state]'
     '--no-clipboard-autosync[Disable automatic clipboard synchronization]'
     '--no-downsize-on-error[Disable lowering definition on MediaCodec error]'
     '--no-key-repeat[Do not forward repeated key events when a key is held down]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -401,6 +401,10 @@ By default, scrcpy removes the server binary from the device and restores the de
 This option disables this cleanup.
 
 .TP
+.B \-\-no\-server\-cleanup
+Keep the server binary on the device while still restoring the device state (show touches, stay awake and power mode) on exit.
+
+.TP
 .B \-\-no\-clipboard\-autosync
 By default, scrcpy automatically synchronizes the computer clipboard to the device clipboard before injecting Ctrl+v, and the device clipboard to the computer clipboard whenever it changes.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -54,6 +54,7 @@ enum {
     OPT_NO_DOWNSIZE_ON_ERROR,
     OPT_OTG,
     OPT_NO_CLEANUP,
+    OPT_NO_SERVER_CLEANUP,
     OPT_PRINT_FPS,
     OPT_NO_POWER_ON,
     OPT_VIDEO_CODEC,
@@ -628,6 +629,13 @@ static const struct sc_option options[] = {
                 "and restores the device state (show touches, stay awake and "
                 "power mode) on exit.\n"
                 "This option disables this cleanup."
+    },
+    {
+        .longopt_id = OPT_NO_SERVER_CLEANUP,
+        .longopt = "no-server-cleanup",
+        .text = "Keep the server binary on the device while still restoring "
+                "the device state (show touches, stay awake and power mode) "
+                "on exit.",
     },
     {
         .longopt_id = OPT_NO_CLIPBOARD_AUTOSYNC,
@@ -2748,6 +2756,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_CLEANUP:
                 opts->cleanup = false;
+                break;
+            case OPT_NO_SERVER_CLEANUP:
+                opts->unlink_server = false;
                 break;
             case OPT_NO_POWER_ON:
                 opts->power_on = false;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -102,6 +102,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .select_tcpip = false,
     .select_usb = false,
     .cleanup = true,
+    .unlink_server = true,
     .start_fps_counter = false,
     .power_on = true,
     .video = true,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -321,6 +321,7 @@ struct scrcpy_options {
     bool select_usb;
     bool select_tcpip;
     bool cleanup;
+    bool unlink_server;
     bool start_fps_counter;
     bool power_on;
     bool video;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -410,6 +410,7 @@ scrcpy(struct scrcpy_options *options) {
         .tcpip = options->tcpip,
         .tcpip_dst = options->tcpip_dst,
         .cleanup = options->cleanup,
+        .unlink_server = options->unlink_server,
         .power_on = options->power_on,
         .kill_adb_on_close = options->kill_adb_on_close,
         .camera_high_speed = options->camera_high_speed,

--- a/app/src/server.c
+++ b/app/src/server.c
@@ -413,6 +413,10 @@ execute_server(struct sc_server *server,
         // By default, cleanup is true
         ADD_PARAM("cleanup=false");
     }
+    if (!params->unlink_server) {
+        // By default, the server binary is removed on exit
+        ADD_PARAM("unlink_server=false");
+    }
     if (!params->power_on) {
         // By default, power_on is true
         ADD_PARAM("power_on=false");

--- a/app/src/server.h
+++ b/app/src/server.h
@@ -67,6 +67,7 @@ struct sc_server_params {
     bool select_usb;
     bool select_tcpip;
     bool cleanup;
+    bool unlink_server;
     bool power_on;
     bool kill_adb_on_close;
     bool camera_high_speed;

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -121,6 +121,26 @@ static void test_options2(void) {
     assert(opts->record_format == SC_RECORD_FORMAT_MP4);
 }
 
+static void test_no_server_cleanup(void) {
+    struct scrcpy_cli_args args = {
+        .opts = scrcpy_options_default,
+        .help = false,
+        .version = false,
+    };
+
+    assert(args.opts.unlink_server);
+
+    char *argv[] = {
+        "scrcpy",
+        "--no-server-cleanup",
+    };
+
+    bool ok = scrcpy_parse_args(&args, ARRAY_LEN(argv), argv);
+    assert(ok);
+    assert(!args.opts.unlink_server);
+    assert(args.opts.cleanup);
+}
+
 static void test_parse_shortcut_mods(void) {
     uint8_t mods;
     bool ok;
@@ -157,6 +177,7 @@ int main(int argc, char *argv[]) {
     test_flag_help();
     test_options();
     test_options2();
+    test_no_server_cleanup();
     test_parse_shortcut_mods();
     return 0;
 }

--- a/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
+++ b/server/src/main/java/com/genymobile/scrcpy/CleanUp.java
@@ -116,14 +116,15 @@ public final class CleanUp {
         boolean powerOffScreen = options.getPowerOffScreenOnClose();
 
         try {
-            run(displayId, restoreStayOn, disableShowTouches, powerOffScreen, restoreScreenOffTimeout, restoreDisplayImePolicy);
+            run(displayId, restoreStayOn, disableShowTouches, powerOffScreen, restoreScreenOffTimeout, restoreDisplayImePolicy,
+                    options.getUnlinkServer());
         } catch (IOException e) {
             Ln.e("Clean up I/O exception", e);
         }
     }
 
     private void run(int displayId, int restoreStayOn, boolean disableShowTouches, boolean powerOffScreen, int restoreScreenOffTimeout,
-            int restoreDisplayImePolicy) throws IOException {
+            int restoreDisplayImePolicy, boolean unlinkServer) throws IOException {
         String[] cmd = {
                 "app_process",
                 "/",
@@ -134,6 +135,7 @@ public final class CleanUp {
                 String.valueOf(powerOffScreen),
                 String.valueOf(restoreScreenOffTimeout),
                 String.valueOf(restoreDisplayImePolicy),
+                String.valueOf(unlinkServer),
         };
 
         ProcessBuilder builder = new ProcessBuilder(cmd);
@@ -192,8 +194,6 @@ public final class CleanUp {
         } catch (ErrnoException e) {
             Ln.e("setsid() failed", e);
         }
-        unlinkSelf();
-
         // Needed for workarounds
         prepareMainLooper();
         Workarounds.apply();
@@ -204,6 +204,11 @@ public final class CleanUp {
         boolean powerOffScreen = Boolean.parseBoolean(args[3]);
         int restoreScreenOffTimeout = Integer.parseInt(args[4]);
         int restoreDisplayImePolicy = Integer.parseInt(args[5]);
+        boolean unlinkServer = Boolean.parseBoolean(args[6]);
+
+        if (unlinkServer) {
+            unlinkSelf();
+        }
 
         // Dynamic option
         boolean restoreDisplayPower = false;

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -62,6 +62,7 @@ public class Options {
     private boolean clipboardAutosync = true;
     private boolean downsizeOnError = true;
     private boolean cleanup = true;
+    private boolean unlinkServer = true;
     private boolean powerOn = true;
 
     private NewDisplay newDisplay;
@@ -241,6 +242,10 @@ public class Options {
 
     public boolean getCleanup() {
         return cleanup;
+    }
+
+    public boolean getUnlinkServer() {
+        return unlinkServer;
     }
 
     public boolean getPowerOn() {
@@ -464,6 +469,9 @@ public class Options {
                     break;
                 case "cleanup":
                     options.cleanup = Boolean.parseBoolean(value);
+                    break;
+                case "unlink_server":
+                    options.unlinkServer = Boolean.parseBoolean(value);
                     break;
                 case "power_on":
                     options.powerOn = Boolean.parseBoolean(value);

--- a/server/src/main/java/com/genymobile/scrcpy/Server.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Server.java
@@ -245,7 +245,7 @@ public final class Server {
         Ln.i("Device: [" + Build.MANUFACTURER + "] " + Build.BRAND + " " + Build.MODEL + " (Android " + Build.VERSION.RELEASE + ")");
 
         if (options.getList()) {
-            if (options.getCleanup()) {
+            if (options.getCleanup() && options.getUnlinkServer()) {
                 CleanUp.unlinkSelf();
             }
 

--- a/server/src/test/java/com/genymobile/scrcpy/OptionsTest.java
+++ b/server/src/test/java/com/genymobile/scrcpy/OptionsTest.java
@@ -1,0 +1,17 @@
+package com.genymobile.scrcpy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OptionsTest {
+    @Test
+    public void testUnlinkServerOption() {
+        Options defaults = Options.parse(BuildConfig.VERSION_NAME);
+        Assert.assertTrue(defaults.getCleanup());
+        Assert.assertTrue(defaults.getUnlinkServer());
+
+        Options keepServer = Options.parse(BuildConfig.VERSION_NAME, "cleanup=true", "unlink_server=false");
+        Assert.assertTrue(keepServer.getCleanup());
+        Assert.assertFalse(keepServer.getUnlinkServer());
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6955 by separating server-file retention from device-state cleanup.

When a client needs to reuse `scrcpy-server.jar` across sessions, `cleanup=false` currently also skips restoration of device state. This adds `--no-server-cleanup` and the corresponding `unlink_server=false` server option so the cleanup process still restores show-touches, stay-awake, screen-off timeout, display IME policy, and display power state while leaving the server file in place.

The default behavior is unchanged: the server file is still removed unless the new option is explicitly requested. Shell completions and the manual page document the new option.

## Validation

- Java server sources compiled with the Android SDK 37 platform and build tools.
- `OptionsTest` passed with JUnit 4.13.2.
- C syntax checks passed for `app/src/cli.c`, `app/src/options.c`, and `app/src/server.c`.
- `git diff --check` passed.