### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup JDK
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu'
           java-version: '17'


### PR DESCRIPTION
## Summary

Upgrade all three release workflow references from actions/setup-java v5 to v6.0.0.

## Validation

Reviewed the workflow-only diff and verified no setup-java reference older than v6 remains in active workflow YAML.