### PR TITLE
Fix dropped keys in UHID mode for some keyboard layouts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ build/
 /x/
 local.properties
 /scrcpy-server
-Start-Wireless-Scrcpy.bat
-issue6983.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 /x/
 local.properties
 /scrcpy-server
+Start-Wireless-Scrcpy.bat
+issue6983.json

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@ build/
 /x/
 local.properties
 /scrcpy-server
-

--- a/app/src/input_manager.c
+++ b/app/src/input_manager.c
@@ -707,12 +707,9 @@ sc_input_manager_process_key(struct sc_input_manager *im,
     }
 
     enum sc_keycode keycode = sc_keycode_from_sdl(sdl_keycode);
-    if (keycode == SC_KEYCODE_UNKNOWN) {
-        return;
-    }
-
     enum sc_scancode scancode = sc_scancode_from_sdl(event->scancode);
-    if (scancode == SC_SCANCODE_UNKNOWN) {
+
+    if (keycode == SC_KEYCODE_UNKNOWN && scancode == SC_SCANCODE_UNKNOWN) {
         return;
     }
 


### PR DESCRIPTION
Subject: Fix dropped keys in UHID mode for some keyboard layouts

Description: This PR fixes Issue #6983 where the Right Shift key is ignored on Korean layouts when using the UHID keyboard (-K).

Background & Testing: We successfully reproduced this issue by testing the Right Shift key under the English (India) layout, which successfully emitted the e5 scancode. However, switching to the Korean IME in Windows caused the Right Shift key to completely fail in scrcpy.

Root Cause Analysis: This is a regression introduced during the SDL3 migration in c8479fe8 ("Discard unknown SDL events"). Because the Korean IME hooks the Right Shift key, SDL3 does not assign it a standard virtual keycode (SDLK_UNKNOWN), but it still faithfully reports the physical hardware scancode (e5).

Because of the strict filter introduced in c8479fe8, scrcpy was dropping the key event entirely whenever the virtual keycode was unknown. This broke the contract of -K (UHID mode), which is designed to bypass the OS layout and rely purely on the physical scancode.

The Fix: This PR relaxes the filter in input_manager.c. It now only drops the key event if both the virtual keycode AND the physical scancode are unknown. This safely allows physical keys intercepted by OS layouts to still be passed through to the Android device in UHID mode, while still protecting the injection layer from garbage events