### PR TITLE
Add zero-copy hardware decoding for Linux, Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
              libasound2-dev libpulse-dev \
              libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
              libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
-             libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+             libxkbcommon-dev libdrm-dev libva-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
              libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev \
              libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev
 
@@ -122,7 +122,7 @@ jobs:
              libasound2-dev libpulse-dev \
              libaudio-dev libfribidi-dev libjack-dev libsndio-dev libx11-dev libxext-dev \
              libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
-             libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
+             libxkbcommon-dev libdrm-dev libva-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
              libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libthai-dev \
              libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev
 

--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -60,6 +60,7 @@ _scrcpy() {
         --no-cleanup
         --no-clipboard-autosync
         --no-downsize-on-error
+        --no-hardware-decoding
         --no-key-repeat
         --no-mipmaps
         --no-mouse-hover

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -66,6 +66,7 @@ arguments=(
     '--no-cleanup[Disable device cleanup actions on exit]'
     '--no-clipboard-autosync[Disable automatic clipboard synchronization]'
     '--no-downsize-on-error[Disable lowering definition on MediaCodec error]'
+    '--no-hardware-decoding[Disable hardware video decoding on the computer]'
     '--no-key-repeat[Do not forward repeated key events when a key is held down]'
     '--no-mipmaps[Disable the generation of mipmaps]'
     '--no-mouse-hover[Do not forward mouse hover events]'

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -56,7 +56,6 @@ else
         --disable-network
         --disable-everything
         --disable-vulkan
-        --disable-vaapi
         --disable-vdpau
         --enable-swresample
         --enable-libdav1d
@@ -82,19 +81,47 @@ else
         --enable-muxer=wav
     )
 
-    if [[ "$HOST" == linux ]]
-    then
-        conf+=(
-            --enable-libv4l2
-            --enable-outdev=v4l2
-            --enable-encoder=rawvideo
-        )
-    else
-        # libavdevice is only used for V4L2 on Linux
-        conf+=(
-            --disable-avdevice
-        )
-    fi
+    case "$HOST" in
+        linux)
+            conf+=(
+                --enable-vaapi
+                --enable-libdrm
+                --disable-xlib
+                --enable-hwaccel=h264_vaapi
+                --enable-hwaccel=hevc_vaapi
+                --enable-hwaccel=av1_vaapi
+                --enable-hwaccel=vp8_vaapi
+                --enable-hwaccel=vp9_vaapi
+                --enable-libv4l2
+                --enable-outdev=v4l2
+                --enable-encoder=rawvideo
+            )
+            ;;
+        macos)
+            conf+=(
+                --disable-avdevice
+                --enable-videotoolbox
+                --enable-hwaccel=h264_videotoolbox
+                --enable-hwaccel=hevc_videotoolbox
+                --enable-hwaccel=av1_videotoolbox
+                --enable-hwaccel=vp9_videotoolbox
+            )
+            ;;
+        win*)
+            conf+=(
+                --disable-avdevice
+                --enable-d3d11va
+                --enable-hwaccel=h264_d3d11va
+                --enable-hwaccel=hevc_d3d11va
+                --enable-hwaccel=av1_d3d11va
+                --enable-hwaccel=vp9_d3d11va
+                --enable-hwaccel=h264_d3d11va2
+                --enable-hwaccel=hevc_d3d11va2
+                --enable-hwaccel=av1_d3d11va2
+                --enable-hwaccel=vp9_d3d11va2
+            )
+            ;;
+    esac
 
     if [[ "$LINK_TYPE" == static ]]
     then

--- a/app/meson.build
+++ b/app/meson.build
@@ -106,6 +106,75 @@ if v4l2_support
     src += [ 'src/v4l2_sink.c' ]
 endif
 
+cc = meson.get_compiler('c')
+
+static = get_option('static')
+
+avformat_dep = dependency('libavformat', version: '>= 57.33', static: static)
+avcodec_dep = dependency('libavcodec', version: '>= 57.37', static: static)
+avutil_dep = dependency('libavutil', static: static)
+swresample_dep = dependency('libswresample', static: static)
+sdl_dep = dependency('sdl3', version: '>= 3.2.0', static: static)
+
+dependencies = [
+    avformat_dep,
+    avcodec_dep,
+    avutil_dep,
+    swresample_dep,
+    sdl_dep,
+]
+
+hwaccel_opt = get_option('hardware_decoding')
+hwaccel_support = false
+if host_machine.system() == 'linux' and not hwaccel_opt.disabled()
+    has_vaapi_api = cc.has_header_symbol(
+        'libavutil/hwcontext.h', 'AV_HWDEVICE_TYPE_VAAPI',
+        dependencies: avutil_dep)
+    has_vaapi_api = has_vaapi_api and cc.has_header_symbol(
+        'libavutil/pixfmt.h', 'AV_PIX_FMT_DRM_PRIME',
+        dependencies: avutil_dep)
+    libdrm_dep = dependency('libdrm', required: hwaccel_opt)
+    hwaccel_support = has_vaapi_api and libdrm_dep.found()
+    if hwaccel_support
+        conf.set('SC_HAVE_VAAPI', true)
+        src += [ 'src/vaapi.c' ]
+    elif hwaccel_opt.enabled()
+        error('The installed FFmpeg does not provide the required VA-API API')
+    endif
+elif host_machine.system() == 'windows' and not hwaccel_opt.disabled()
+    hwaccel_support = cc.has_header_symbol(
+        'libavutil/hwcontext.h', 'AV_HWDEVICE_TYPE_D3D11VA',
+        dependencies: avutil_dep)
+    hwaccel_support = hwaccel_support and cc.has_header_symbol(
+        'libavutil/pixfmt.h', 'AV_PIX_FMT_D3D11',
+        dependencies: avutil_dep)
+    hwaccel_support = hwaccel_support and cc.has_header(
+        'libavutil/hwcontext_d3d11va.h', dependencies: avutil_dep)
+    if hwaccel_support
+        conf.set('SC_HAVE_D3D11', true)
+    elif hwaccel_opt.enabled()
+        error('The installed FFmpeg does not provide the required D3D11 API')
+    endif
+elif host_machine.system() == 'darwin' and not hwaccel_opt.disabled()
+    hwaccel_support = cc.has_header_symbol(
+        'libavutil/hwcontext.h', 'AV_HWDEVICE_TYPE_VIDEOTOOLBOX',
+        dependencies: avutil_dep)
+    hwaccel_support = hwaccel_support and cc.has_header_symbol(
+        'libavutil/pixfmt.h', 'AV_PIX_FMT_VIDEOTOOLBOX',
+        dependencies: avutil_dep)
+    if hwaccel_support
+        conf.set('SC_HAVE_VIDEOTOOLBOX', true)
+    elif hwaccel_opt.enabled()
+        error('The installed FFmpeg does not provide the required ' +
+              'VideoToolbox API')
+    endif
+elif hwaccel_opt.enabled()
+    error('Hardware decoding is only supported on Linux, Windows, and macOS')
+endif
+if hwaccel_support
+    src += [ 'src/hwaccel.c' ]
+endif
+
 usb_support = get_option('usb')
 if usb_support
     src += [
@@ -118,17 +187,9 @@ if usb_support
     ]
 endif
 
-cc = meson.get_compiler('c')
-
-static = get_option('static')
-
-dependencies = [
-    dependency('libavformat', version: '>= 57.33', static: static),
-    dependency('libavcodec', version: '>= 57.37', static: static),
-    dependency('libavutil', static: static),
-    dependency('libswresample', static: static),
-    dependency('sdl3', version: '>= 3.2.0', static: static),
-]
+if hwaccel_support and host_machine.system() == 'linux'
+    dependencies += [libdrm_dep]
+endif
 
 if v4l2_support
     dependencies += dependency('libavdevice', static: static)
@@ -182,6 +243,9 @@ conf.set('SERVER_DEBUGGER', get_option('server_debugger'))
 
 # enable V4L2 support (linux only)
 conf.set('HAVE_V4L2', v4l2_support)
+
+# enable platform hardware video decoding
+conf.set('HAVE_HWACCEL', hwaccel_support)
 
 # enable HID over AOA support (linux only)
 conf.set('HAVE_USB', usb_support)

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -318,6 +318,8 @@ Same as \fB\-\-mouse=uhid\fR, or \fB\-\-mouse=aoa\fR if \fB\-\-otg\fR is set.
 .BI "\-\-max\-fps " value
 Limit the framerate of screen capture (officially supported since Android 10, but may work on earlier versions).
 
+Default is 60.
+
 .TP
 .BI "\-\-min\-size\-alignment " alignment
 Configure the minimum video size alignment.

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -415,6 +415,10 @@ By default, on MediaCodec error, scrcpy automatically tries again with a lower d
 This option disables this behavior.
 
 .TP
+.B \-\-no\-hardware\-decoding
+Disable hardware video decoding on the computer.
+
+.TP
 .B \-\-no\-key\-repeat
 Do not forward repeated key events when a key is held down.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -529,7 +529,8 @@ static const struct sc_option options[] = {
         .longopt = "max-fps",
         .argdesc = "value",
         .text = "Limit the frame rate of screen capture (officially supported "
-                "since Android 10, but may work on earlier versions).",
+                "since Android 10, but may work on earlier versions).\n"
+                "Default is 60.",
     },
     {
         .longopt_id = OPT_MIN_SIZE_ALIGNMENT,

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -35,6 +35,7 @@ enum {
     OPT_DISPLAY_ID,
     OPT_RENDER_DRIVER,
     OPT_NO_MIPMAPS,
+    OPT_NO_HARDWARE_DECODING,
     OPT_VIDEO_CODEC_OPTIONS,
     OPT_FORCE_ADB_FORWARD,
     OPT_DISABLE_SCREENSAVER,
@@ -645,6 +646,11 @@ static const struct sc_option options[] = {
         .text = "By default, on MediaCodec error, scrcpy automatically tries "
                 "again with a lower definition.\n"
                 "This option disables this behavior.",
+    },
+    {
+        .longopt_id = OPT_NO_HARDWARE_DECODING,
+        .longopt = "no-hardware-decoding",
+        .text = "Disable hardware video decoding on the computer.",
     },
     {
         .longopt_id = OPT_NO_KEY_REPEAT,
@@ -2693,6 +2699,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
                 break;
             case OPT_NO_MIPMAPS:
                 opts->mipmaps = false;
+                break;
+            case OPT_NO_HARDWARE_DECODING:
+                opts->hardware_decoding = false;
                 break;
             case OPT_NO_KEY_REPEAT:
                 opts->forward_key_repeat = false;

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -6,6 +6,9 @@
 #include <libavutil/channel_layout.h>
 
 #include "packet_merger.h"
+#ifdef HAVE_HWACCEL
+# include "hwaccel.h"
+#endif
 #include "util/binary.h"
 #include "util/log.h"
 
@@ -254,6 +257,12 @@ run_demuxer(void *data) {
         codec_ctx->height = session_data.video.height;
         codec_ctx->pix_fmt = AV_PIX_FMT_YUV420P;
 
+#ifdef HAVE_HWACCEL
+        if (demuxer->hwaccel) {
+            sc_hwaccel_configure_decoder(demuxer->hwaccel, codec_ctx);
+        }
+#endif
+
     } else {
         // Hardcoded audio properties
 #ifdef SCRCPY_LAVU_HAS_CHLAYOUT
@@ -362,12 +371,24 @@ sc_demuxer_init(struct sc_demuxer *demuxer, const char *name, sc_socket socket,
     demuxer->name = name; // statically allocated
     demuxer->socket = socket;
     sc_packet_source_init(&demuxer->packet_source);
+#ifdef HAVE_HWACCEL
+    demuxer->hwaccel = NULL;
+#endif
 
     assert(cbs && cbs->on_ended);
 
     demuxer->cbs = cbs;
     demuxer->cbs_userdata = cbs_userdata;
 }
+
+#ifdef HAVE_HWACCEL
+void
+sc_demuxer_enable_hardware_decoding(struct sc_demuxer *demuxer,
+                                    struct sc_hwaccel *hwaccel) {
+    assert(hwaccel);
+    demuxer->hwaccel = hwaccel;
+}
+#endif
 
 bool
 sc_demuxer_start(struct sc_demuxer *demuxer) {

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -259,7 +259,8 @@ run_demuxer(void *data) {
 
 #ifdef HAVE_HWACCEL
         if (demuxer->hwaccel) {
-            sc_hwaccel_configure_decoder(demuxer->hwaccel, codec_ctx);
+            sc_hwaccel_configure_decoder(demuxer->hwaccel, codec_ctx,
+                                         demuxer->hwaccel_buffered_frames);
         }
 #endif
 
@@ -373,6 +374,7 @@ sc_demuxer_init(struct sc_demuxer *demuxer, const char *name, sc_socket socket,
     sc_packet_source_init(&demuxer->packet_source);
 #ifdef HAVE_HWACCEL
     demuxer->hwaccel = NULL;
+    demuxer->hwaccel_buffered_frames = -1;
 #endif
 
     assert(cbs && cbs->on_ended);
@@ -384,9 +386,11 @@ sc_demuxer_init(struct sc_demuxer *demuxer, const char *name, sc_socket socket,
 #ifdef HAVE_HWACCEL
 void
 sc_demuxer_enable_hardware_decoding(struct sc_demuxer *demuxer,
-                                    struct sc_hwaccel *hwaccel) {
+                                    struct sc_hwaccel *hwaccel,
+                                    int buffered_frames) {
     assert(hwaccel);
     demuxer->hwaccel = hwaccel;
+    demuxer->hwaccel_buffered_frames = buffered_frames;
 }
 #endif
 

--- a/app/src/demuxer.h
+++ b/app/src/demuxer.h
@@ -19,6 +19,10 @@ struct sc_demuxer {
 
     const struct sc_demuxer_callbacks *cbs;
     void *cbs_userdata;
+
+#ifdef HAVE_HWACCEL
+    struct sc_hwaccel *hwaccel;
+#endif
 };
 
 enum sc_demuxer_status {
@@ -36,6 +40,12 @@ struct sc_demuxer_callbacks {
 void
 sc_demuxer_init(struct sc_demuxer *demuxer, const char *name, sc_socket socket,
                 const struct sc_demuxer_callbacks *cbs, void *cbs_userdata);
+
+#ifdef HAVE_HWACCEL
+void
+sc_demuxer_enable_hardware_decoding(struct sc_demuxer *demuxer,
+                                    struct sc_hwaccel *hwaccel);
+#endif
 
 bool
 sc_demuxer_start(struct sc_demuxer *demuxer);

--- a/app/src/demuxer.h
+++ b/app/src/demuxer.h
@@ -22,6 +22,7 @@ struct sc_demuxer {
 
 #ifdef HAVE_HWACCEL
     struct sc_hwaccel *hwaccel;
+    int hwaccel_buffered_frames;
 #endif
 };
 
@@ -44,7 +45,8 @@ sc_demuxer_init(struct sc_demuxer *demuxer, const char *name, sc_socket socket,
 #ifdef HAVE_HWACCEL
 void
 sc_demuxer_enable_hardware_decoding(struct sc_demuxer *demuxer,
-                                    struct sc_hwaccel *hwaccel);
+                                    struct sc_hwaccel *hwaccel,
+                                    int buffered_frames);
 #endif
 
 bool

--- a/app/src/hwaccel.c
+++ b/app/src/hwaccel.c
@@ -184,9 +184,20 @@ sc_hwaccel_destroy(struct sc_hwaccel *hwaccel) {
 #endif
 }
 
+#ifdef SC_HAVE_D3D11
+// FFmpeg allocates the decoder surfaces as a single D3D11 texture array, which
+// the driver specification limits to 64 slices (MAX_ARRAY_SIZE in
+// libavutil/hwcontext_d3d11va.c). The decoder keeps some of them for itself:
+// ff_dxva2_common_frame_params() in libavcodec/dxva2.c takes 1 work surface
+// plus the possible references (16 for H.264/H.265, 8 for VP9/AV1), then
+// ff_decode_get_hw_frames_ctx() in libavcodec/decode.c adds 3 to guarantee 4
+// work surfaces. extra_hw_frames may claim the rest.
+# define SC_HWACCEL_MAX_BUFFERED_FRAMES (64 - 20)
+#endif
+
 bool
-sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel,
-                             AVCodecContext *ctx) {
+sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel, AVCodecContext *ctx,
+                             int buffered_frames) {
     assert(hwaccel->available);
     assert(ctx->codec_type == AVMEDIA_TYPE_VIDEO);
 #ifndef SC_HAVE_D3D11
@@ -222,6 +233,19 @@ sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel,
         av_buffer_unref(&ctx->hw_device_ctx);
         return false;
     }
+
+#ifdef SC_HWACCEL_MAX_BUFFERED_FRAMES
+    if (buffered_frames > SC_HWACCEL_MAX_BUFFERED_FRAMES) {
+        LOGW("The video buffer is too large for " SC_HWACCEL_NAME " decoding: "
+             "only %d delayed frames fit in the surface pool. Decrease "
+             "--video-buffer or use --no-hardware-decoding.",
+             SC_HWACCEL_MAX_BUFFERED_FRAMES);
+        buffered_frames = SC_HWACCEL_MAX_BUFFERED_FRAMES;
+    }
+    ctx->extra_hw_frames = buffered_frames;
+#else
+    (void) buffered_frames;
+#endif
 
     // Some backends do not expose plain Baseline (only Constrained Baseline).
     // Hardware supporting Main/High can still decode Baseline.

--- a/app/src/hwaccel.c
+++ b/app/src/hwaccel.c
@@ -1,0 +1,447 @@
+#include "hwaccel.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <libavutil/error.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/pixdesc.h>
+
+#ifdef SC_HAVE_D3D11
+# include <d3d10.h>
+#endif
+
+#include "util/log.h"
+
+#ifdef SC_HAVE_VAAPI
+# define SC_HWACCEL_NAME "VA-API"
+# define SC_HWACCEL_DEVICE_TYPE AV_HWDEVICE_TYPE_VAAPI
+# define SC_HWACCEL_PIXEL_FORMAT AV_PIX_FMT_VAAPI
+#elif defined(SC_HAVE_D3D11)
+# define SC_HWACCEL_NAME "D3D11"
+# define SC_HWACCEL_DEVICE_TYPE AV_HWDEVICE_TYPE_D3D11VA
+# define SC_HWACCEL_PIXEL_FORMAT AV_PIX_FMT_D3D11
+#elif defined(SC_HAVE_VIDEOTOOLBOX)
+# define SC_HWACCEL_NAME "VideoToolbox"
+# define SC_HWACCEL_DEVICE_TYPE AV_HWDEVICE_TYPE_VIDEOTOOLBOX
+# define SC_HWACCEL_PIXEL_FORMAT AV_PIX_FMT_VIDEOTOOLBOX
+#else
+# error "No hardware decoding backend selected"
+#endif
+
+bool
+sc_hwaccel_set_hints(void) {
+#ifdef SC_HAVE_D3D11
+    // The decoder and renderer use the device from different threads. This
+    // prevents SDL from creating it with D3D11_CREATE_DEVICE_SINGLETHREADED.
+    return SDL_SetHintWithPriority(SDL_HINT_RENDER_DIRECT3D_THREADSAFE, "1",
+                                   SDL_HINT_OVERRIDE);
+#else
+    return true;
+#endif
+}
+
+static enum AVPixelFormat
+sc_hwaccel_get_format(AVCodecContext *ctx,
+                      const enum AVPixelFormat *formats) {
+    // On hwaccel initialization failure, FFmpeg calls get_format() again with
+    // the failing format removed. Remember that we already selected it, to
+    // report an accurate reason on the second call.
+    bool retry = ctx->opaque != NULL;
+
+    for (const enum AVPixelFormat *format = formats;
+         *format != AV_PIX_FMT_NONE; ++format) {
+        if (*format == SC_HWACCEL_PIXEL_FORMAT) {
+            ctx->opaque = (void *) (uintptr_t) 1;
+            return *format;
+        }
+    }
+
+    for (const enum AVPixelFormat *format = formats;
+         *format != AV_PIX_FMT_NONE; ++format) {
+        const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(*format);
+        if (desc && !(desc->flags & AV_PIX_FMT_FLAG_HWACCEL)) {
+            if (retry) {
+                LOGI(SC_HWACCEL_NAME " unavailable: hardware decoder "
+                     "initialization failed; using software decoding");
+            } else {
+                LOGI(SC_HWACCEL_NAME " unavailable: decoder does not offer "
+                     "the required pixel format; using software decoding");
+            }
+            return *format;
+        }
+    }
+
+    return AV_PIX_FMT_NONE;
+}
+
+#ifdef SC_HAVE_D3D11
+static bool
+sc_d3d11_enable_multithread_protection(ID3D11Device *device) {
+    // Avoid depending on an external IID symbol when linking with MinGW.
+    static const GUID iid_multithread = {
+        0x9b7e4e00, 0x342c, 0x4106,
+        {0xa1, 0x9f, 0x4f, 0x27, 0x04, 0xf6, 0x89, 0xf0},
+    };
+
+    ID3D10Multithread *multithread = NULL;
+    HRESULT hr = ID3D11Device_QueryInterface(device, &iid_multithread,
+                                              (void **) &multithread);
+    if (FAILED(hr)) {
+        return false;
+    }
+
+    ID3D10Multithread_SetMultithreadProtected(multithread, TRUE);
+    ID3D10Multithread_Release(multithread);
+    return true;
+}
+#endif
+
+void
+sc_hwaccel_init(struct sc_hwaccel *hwaccel, SDL_Renderer *renderer,
+                bool enabled) {
+    memset(hwaccel, 0, sizeof(*hwaccel));
+    hwaccel->unavailable_reason = "unknown initialization failure";
+
+    if (!enabled) {
+        // Do not probe the platform API
+        hwaccel->unavailable_reason = "hardware decoding is disabled";
+        return;
+    }
+
+#ifdef SC_HAVE_VAAPI
+    if (!sc_vaapi_init(&hwaccel->vaapi, renderer,
+                       &hwaccel->unavailable_reason)) {
+        return;
+    }
+#elif defined(SC_HAVE_D3D11)
+    const char *renderer_name = SDL_GetRendererName(renderer);
+    if (!renderer_name || strcmp(renderer_name, "direct3d11")) {
+        hwaccel->unavailable_reason =
+            "the selected SDL renderer is not Direct3D 11";
+        return;
+    }
+
+    SDL_PropertiesID props = SDL_GetRendererProperties(renderer);
+    hwaccel->device = SDL_GetPointerProperty(
+        props, SDL_PROP_RENDERER_D3D11_DEVICE_POINTER, NULL);
+    if (!hwaccel->device) {
+        hwaccel->unavailable_reason =
+            "SDL did not expose its Direct3D 11 device";
+        return;
+    }
+
+    ID3D11Device_GetImmediateContext(hwaccel->device,
+                                     &hwaccel->device_context);
+    if (!hwaccel->device_context) {
+        hwaccel->unavailable_reason =
+            "the Direct3D 11 immediate context is unavailable";
+        return;
+    }
+
+    // FFmpeg decodes on its worker thread while SDL renders on the main
+    // thread, and both use this immediate context.
+    if (!sc_d3d11_enable_multithread_protection(hwaccel->device)) {
+        hwaccel->unavailable_reason =
+            "the Direct3D 11 device does not support multithread protection";
+        ID3D11DeviceContext_Release(hwaccel->device_context);
+        hwaccel->device_context = NULL;
+        return;
+    }
+#else
+    const char *renderer_name = SDL_GetRendererName(renderer);
+    if (!renderer_name || strcmp(renderer_name, "metal")) {
+        hwaccel->unavailable_reason =
+            "the selected SDL renderer is not Metal";
+        return;
+    }
+#endif
+
+    hwaccel->available = true;
+    hwaccel->unavailable_reason = NULL;
+}
+
+void
+sc_hwaccel_reset(struct sc_hwaccel *hwaccel) {
+#ifdef SC_HAVE_VAAPI
+    sc_vaapi_reset(&hwaccel->vaapi);
+#else
+    (void) hwaccel;
+#endif
+}
+
+void
+sc_hwaccel_destroy(struct sc_hwaccel *hwaccel) {
+#ifdef SC_HAVE_VAAPI
+    sc_vaapi_destroy(&hwaccel->vaapi);
+#elif defined(SC_HAVE_D3D11)
+    if (hwaccel->device_context) {
+        ID3D11DeviceContext_Release(hwaccel->device_context);
+    }
+#else
+    (void) hwaccel;
+#endif
+}
+
+bool
+sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel,
+                             AVCodecContext *ctx) {
+    assert(hwaccel->available);
+    assert(ctx->codec_type == AVMEDIA_TYPE_VIDEO);
+#ifndef SC_HAVE_D3D11
+    (void) hwaccel;
+#endif
+
+    int ret;
+#ifdef SC_HAVE_D3D11
+    ctx->hw_device_ctx = av_hwdevice_ctx_alloc(SC_HWACCEL_DEVICE_TYPE);
+    if (!ctx->hw_device_ctx) {
+        LOG_OOM();
+        return false;
+    }
+
+    AVHWDeviceContext *device_ctx =
+        (AVHWDeviceContext *) ctx->hw_device_ctx->data;
+    AVD3D11VADeviceContext *d3d11 =
+        (AVD3D11VADeviceContext *) device_ctx->hwctx;
+    d3d11->device = hwaccel->device;
+    ID3D11Device_AddRef(d3d11->device);
+    d3d11->device_context = hwaccel->device_context;
+    ID3D11DeviceContext_AddRef(d3d11->device_context);
+    ret = av_hwdevice_ctx_init(ctx->hw_device_ctx);
+#else
+    ret = av_hwdevice_ctx_create(&ctx->hw_device_ctx,
+                                 SC_HWACCEL_DEVICE_TYPE, NULL, NULL, 0);
+#endif
+    if (ret < 0) {
+        char err[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, err, sizeof(err));
+        LOGI(SC_HWACCEL_NAME " unavailable: could not create device: %s; "
+             "using software decoding", err);
+        av_buffer_unref(&ctx->hw_device_ctx);
+        return false;
+    }
+
+    // Some backends do not expose plain Baseline (only Constrained Baseline).
+    // Hardware supporting Main/High can still decode Baseline.
+    ctx->hwaccel_flags |= AV_HWACCEL_FLAG_ALLOW_PROFILE_MISMATCH;
+    ctx->get_format = sc_hwaccel_get_format;
+    return true;
+}
+
+bool
+sc_hwaccel_is_frame(const AVFrame *frame) {
+    return frame->format == SC_HWACCEL_PIXEL_FORMAT;
+}
+
+static enum AVPixelFormat
+sc_hwaccel_get_software_format(const AVFrame *frame) {
+    if (!frame->hw_frames_ctx) {
+        return AV_PIX_FMT_NONE;
+    }
+
+    const AVHWFramesContext *frames =
+        (const AVHWFramesContext *) frame->hw_frames_ctx->data;
+    return frames->sw_format;
+}
+
+SDL_PixelFormat
+sc_hwaccel_get_texture_format(const AVFrame *frame) {
+    enum AVPixelFormat format = sc_hwaccel_get_software_format(frame);
+    switch (format) {
+        case AV_PIX_FMT_NV12:
+            return SDL_PIXELFORMAT_NV12;
+        case AV_PIX_FMT_P010:
+            return SDL_PIXELFORMAT_P010;
+        default:
+            return SDL_PIXELFORMAT_UNKNOWN;
+    }
+}
+
+static void
+sc_hwaccel_get_texture_size(const AVFrame *frame, int *width, int *height) {
+#if defined(SC_HAVE_D3D11) || defined(SC_HAVE_VIDEOTOOLBOX)
+    const AVHWFramesContext *frames =
+        (const AVHWFramesContext *) frame->hw_frames_ctx->data;
+    *width = frames->width;
+    *height = frames->height;
+#else
+    *width = frame->width;
+    *height = frame->height;
+#endif
+}
+
+bool
+sc_hwaccel_needs_new_texture(SDL_Texture *texture, const AVFrame *frame) {
+#ifdef SC_HAVE_VIDEOTOOLBOX
+    (void) texture;
+    (void) frame;
+    return true;
+#elif defined(SC_HAVE_D3D11)
+    int expected_width;
+    int expected_height;
+    sc_hwaccel_get_texture_size(frame, &expected_width, &expected_height);
+
+    float width;
+    float height;
+    return !SDL_GetTextureSize(texture, &width, &height)
+        || width != expected_width
+        || height != expected_height;
+#else
+    (void) texture;
+    (void) frame;
+    return false;
+#endif
+}
+
+SDL_Texture *
+sc_hwaccel_create_texture(struct sc_hwaccel *hwaccel,
+                          SDL_Renderer *renderer, const AVFrame *frame,
+                          SDL_Colorspace colorspace) {
+    (void) hwaccel;
+    SDL_PixelFormat format = sc_hwaccel_get_texture_format(frame);
+#ifdef SC_HAVE_VAAPI
+    // The EGL import path currently supports only 8-bit NV12.
+    if (format != SDL_PIXELFORMAT_NV12) {
+        LOGW("VA-API zero-copy unavailable: unsupported software pixel "
+             "format %d", sc_hwaccel_get_software_format(frame));
+        return NULL;
+    }
+    if (!sc_vaapi_set_nv12_rg_shader(true)) {
+        LOGE("Could not select SDL's DMA-BUF NV12 shader");
+        return NULL;
+    }
+#else
+    if (format == SDL_PIXELFORMAT_UNKNOWN) {
+        LOGW(SC_HWACCEL_NAME " rendering unavailable: unsupported software "
+             "pixel format %d", sc_hwaccel_get_software_format(frame));
+        return NULL;
+    }
+#endif
+
+    int width;
+    int height;
+    sc_hwaccel_get_texture_size(frame, &width, &height);
+
+    SDL_PropertiesID props = SDL_CreateProperties();
+    if (!props) {
+        return NULL;
+    }
+
+    bool ok =
+        SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER,
+                              format);
+#ifdef SC_HAVE_VAAPI
+    ok &= SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_ACCESS_NUMBER,
+                                SDL_TEXTUREACCESS_STREAMING);
+#else
+    ok &= SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_ACCESS_NUMBER,
+                                SDL_TEXTUREACCESS_STATIC);
+#endif
+    ok &= SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_WIDTH_NUMBER,
+                                width);
+    ok &= SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_HEIGHT_NUMBER,
+                                height);
+    ok &= SDL_SetNumberProperty(props,
+                                SDL_PROP_TEXTURE_CREATE_COLORSPACE_NUMBER,
+                                colorspace);
+#ifdef SC_HAVE_VIDEOTOOLBOX
+    if (!frame->data[3]) {
+        ok = false;
+    } else {
+        ok &= SDL_SetPointerProperty(
+            props, SDL_PROP_TEXTURE_CREATE_METAL_PIXELBUFFER_POINTER,
+            frame->data[3]);
+    }
+#endif
+
+    SDL_Texture *texture = NULL;
+    if (ok) {
+        texture = SDL_CreateTextureWithProperties(renderer, props);
+    } else {
+        LOGE("Could not set hardware texture properties");
+    }
+    SDL_DestroyProperties(props);
+
+    if (!texture) {
+        LOGD("Could not create " SC_HWACCEL_NAME " texture: %s",
+             SDL_GetError());
+    }
+    return texture;
+}
+
+bool
+sc_hwaccel_update_texture(struct sc_hwaccel *hwaccel,
+                          SDL_Renderer *renderer, SDL_Texture *texture,
+                          const AVFrame *frame) {
+    bool ok;
+#ifdef SC_HAVE_VAAPI
+    ok = sc_vaapi_set_frame(&hwaccel->vaapi, renderer, texture, frame);
+#elif defined(SC_HAVE_D3D11)
+    SDL_PropertiesID props = SDL_GetTextureProperties(texture);
+    ID3D11Resource *dst = SDL_GetPointerProperty(
+        props, SDL_PROP_TEXTURE_D3D11_TEXTURE_POINTER, NULL);
+    if (!dst) {
+        LOGW("D3D11 rendering unavailable: SDL did not expose its texture");
+        return false;
+    }
+
+    ID3D11Resource *src = (ID3D11Resource *) frame->data[0];
+    if (!src) {
+        LOGW("D3D11 rendering unavailable: decoded surface is missing");
+        return false;
+    }
+
+    if (!SDL_FlushRenderer(renderer)) {
+        LOGD("Could not flush renderer before D3D11 surface copy: %s",
+             SDL_GetError());
+    }
+    UINT slice = (UINT) (uintptr_t) frame->data[1];
+    ID3D11DeviceContext_CopySubresourceRegion(hwaccel->device_context,
+                                              dst, 0, 0, 0, 0,
+                                              src, slice, NULL);
+    ok = true;
+#else
+    (void) hwaccel;
+    (void) renderer;
+    (void) texture;
+    (void) frame;
+    ok = true; // The SDL texture directly wraps the CVPixelBuffer.
+#endif
+
+    if (ok && !hwaccel->use_logged) {
+#ifdef SC_HAVE_VAAPI
+        LOGI("Video decoding: VA-API with zero-copy DMA-BUF rendering");
+#elif defined(SC_HAVE_D3D11)
+        LOGI("Video decoding: D3D11 with GPU surface copies");
+#else
+        LOGI("Video decoding: VideoToolbox with zero-copy Metal rendering");
+#endif
+        hwaccel->use_logged = true;
+    }
+    return ok;
+}
+
+bool
+sc_hwaccel_prepare_software(struct sc_hwaccel *hwaccel) {
+#ifdef SC_HAVE_VAAPI
+    (void) hwaccel;
+    return sc_vaapi_set_nv12_rg_shader(false);
+#else
+    (void) hwaccel;
+    return true;
+#endif
+}
+
+bool
+sc_hwaccel_disable_rendering(struct sc_hwaccel *hwaccel) {
+    hwaccel->rendering_failed = true;
+    LOGW(SC_HWACCEL_NAME " rendering failed; transferring hardware frames "
+         "to system memory");
+    if (!sc_hwaccel_prepare_software(hwaccel)) {
+        LOGE("Could not restore SDL's software texture configuration");
+        return false;
+    }
+    return true;
+}

--- a/app/src/hwaccel.h
+++ b/app/src/hwaccel.h
@@ -46,8 +46,8 @@ void
 sc_hwaccel_reset(struct sc_hwaccel *hwaccel);
 
 bool
-sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel,
-                             AVCodecContext *ctx);
+sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel, AVCodecContext *ctx,
+                             int buffered_frames);
 
 bool
 sc_hwaccel_is_frame(const AVFrame *frame);

--- a/app/src/hwaccel.h
+++ b/app/src/hwaccel.h
@@ -1,0 +1,77 @@
+#ifndef SC_HWACCEL_H
+#define SC_HWACCEL_H
+
+#include "common.h"
+
+#include <stdbool.h>
+
+#include <SDL3/SDL.h>
+#include <libavcodec/avcodec.h>
+#include <libavutil/frame.h>
+
+#ifdef SC_HAVE_VAAPI
+# include "vaapi.h"
+#elif defined(SC_HAVE_D3D11)
+# ifndef COBJMACROS
+#  define COBJMACROS
+# endif
+# include <libavutil/hwcontext_d3d11va.h>
+#endif
+
+struct sc_hwaccel {
+#ifdef SC_HAVE_VAAPI
+    struct sc_vaapi vaapi;
+#elif defined(SC_HAVE_D3D11)
+    ID3D11Device *device; // borrowed from the SDL renderer
+    ID3D11DeviceContext *device_context;
+#endif
+
+    const char *unavailable_reason;
+    bool available;
+    bool rendering_failed;
+    bool use_logged;
+};
+
+bool
+sc_hwaccel_set_hints(void);
+
+void
+sc_hwaccel_init(struct sc_hwaccel *hwaccel, SDL_Renderer *renderer,
+                bool enabled);
+
+void
+sc_hwaccel_destroy(struct sc_hwaccel *hwaccel);
+
+void
+sc_hwaccel_reset(struct sc_hwaccel *hwaccel);
+
+bool
+sc_hwaccel_configure_decoder(struct sc_hwaccel *hwaccel,
+                             AVCodecContext *ctx);
+
+bool
+sc_hwaccel_is_frame(const AVFrame *frame);
+
+SDL_PixelFormat
+sc_hwaccel_get_texture_format(const AVFrame *frame);
+
+bool
+sc_hwaccel_needs_new_texture(SDL_Texture *texture, const AVFrame *frame);
+
+SDL_Texture *
+sc_hwaccel_create_texture(struct sc_hwaccel *hwaccel,
+                          SDL_Renderer *renderer, const AVFrame *frame,
+                          SDL_Colorspace colorspace);
+
+bool
+sc_hwaccel_update_texture(struct sc_hwaccel *hwaccel,
+                          SDL_Renderer *renderer, SDL_Texture *texture,
+                          const AVFrame *frame);
+
+bool
+sc_hwaccel_disable_rendering(struct sc_hwaccel *hwaccel);
+
+bool
+sc_hwaccel_prepare_software(struct sc_hwaccel *hwaccel);
+
+#endif

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -83,6 +83,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .always_on_top = false,
     .control = true,
     .video_playback = true,
+    .hardware_decoding = true,
     .audio_playback = true,
     .turn_screen_off = false,
     .key_inject_mode = SC_KEY_INJECT_MODE_MIXED,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -302,6 +302,7 @@ struct scrcpy_options {
     bool always_on_top;
     bool control;
     bool video_playback;
+    bool hardware_decoding;
     bool audio_playback;
     bool turn_screen_off;
     enum sc_key_inject_mode key_inject_mode;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -20,6 +20,9 @@
 #include "demuxer.h"
 #include "events.h"
 #include "file_pusher.h"
+#ifdef HAVE_HWACCEL
+# include "hwaccel.h"
+#endif
 #include "keyboard_sdk.h"
 #include "mouse_sdk.h"
 #include "recorder.h"
@@ -439,6 +442,20 @@ scrcpy(struct scrcpy_options *options) {
 
     // Set hints before starting the server thread to avoid race conditions in
     // SDL
+#ifdef HAVE_HWACCEL
+    // Never force a render driver here: SDL only tries the driver it is given,
+    // so pinning one would remove its fallback to the other backends. Its
+    // default backend is already the one matching the hardware decoding API on
+    // every supported platform.
+    bool hwaccel_may_be_used = options->video_playback
+                            && options->hardware_decoding;
+# ifdef HAVE_V4L2
+    hwaccel_may_be_used &= !options->v4l2_device;
+# endif
+    if (hwaccel_may_be_used && !sc_hwaccel_set_hints()) {
+        LOGW("Could not set hardware decoding hints");
+    }
+#endif
     sc_sdl_set_hints(options->render_driver, options->disable_screensaver);
 
     if (!sc_server_start(&s->server)) {
@@ -780,6 +797,7 @@ aoa_complete:
             .render_fit = options->render_fit,
             .orientation = options->display_orientation,
             .mipmaps = options->mipmaps,
+            .hardware_decoding = options->hardware_decoding,
             .fullscreen = options->fullscreen,
             .start_fps_counter = options->start_fps_counter,
         };
@@ -788,6 +806,37 @@ aoa_complete:
             goto end;
         }
         screen_initialized = true;
+
+#ifdef HAVE_HWACCEL
+        if (options->video_playback && options->hardware_decoding) {
+            bool hwaccel_allowed = true;
+# ifdef HAVE_V4L2
+            // The V4L2 sink requires CPU-addressable frames.
+            hwaccel_allowed = !options->v4l2_device;
+# endif
+            if (!hwaccel_allowed) {
+                LOGI("Hardware decoding unavailable: the V4L2 sink requires "
+                     "CPU-addressable frames; using software decoding");
+            } else if (!sc_texture_supports_hardware_decoding(
+                           &s->screen.tex)) {
+                const char *reason =
+                    sc_texture_get_hardware_decoding_unavailable_reason(
+                        &s->screen.tex);
+                LOGI("Hardware decoding unavailable: %s; using software "
+                     "decoding", reason);
+            } else {
+                struct sc_hwaccel *hwaccel =
+                    sc_texture_get_hwaccel(&s->screen.tex);
+                sc_demuxer_enable_hardware_decoding(&s->video_demuxer,
+                                                     hwaccel);
+            }
+        }
+#elif defined(__linux__) || defined(_WIN32) || defined(__APPLE__)
+        if (options->video_playback && options->hardware_decoding) {
+            LOGI("Hardware decoding unavailable: support was not compiled "
+                 "in; using software decoding");
+        }
+#endif
 
         if (options->video_playback) {
             struct sc_frame_source *src = &s->video_decoder.frame_source;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -267,6 +268,29 @@ sc_server_on_disconnected(struct sc_server *server, void *userdata) {
     // Do nothing, the disconnection will be handled by the "stream stopped"
     // event
 }
+
+#ifdef HAVE_HWACCEL
+// Number of decoded frames scrcpy may hold at once, outside of the decoder,
+// or -1 to let the decoder decide.
+static int
+sc_hwaccel_count_buffered_frames(const struct scrcpy_options *options) {
+    if (!options->video_buffer) {
+        return -1;
+    }
+
+    double fps = 60;
+    if (options->max_fps) {
+        char *end;
+        double parsed = strtod(options->max_fps, &end);
+        if (end != options->max_fps && parsed > 0) {
+            fps = parsed;
+        }
+    }
+
+    double delayed = fps * SC_TICK_TO_MS(options->video_buffer) / 1000 + 1;
+    return delayed < INT_MAX ? (int) delayed : INT_MAX;
+}
+#endif
 
 static void
 sc_timeout_on_timeout(struct sc_timeout *timeout, void *userdata) {
@@ -827,8 +851,10 @@ aoa_complete:
             } else {
                 struct sc_hwaccel *hwaccel =
                     sc_texture_get_hwaccel(&s->screen.tex);
-                sc_demuxer_enable_hardware_decoding(&s->video_demuxer,
-                                                     hwaccel);
+                int buffered_frames =
+                    sc_hwaccel_count_buffered_frames(options);
+                sc_demuxer_enable_hardware_decoding(&s->video_demuxer, hwaccel,
+                                                    buffered_frames);
             }
         }
 #elif defined(__linux__) || defined(_WIN32) || defined(__APPLE__)

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -267,6 +267,10 @@ sc_screen_render(struct sc_screen *screen, bool update_content_rect) {
         .w = screen->rect.w * scale,
         .h = screen->rect.h * scale,
     };
+    SDL_FRect source = {
+        .w = screen->tex.texture_size.width,
+        .h = screen->tex.texture_size.height,
+    };
     enum sc_orientation orientation = screen->orientation;
 
     bool ok = false;
@@ -274,7 +278,7 @@ sc_screen_render(struct sc_screen *screen, bool update_content_rect) {
         // always align to a physical pixel
         geometry.x = (int32_t) geometry.x;
         geometry.y = (int32_t) geometry.y;
-        ok = SDL_RenderTexture(renderer, texture, NULL, &geometry);
+        ok = SDL_RenderTexture(renderer, texture, &source, &geometry);
     } else {
         unsigned cw_rotation = sc_orientation_get_rotation(orientation);
         double angle = 90 * cw_rotation;
@@ -297,8 +301,8 @@ sc_screen_render(struct sc_screen *screen, bool update_content_rect) {
         // always align to a physical pixel
         dstrect->x = (int32_t) dstrect->x;
         dstrect->y = (int32_t) dstrect->y;
-        ok = SDL_RenderTextureRotated(renderer, texture, NULL, dstrect, angle,
-                                      NULL, flip);
+        ok = SDL_RenderTextureRotated(renderer, texture, &source, dstrect,
+                                      angle, NULL, flip);
     }
 
     if (!ok) {
@@ -610,7 +614,10 @@ sc_screen_init(struct sc_screen *screen,
 #endif
 
     bool mipmaps = params->video;
-    ok = sc_texture_init(&screen->tex, screen->renderer, mipmaps);
+    // Hardware decoding is only used to feed the video texture
+    bool hardware_decoding = params->video && params->hardware_decoding;
+    ok = sc_texture_init(&screen->tex, screen->renderer, mipmaps,
+                         hardware_decoding);
     if (!ok) {
         goto error_destroy_renderer;
     }

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -141,6 +141,7 @@ struct sc_screen_params {
     enum sc_render_fit render_fit;
     enum sc_orientation orientation;
     bool mipmaps;
+    bool hardware_decoding;
 
     bool fullscreen;
     bool start_fps_counter;

--- a/app/src/texture.c
+++ b/app/src/texture.c
@@ -3,12 +3,19 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <string.h>
+#ifdef HAVE_HWACCEL
+# include <libavutil/error.h>
+#endif
 #include <libavutil/pixfmt.h>
+#ifdef HAVE_HWACCEL
+# include <libavutil/hwcontext.h>
+#endif
 
 #include "util/log.h"
 
 bool
-sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps) {
+sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps,
+                bool hardware_decoding) {
     const char *renderer_name = SDL_GetRendererName(renderer);
     LOGI("Renderer: %s", renderer_name ? renderer_name : "(unknown)");
 
@@ -42,14 +49,61 @@ sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps) {
 
     tex->renderer = renderer;
     tex->texture = NULL;
+    tex->texture_hardware = false;
+#ifdef HAVE_HWACCEL
+    sc_hwaccel_init(&tex->hwaccel, renderer, hardware_decoding);
+#else
+    (void) hardware_decoding;
+#endif
     return true;
+}
+
+bool
+sc_texture_supports_hardware_decoding(const struct sc_texture *tex) {
+#ifdef HAVE_HWACCEL
+    return tex->hwaccel.available;
+#else
+    (void) tex;
+    return false;
+#endif
+}
+
+const char *
+sc_texture_get_hardware_decoding_unavailable_reason(
+        const struct sc_texture *tex) {
+#ifdef HAVE_HWACCEL
+    return tex->hwaccel.unavailable_reason;
+#else
+    (void) tex;
+    return "hardware decoding support was not compiled in";
+#endif
+}
+
+#ifdef HAVE_HWACCEL
+struct sc_hwaccel *
+sc_texture_get_hwaccel(struct sc_texture *tex) {
+    assert(tex->hwaccel.available);
+    return &tex->hwaccel;
+}
+#endif
+
+static void
+sc_texture_destroy_texture(struct sc_texture *tex) {
+    if (tex->texture) {
+        SDL_DestroyTexture(tex->texture);
+        tex->texture = NULL;
+    }
+#ifdef HAVE_HWACCEL
+    sc_hwaccel_reset(&tex->hwaccel);
+#endif
 }
 
 void
 sc_texture_destroy(struct sc_texture *tex) {
-    if (tex->texture) {
-        SDL_DestroyTexture(tex->texture);
-    }
+    sc_texture_destroy_texture(tex);
+#ifdef HAVE_HWACCEL
+    sc_hwaccel_destroy(&tex->hwaccel);
+#endif
 }
 
 static enum SDL_Colorspace
@@ -80,6 +134,7 @@ sc_texture_to_sdl_color_space(enum AVColorSpace color_space,
 static SDL_Texture *
 sc_texture_create_frame_texture(struct sc_texture *tex,
                                 struct sc_size size,
+                                SDL_PixelFormat format,
                                 enum AVColorSpace color_space,
                                 enum AVColorRange color_range) {
     LOGV("Creating new texture: size=%" PRIu16 "x%" PRIu16 " color_space=%d "
@@ -95,7 +150,7 @@ sc_texture_create_frame_texture(struct sc_texture *tex,
 
     bool ok =
         SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_FORMAT_NUMBER,
-                              SDL_PIXELFORMAT_YV12);
+                              format);
     ok &= SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_ACCESS_NUMBER,
                                 SDL_TEXTUREACCESS_STREAMING);
     ok &= SDL_SetNumberProperty(props, SDL_PROP_TEXTURE_CREATE_WIDTH_NUMBER,
@@ -120,7 +175,7 @@ sc_texture_create_frame_texture(struct sc_texture *tex,
         return NULL;
     }
 
-    if (tex->mipmaps) {
+    if (tex->mipmaps && format == SDL_PIXELFORMAT_YV12) {
         struct sc_opengl *gl = &tex->gl;
 
         SDL_PropertiesID props = SDL_GetTextureProperties(texture);
@@ -158,25 +213,26 @@ sc_texture_create_frame_texture(struct sc_texture *tex,
     return texture;
 }
 
-bool
-sc_texture_set_from_frame(struct sc_texture *tex, const AVFrame *frame) {
-
+static bool
+sc_texture_prepare_frame_texture(struct sc_texture *tex, const AVFrame *frame,
+                                 SDL_PixelFormat format) {
     struct sc_size size = {frame->width, frame->height};
     assert(size.width && size.height);
 
     if (!tex->texture
             || tex->texture_type != SC_TEXTURE_TYPE_FRAME
+            || tex->texture_hardware
+            || tex->texture_format != format
             || tex->texture_size.width != size.width
             || tex->texture_size.height != size.height) {
         // Incompatible texture, recreate it
         enum AVColorSpace color_space = frame->colorspace;
         enum AVColorRange color_range = frame->color_range;
 
-        if (tex->texture) {
-            SDL_DestroyTexture(tex->texture);
-        }
+        sc_texture_destroy_texture(tex);
 
-        tex->texture = sc_texture_create_frame_texture(tex, size, color_space,
+        tex->texture = sc_texture_create_frame_texture(tex, size, format,
+                                                       color_space,
                                                        color_range);
         if (!tex->texture) {
             return false;
@@ -184,23 +240,60 @@ sc_texture_set_from_frame(struct sc_texture *tex, const AVFrame *frame) {
 
         tex->texture_size = size;
         tex->texture_type = SC_TEXTURE_TYPE_FRAME;
+        tex->texture_format = format;
+        tex->texture_hardware = false;
 
         LOGI("Texture: %" PRIu16 "x%" PRIu16, size.width, size.height);
     }
 
     assert(tex->texture);
     assert(tex->texture_type == SC_TEXTURE_TYPE_FRAME);
+    assert(tex->texture_format == format);
 
-    bool ok = SDL_UpdateYUVTexture(tex->texture, NULL,
-                                   frame->data[0], frame->linesize[0],
-                                   frame->data[1], frame->linesize[1],
-                                   frame->data[2], frame->linesize[2]);
+    return true;
+}
+
+static bool
+sc_texture_set_from_sw_frame(struct sc_texture *tex, const AVFrame *frame) {
+    SDL_PixelFormat format;
+    switch (frame->format) {
+        case AV_PIX_FMT_YUV420P:
+        case AV_PIX_FMT_YUVJ420P:
+            format = SDL_PIXELFORMAT_YV12;
+            break;
+        case AV_PIX_FMT_NV12:
+            format = SDL_PIXELFORMAT_NV12;
+            break;
+        case AV_PIX_FMT_P010:
+            format = SDL_PIXELFORMAT_P010;
+            break;
+        default:
+            LOGD("Unsupported software pixel format: %d", frame->format);
+            return false;
+    }
+
+    if (!sc_texture_prepare_frame_texture(tex, frame, format)) {
+        return false;
+    }
+
+    bool ok;
+    if (format == SDL_PIXELFORMAT_NV12
+            || format == SDL_PIXELFORMAT_P010) {
+        ok = SDL_UpdateNVTexture(tex->texture, NULL,
+                                 frame->data[0], frame->linesize[0],
+                                 frame->data[1], frame->linesize[1]);
+    } else {
+        ok = SDL_UpdateYUVTexture(tex->texture, NULL,
+                                  frame->data[0], frame->linesize[0],
+                                  frame->data[1], frame->linesize[1],
+                                  frame->data[2], frame->linesize[2]);
+    }
     if (!ok) {
         LOGD("Could not update texture: %s", SDL_GetError());
         return false;
     }
 
-    if (tex->mipmaps) {
+    if (tex->mipmaps && format == SDL_PIXELFORMAT_YV12) {
         assert(tex->texture_id);
         struct sc_opengl *gl = &tex->gl;
 
@@ -212,11 +305,112 @@ sc_texture_set_from_frame(struct sc_texture *tex, const AVFrame *frame) {
     return true;
 }
 
+#ifdef HAVE_HWACCEL
+static bool
+sc_texture_set_from_hw_frame(struct sc_texture *tex, const AVFrame *frame) {
+    struct sc_size size = {frame->width, frame->height};
+    assert(size.width && size.height);
+
+    SDL_PixelFormat format = sc_hwaccel_get_texture_format(frame);
+    if (format == SDL_PIXELFORMAT_UNKNOWN) {
+        return false;
+    }
+
+    bool metadata_changed = !tex->texture
+                         || tex->texture_type != SC_TEXTURE_TYPE_FRAME
+                         || !tex->texture_hardware
+                         || tex->texture_format != format
+                         || tex->texture_size.width != size.width
+                         || tex->texture_size.height != size.height;
+    if (metadata_changed
+            || sc_hwaccel_needs_new_texture(tex->texture, frame)) {
+        sc_texture_destroy_texture(tex);
+
+        SDL_Colorspace colorspace = sc_texture_to_sdl_color_space(
+            frame->colorspace, frame->color_range);
+        tex->texture = sc_hwaccel_create_texture(
+            &tex->hwaccel, tex->renderer, frame, colorspace);
+        if (!tex->texture) {
+            return false;
+        }
+
+        tex->texture_size = size;
+        tex->texture_type = SC_TEXTURE_TYPE_FRAME;
+        tex->texture_format = format;
+        tex->texture_hardware = true;
+
+        if (metadata_changed) {
+            LOGI("Texture: %" PRIu16 "x%" PRIu16,
+                 size.width, size.height);
+        }
+    }
+
+    return sc_hwaccel_update_texture(&tex->hwaccel, tex->renderer,
+                                     tex->texture, frame);
+}
+#endif
+
+bool
+sc_texture_set_from_frame(struct sc_texture *tex, const AVFrame *frame) {
+#ifdef HAVE_HWACCEL
+    if (sc_hwaccel_is_frame(frame)) {
+        if (tex->hwaccel.available && !tex->hwaccel.rendering_failed) {
+            if (sc_texture_set_from_hw_frame(tex, frame)) {
+                return true;
+            }
+            if (!sc_hwaccel_disable_rendering(&tex->hwaccel)) {
+                return false;
+            }
+        }
+
+        // Keep playback working if the platform's native surface cannot be
+        // imported by this renderer/driver combination.
+        AVFrame *sw_frame = av_frame_alloc();
+        if (!sw_frame) {
+            LOG_OOM();
+            return false;
+        }
+        int ret = av_hwframe_transfer_data(sw_frame, frame, 0);
+        if (ret < 0) {
+            char err[AV_ERROR_MAX_STRING_SIZE];
+            av_strerror(ret, err, sizeof(err));
+            LOGE("Could not transfer hardware frame to system memory: %s",
+                 err);
+            av_frame_free(&sw_frame);
+            return false;
+        }
+        ret = av_frame_copy_props(sw_frame, frame);
+        if (ret < 0) {
+            LOGE("Could not copy hardware frame properties: %d", ret);
+            av_frame_free(&sw_frame);
+            return false;
+        }
+
+        // A hardware texture may be static or backed by a decoder surface.
+        // Once rendering has fallen back, keep reusing the software texture.
+        if (tex->texture && tex->texture_hardware) {
+            sc_texture_destroy_texture(tex);
+        }
+        bool ok = sc_texture_set_from_sw_frame(tex, sw_frame);
+        av_frame_free(&sw_frame);
+        return ok;
+    }
+
+    if (tex->texture && tex->texture_hardware) {
+        if (!sc_hwaccel_prepare_software(&tex->hwaccel)) {
+            LOGE("Could not restore SDL's software texture configuration");
+            return false;
+        }
+        sc_texture_destroy_texture(tex);
+    }
+#endif
+
+    return sc_texture_set_from_sw_frame(tex, frame);
+}
+
 bool
 sc_texture_set_from_surface(struct sc_texture *tex, SDL_Surface *surface) {
-    if (tex->texture) {
-        SDL_DestroyTexture(tex->texture);
-    }
+    sc_texture_destroy_texture(tex);
 
     tex->texture = SDL_CreateTextureFromSurface(tex->renderer, surface);
     if (!tex->texture) {
@@ -227,14 +421,13 @@ sc_texture_set_from_surface(struct sc_texture *tex, SDL_Surface *surface) {
     tex->texture_size.width = surface->w;
     tex->texture_size.height = surface->h;
     tex->texture_type = SC_TEXTURE_TYPE_ICON;
+    tex->texture_format = surface->format;
+    tex->texture_hardware = false;
 
     return true;
 }
 
 void
 sc_texture_reset(struct sc_texture *tex) {
-    if (tex->texture) {
-        SDL_DestroyTexture(tex->texture);
-        tex->texture = NULL;
-    }
+    sc_texture_destroy_texture(tex);
 }

--- a/app/src/texture.h
+++ b/app/src/texture.h
@@ -10,6 +10,9 @@
 
 #include "coords.h"
 #include "opengl.h"
+#ifdef HAVE_HWACCEL
+# include "hwaccel.h"
+#endif
 
 enum sc_texture_type {
     SC_TEXTURE_TYPE_FRAME,
@@ -22,15 +25,33 @@ struct sc_texture {
     // Only valid if texture != NULL
     struct sc_size texture_size;
     enum sc_texture_type texture_type;
+    SDL_PixelFormat texture_format;
 
     struct sc_opengl gl;
 
     bool mipmaps;
+    bool texture_hardware;
     uint32_t texture_id; // only set if mipmaps is enabled
+#ifdef HAVE_HWACCEL
+    struct sc_hwaccel hwaccel;
+#endif
 };
 
 bool
-sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps);
+sc_texture_init(struct sc_texture *tex, SDL_Renderer *renderer, bool mipmaps,
+                bool hardware_decoding);
+
+bool
+sc_texture_supports_hardware_decoding(const struct sc_texture *tex);
+
+const char *
+sc_texture_get_hardware_decoding_unavailable_reason(
+    const struct sc_texture *tex);
+
+#ifdef HAVE_HWACCEL
+struct sc_hwaccel *
+sc_texture_get_hwaccel(struct sc_texture *tex);
+#endif
 
 void
 sc_texture_destroy(struct sc_texture *tex);

--- a/app/src/vaapi.c
+++ b/app/src/vaapi.c
@@ -1,0 +1,323 @@
+#include "vaapi.h"
+
+#include "common.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include <drm_fourcc.h>
+#include <libavutil/error.h>
+#include <libavutil/hwcontext.h>
+#include <libavutil/hwcontext_drm.h>
+#include <libavutil/pixfmt.h>
+
+#include "util/log.h"
+
+#define SC_GL_TEXTURE_2D 0x0DE1
+
+static bool
+sc_has_extension(const char *extensions, const char *extension) {
+    if (!extensions || !extension || strchr(extension, ' ')) {
+        return false;
+    }
+
+    size_t len = strlen(extension);
+    const char *p = extensions;
+    while ((p = strstr(p, extension))) {
+        if ((p == extensions || p[-1] == ' ')
+                && (p[len] == '\0' || p[len] == ' ')) {
+            return true;
+        }
+        p += len;
+    }
+    return false;
+}
+
+static void
+sc_vaapi_destroy_images(struct sc_vaapi *vaapi) {
+    for (unsigned i = 0; i < 2; ++i) {
+        if (vaapi->images[i] != EGL_NO_IMAGE_KHR) {
+            vaapi->DestroyImageKHR(vaapi->display, vaapi->images[i]);
+            vaapi->images[i] = EGL_NO_IMAGE_KHR;
+        }
+    }
+}
+
+bool
+sc_vaapi_init(struct sc_vaapi *vaapi, SDL_Renderer *renderer,
+              const char **unavailable_reason) {
+    memset(vaapi, 0, sizeof(*vaapi));
+    vaapi->images[0] = EGL_NO_IMAGE_KHR;
+    vaapi->images[1] = EGL_NO_IMAGE_KHR;
+
+    const char *renderer_name = SDL_GetRendererName(renderer);
+    bool is_opengl = renderer_name && !strcmp(renderer_name, "opengl");
+    bool is_opengles2 = renderer_name && !strcmp(renderer_name, "opengles2");
+    if (!is_opengl && !is_opengles2) {
+        *unavailable_reason =
+            "the selected SDL renderer is not OpenGL/OpenGL ES";
+        return false;
+    }
+
+    vaapi->display = (EGLDisplay) SDL_EGL_GetCurrentDisplay();
+    if (vaapi->display == EGL_NO_DISPLAY) {
+        *unavailable_reason =
+            "the OpenGL renderer does not use EGL "
+            "(try with SDL_VIDEO_FORCE_EGL=1)";
+        return false;
+    }
+
+    PFNEGLQUERYSTRINGPROC QueryString = (PFNEGLQUERYSTRINGPROC)
+        SDL_EGL_GetProcAddress("eglQueryString");
+    if (!QueryString) {
+        *unavailable_reason = "eglQueryString is unavailable";
+        return false;
+    }
+
+    const char *egl_extensions = QueryString(vaapi->display, EGL_EXTENSIONS);
+    if (!sc_has_extension(egl_extensions, "EGL_EXT_image_dma_buf_import")) {
+        *unavailable_reason =
+            "EGL_EXT_image_dma_buf_import is not supported";
+        return false;
+    }
+
+    const unsigned char *(*GetString)(unsigned int) =
+        (const unsigned char *(*)(unsigned int))
+            SDL_GL_GetProcAddress("glGetString");
+    if (!GetString) {
+        *unavailable_reason = "glGetString is unavailable";
+        return false;
+    }
+    const char *gl_extensions =
+        (const char *) GetString(0x1F03 /* GL_EXTENSIONS */);
+    if (!sc_has_extension(gl_extensions, "GL_OES_EGL_image")) {
+        *unavailable_reason = "GL_OES_EGL_image is not supported";
+        return false;
+    }
+
+    vaapi->CreateImageKHR = (PFNEGLCREATEIMAGEKHRPROC)
+        SDL_EGL_GetProcAddress("eglCreateImageKHR");
+    vaapi->DestroyImageKHR = (PFNEGLDESTROYIMAGEKHRPROC)
+        SDL_EGL_GetProcAddress("eglDestroyImageKHR");
+    vaapi->EglGetError = (PFNEGLGETERRORPROC)
+        SDL_EGL_GetProcAddress("eglGetError");
+    vaapi->BindTexture = (void (*)(unsigned int, unsigned int))
+        SDL_GL_GetProcAddress("glBindTexture");
+    vaapi->EGLImageTargetTexture2DOES =
+        (void (*)(unsigned int, void *))
+            SDL_GL_GetProcAddress("glEGLImageTargetTexture2DOES");
+    vaapi->GetError = (unsigned int (*)(void))
+        SDL_GL_GetProcAddress("glGetError");
+    if (!vaapi->CreateImageKHR || !vaapi->DestroyImageKHR
+            || !vaapi->EglGetError || !vaapi->BindTexture
+            || !vaapi->EGLImageTargetTexture2DOES || !vaapi->GetError) {
+        *unavailable_reason =
+            "required EGLImage/OpenGL entry points are unavailable";
+        return false;
+    }
+
+    vaapi->texture_prop = is_opengl
+                        ? SDL_PROP_TEXTURE_OPENGL_TEXTURE_NUMBER
+                        : SDL_PROP_TEXTURE_OPENGLES2_TEXTURE_NUMBER;
+    vaapi->texture_uv_prop = is_opengl
+                           ? SDL_PROP_TEXTURE_OPENGL_TEXTURE_UV_NUMBER
+                           : SDL_PROP_TEXTURE_OPENGLES2_TEXTURE_UV_NUMBER;
+    vaapi->has_modifiers = sc_has_extension(
+        egl_extensions, "EGL_EXT_image_dma_buf_import_modifiers");
+    return true;
+}
+
+void
+sc_vaapi_reset(struct sc_vaapi *vaapi) {
+    sc_vaapi_destroy_images(vaapi);
+    av_frame_free(&vaapi->drm_frame);
+}
+
+void
+sc_vaapi_destroy(struct sc_vaapi *vaapi) {
+    sc_vaapi_reset(vaapi);
+}
+
+bool
+sc_vaapi_set_nv12_rg_shader(bool enabled) {
+    // SDL normally stores NV12 chroma in a legacy GL_LUMINANCE_ALPHA texture
+    // and samples it from .ra. An EGLImage imported from DRM_FORMAT_GR88 is a
+    // two-channel texture, so it must be sampled from .rg instead. This hint is
+    // intentionally set with override priority: both paths render incorrectly
+    // if an environment hint forces the texture's other storage convention.
+    return SDL_SetHintWithPriority("SDL_RENDER_OPENGL_NV12_RG_SHADER",
+                                   enabled ? "1" : "0", SDL_HINT_OVERRIDE);
+}
+
+struct sc_vaapi_plane {
+    const AVDRMObjectDescriptor *object;
+    const AVDRMPlaneDescriptor *plane;
+};
+
+static bool
+sc_vaapi_find_nv12_planes(const AVDRMFrameDescriptor *desc,
+                          struct sc_vaapi_plane planes[2]) {
+    if (desc->nb_layers == 1) {
+        const AVDRMLayerDescriptor *layer = &desc->layers[0];
+        if (layer->format != DRM_FORMAT_NV12 || layer->nb_planes != 2) {
+            return false;
+        }
+        for (unsigned i = 0; i < 2; ++i) {
+            int object_index = layer->planes[i].object_index;
+            if (object_index < 0 || object_index >= desc->nb_objects) {
+                return false;
+            }
+            planes[i].object = &desc->objects[object_index];
+            planes[i].plane = &layer->planes[i];
+        }
+        return true;
+    }
+
+    if (desc->nb_layers == 2
+            && desc->layers[0].format == DRM_FORMAT_R8
+            && desc->layers[1].format == DRM_FORMAT_GR88
+            && desc->layers[0].nb_planes == 1
+            && desc->layers[1].nb_planes == 1) {
+        for (unsigned i = 0; i < 2; ++i) {
+            const AVDRMPlaneDescriptor *plane = &desc->layers[i].planes[0];
+            if (plane->object_index < 0
+                    || plane->object_index >= desc->nb_objects) {
+                return false;
+            }
+            planes[i].object = &desc->objects[plane->object_index];
+            planes[i].plane = plane;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+static EGLImageKHR
+sc_vaapi_import_plane(struct sc_vaapi *vaapi,
+                      const struct sc_vaapi_plane *plane, uint32_t format,
+                      int width, int height) {
+    EGLint attrs[20];
+    unsigned n = 0;
+    attrs[n++] = EGL_WIDTH;
+    attrs[n++] = width;
+    attrs[n++] = EGL_HEIGHT;
+    attrs[n++] = height;
+    attrs[n++] = EGL_LINUX_DRM_FOURCC_EXT;
+    attrs[n++] = (EGLint) format;
+    attrs[n++] = EGL_DMA_BUF_PLANE0_FD_EXT;
+    attrs[n++] = plane->object->fd;
+    attrs[n++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
+    attrs[n++] = (EGLint) plane->plane->offset;
+    attrs[n++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
+    attrs[n++] = (EGLint) plane->plane->pitch;
+
+    uint64_t modifier = plane->object->format_modifier;
+    if (vaapi->has_modifiers && modifier != DRM_FORMAT_MOD_INVALID) {
+        attrs[n++] = EGL_DMA_BUF_PLANE0_MODIFIER_LO_EXT;
+        attrs[n++] = (EGLint) (modifier & UINT32_MAX);
+        attrs[n++] = EGL_DMA_BUF_PLANE0_MODIFIER_HI_EXT;
+        attrs[n++] = (EGLint) (modifier >> 32);
+    }
+    attrs[n++] = EGL_NONE;
+    assert(n <= ARRAY_LEN(attrs));
+
+    return vaapi->CreateImageKHR(vaapi->display, EGL_NO_CONTEXT,
+                                 EGL_LINUX_DMA_BUF_EXT, NULL, attrs);
+}
+
+bool
+sc_vaapi_set_frame(struct sc_vaapi *vaapi, SDL_Renderer *renderer,
+                   SDL_Texture *texture, const AVFrame *frame) {
+    assert(frame->format == AV_PIX_FMT_VAAPI);
+
+    AVFrame *drm_frame = av_frame_alloc();
+    if (!drm_frame) {
+        LOG_OOM();
+        return false;
+    }
+    drm_frame->format = AV_PIX_FMT_DRM_PRIME;
+    int ret = av_hwframe_map(drm_frame, frame,
+                             AV_HWFRAME_MAP_READ | AV_HWFRAME_MAP_DIRECT);
+    if (ret < 0) {
+        char err[AV_ERROR_MAX_STRING_SIZE];
+        av_strerror(ret, err, sizeof(err));
+        LOGW("VA-API zero-copy unavailable: could not export the decoded "
+             "frame as DMA-BUF: %s", err);
+        av_frame_free(&drm_frame);
+        return false;
+    }
+
+    const AVDRMFrameDescriptor *desc =
+        (const AVDRMFrameDescriptor *) drm_frame->data[0];
+    struct sc_vaapi_plane planes[2];
+    if (!desc || !sc_vaapi_find_nv12_planes(desc, planes)) {
+        uint32_t format = desc && desc->nb_layers ? desc->layers[0].format : 0;
+        LOGW("VA-API zero-copy unavailable: unsupported DRM PRIME layout "
+             "(layers=%d, format=%#08x)", desc ? desc->nb_layers : 0,
+             format);
+        av_frame_free(&drm_frame);
+        return false;
+    }
+
+    EGLImageKHR images[2];
+    images[0] = sc_vaapi_import_plane(vaapi, &planes[0], DRM_FORMAT_R8,
+                                      frame->width, frame->height);
+    images[1] = sc_vaapi_import_plane(vaapi, &planes[1], DRM_FORMAT_GR88,
+                                      (frame->width + 1) / 2,
+                                      (frame->height + 1) / 2);
+    if (images[0] == EGL_NO_IMAGE_KHR || images[1] == EGL_NO_IMAGE_KHR) {
+        LOGW("VA-API zero-copy unavailable: could not import DMA-BUF as "
+             "EGLImage (EGL error %#x)", vaapi->EglGetError());
+        for (unsigned i = 0; i < 2; ++i) {
+            if (images[i] != EGL_NO_IMAGE_KHR) {
+                vaapi->DestroyImageKHR(vaapi->display, images[i]);
+            }
+        }
+        av_frame_free(&drm_frame);
+        return false;
+    }
+
+    SDL_PropertiesID props = SDL_GetTextureProperties(texture);
+    unsigned int texture_y =
+        SDL_GetNumberProperty(props, vaapi->texture_prop, 0);
+    unsigned int texture_uv =
+        SDL_GetNumberProperty(props, vaapi->texture_uv_prop, 0);
+    if (!texture_y || !texture_uv) {
+        LOGW("VA-API zero-copy unavailable: SDL did not expose its NV12 "
+             "OpenGL textures");
+        vaapi->DestroyImageKHR(vaapi->display, images[0]);
+        vaapi->DestroyImageKHR(vaapi->display, images[1]);
+        av_frame_free(&drm_frame);
+        return false;
+    }
+
+    if (!SDL_FlushRenderer(renderer)) {
+        LOGD("Could not flush renderer before DMA-BUF import: %s",
+             SDL_GetError());
+    }
+    while (vaapi->GetError()) {
+        // Clear errors left by the renderer before checking our GL calls.
+    }
+    vaapi->BindTexture(SC_GL_TEXTURE_2D, texture_y);
+    vaapi->EGLImageTargetTexture2DOES(SC_GL_TEXTURE_2D, images[0]);
+    vaapi->BindTexture(SC_GL_TEXTURE_2D, texture_uv);
+    vaapi->EGLImageTargetTexture2DOES(SC_GL_TEXTURE_2D, images[1]);
+    vaapi->BindTexture(SC_GL_TEXTURE_2D, 0);
+    unsigned int gl_error = vaapi->GetError();
+    if (gl_error) {
+        LOGW("VA-API zero-copy unavailable: could not attach EGLImages to "
+             "the SDL texture (GL error %#x)", gl_error);
+        vaapi->DestroyImageKHR(vaapi->display, images[0]);
+        vaapi->DestroyImageKHR(vaapi->display, images[1]);
+        av_frame_free(&drm_frame);
+        return false;
+    }
+
+    sc_vaapi_destroy_images(vaapi);
+    av_frame_free(&vaapi->drm_frame);
+    vaapi->images[0] = images[0];
+    vaapi->images[1] = images[1];
+    vaapi->drm_frame = drm_frame;
+    return true;
+}

--- a/app/src/vaapi.h
+++ b/app/src/vaapi.h
@@ -1,0 +1,48 @@
+#ifndef SC_VAAPI_H
+#define SC_VAAPI_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+// Use the EGL definitions bundled with SDL, so that no external EGL
+// development package is required
+#define SDL_USE_BUILTIN_OPENGL_DEFINITIONS
+#include <SDL3/SDL_egl.h>
+#include <SDL3/SDL.h>
+#include <libavutil/frame.h>
+
+struct sc_vaapi {
+    EGLDisplay display;
+    PFNEGLCREATEIMAGEKHRPROC CreateImageKHR;
+    PFNEGLDESTROYIMAGEKHRPROC DestroyImageKHR;
+    PFNEGLGETERRORPROC EglGetError;
+    void (*BindTexture)(unsigned int target, unsigned int texture);
+    void (*EGLImageTargetTexture2DOES)(unsigned int target, void *image);
+    unsigned int (*GetError)(void);
+
+    EGLImageKHR images[2];
+    AVFrame *drm_frame;
+
+    const char *texture_prop;
+    const char *texture_uv_prop;
+    bool has_modifiers;
+};
+
+bool
+sc_vaapi_init(struct sc_vaapi *vaapi, SDL_Renderer *renderer,
+              const char **unavailable_reason);
+
+void
+sc_vaapi_destroy(struct sc_vaapi *vaapi);
+
+void
+sc_vaapi_reset(struct sc_vaapi *vaapi);
+
+bool
+sc_vaapi_set_frame(struct sc_vaapi *vaapi, SDL_Renderer *renderer,
+                   SDL_Texture *texture, const AVFrame *frame);
+
+bool
+sc_vaapi_set_nv12_rg_shader(bool enabled);
+
+#endif

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -49,6 +49,7 @@ static void test_options(void) {
         "--video-bit-rate", "5M",
         "--crop", "100:200:300:400",
         "--fullscreen",
+        "--no-hardware-decoding",
         "--max-fps", "30",
         "--max-size", "1024",
         // "--no-control" is not compatible with "--turn-screen-off"
@@ -77,6 +78,7 @@ static void test_options(void) {
     assert(opts->video_bit_rate == 5000000);
     assert(!strcmp(opts->crop, "100:200:300:400"));
     assert(opts->fullscreen);
+    assert(!opts->hardware_decoding);
     assert(!strcmp(opts->max_fps, "30"));
     assert(opts->max_size == 1024);
     assert(opts->port_range.first == 1234);

--- a/doc/build.md
+++ b/doc/build.md
@@ -55,7 +55,8 @@ sudo apt install ffmpeg libsdl3-0 adb libusb-1.0-0
 # client build dependencies
 sudo apt install gcc git pkg-config meson ninja-build libsdl3-dev \
                  libavcodec-dev libavdevice-dev libavformat-dev libavutil-dev \
-                 libswresample-dev libusb-1.0-0-dev libv4l-dev
+                 libswresample-dev libusb-1.0-0-dev libv4l-dev libegl-dev \
+                 libdrm-dev libva-dev
 
 # server build dependencies
 sudo apt install openjdk-17-jdk
@@ -77,7 +78,8 @@ pip3 install meson
 sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
 
 # client build dependencies
-sudo dnf install SDL3-devel ffms2-devel libusb1-devel libavdevice-free-devel meson gcc make
+sudo dnf install SDL3-devel ffms2-devel libusb1-devel libavdevice-free-devel \
+                 libdrm-devel libglvnd-devel libva-devel meson gcc make
 
 # server build dependencies
 sudo dnf install java-devel

--- a/doc/video.md
+++ b/doc/video.md
@@ -97,6 +97,32 @@ check `--video-codec-options` in the manpage or in `scrcpy --help`.
 [`MediaFormat`]: https://developer.android.com/reference/android/media/MediaFormat
 
 
+## Hardware decoding
+
+scrcpy automatically uses the platform video decoding API when it is available:
+
+ - VA-API on Linux. Decoded NV12 surfaces are imported into the SDL OpenGL
+   renderer through DMA-BUF and EGL without a copy through system memory. This
+   requires the renderer to use EGL: this is the case on Wayland, but on X11
+   SDL uses GLX by default (set `SDL_VIDEO_FORCE_EGL=1` to switch to EGL).
+ - D3D11 on Windows. FFmpeg decodes with the SDL renderer's D3D11 device, then
+   copies each decoded surface into the render texture entirely on the GPU.
+ - VideoToolbox on macOS. The decoded `CVPixelBuffer` is imported directly by
+   the SDL Metal renderer without a copy through system memory.
+
+If hardware decoding or native-surface rendering is unavailable, scrcpy falls
+back to software decoding or a system-memory transfer. Hardware decoding may
+be disabled explicitly:
+
+```bash
+scrcpy --no-hardware-decoding
+```
+
+The feature is enabled by default. On Linux, EGL and libdrm development files
+are also required. It may be disabled at build time with
+`-Dhardware_decoding=disabled`.
+
+
 ## Encoder
 
 Several encoders may be available on the device. They can be listed by:

--- a/doc/video.md
+++ b/doc/video.md
@@ -56,7 +56,8 @@ scrcpy -b 2M                     # short version
 
 ## Frame rate
 
-The capture frame rate can be limited:
+By default, the capture frame rate is limited to 60 fps. To configure a
+different limit:
 
 ```bash
 scrcpy --max-fps=15

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,4 +5,5 @@ option('portable', type: 'boolean', value: false, description: 'Use scrcpy-serve
 option('static', type: 'boolean', value: false, description: 'Use static dependencies')
 option('server_debugger', type: 'boolean', value: false, description: 'Run a server debugger and wait for a client to be attached')
 option('v4l2', type: 'boolean', value: true, description: 'Enable V4L2 feature when supported')
+option('hardware_decoding', type: 'feature', value: 'enabled', description: 'Enable platform hardware video decoding')
 option('usb', type: 'boolean', value: true, description: 'Enable HID/OTG features when supported')

--- a/release/build_linux.sh
+++ b/release/build_linux.sh
@@ -21,10 +21,11 @@ app/deps/libusb.sh linux native static
 
 DEPS_INSTALL_DIR="$PWD/app/deps/work/install/linux-native-static"
 ADB_INSTALL_DIR="$PWD/app/deps/work/install/adb-linux"
+SYSTEM_PKG_CONFIG_LIBDIR="$(pkg-config --variable pc_path pkg-config)"
 
-# Never fall back to system libs
+# Prefer the bundled dependencies, but keep system graphics APIs available.
 unset PKG_CONFIG_PATH
-export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="$DEPS_INSTALL_DIR/lib/pkgconfig:$SYSTEM_PKG_CONFIG_LIBDIR"
 
 rm -rf "$LINUX_BUILD_DIR"
 meson setup "$LINUX_BUILD_DIR" \

--- a/server/src/main/java/com/genymobile/scrcpy/Options.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Options.java
@@ -35,7 +35,7 @@ public class Options {
     private boolean audioDup;
     private int videoBitRate = 8000000;
     private int audioBitRate = 128000;
-    private float maxFps;
+    private float maxFps = 60;
     private float angle;
     private boolean tunnelForward;
     private Rect crop;


### PR DESCRIPTION
https://github.com/libsdl-org/SDL/pull/8366/commits was used as a reference and tested on linux-x86_64, win64, winarm64, macos-x86_64, macos-aarch64.

Target device: Galaxy S25
linux-x86_64-1: Intel Core Ultra X7 358H on Ubuntu 26.04 (Wayland, GNOME)
linux-x86_64-2: Intel Atom E3950 on Ubuntu 24.04 (KDE, X11)
win64: AMD Ryzen 5 5600G
winarm64: Xiaomi Mi Pad 5
macos-x86_64: AMD Ryzen 5 5600G (OpenCore)
macos-aarch64: Apple M3 Pro (Mac15,7)

| Platform        | Before | After | Improvement |
| --------------- | -----: | ----: | ----------: |
| linux-x86_64-1 |  48.5% |  3.0% |       93.8% |
| linux-x86_64-1 | 120.0% | 16.7% |       86.1% |
| win64           | 103.2% |  3.6% |       96.5% |
| winarm64        | 112.0% |  8.0% |       92.9% |
| macos-x86_64    | 120.0% | 10.8% |       91.0% |
| macos-aarch64   |  50.2% | 19.8% |       60.6% |

On Windows, CPU usage reported by Task Manager (arm64) or TMX was multiplied by the number of cores for consistencies with other platforms.

This is additionally tested on following devices with both H264 and H265 encoders (when available by the device):
OnePlus 3T (ONEPLUS A3003) - Snapdragon 821
OnePlus 5 (ONEPLUS A5000) - Snapdragon 835
OnePlus 6 (ONEPLUS A6003) - Snapdragon 845
Samsung Galaxy A03s (SM-A037U) - MediaTek Helio P35
UMIDIGI Power 7 (UMIDIGI MP06) - Unisoc Tiger T610
Samsung Galaxy A Quantum (SM-A716S) - Exynos 980
OnePlus 8T (KB2003) - Snapdragon 865
Samsung Galaxy S20+ 5G (SM-G986N) - Snapdragon 865
Samsung Galaxy M32 5G (SM-M326B) - MediaTek Dimensity 720
OnePlus 9 Pro (OnePlus 9 Pro) - Snapdragon 888
Samsung Galaxy S21+ 5G (SM-G996N) - Exynos 2100
Samsung Galaxy Quantum3 (SM-M536S) - MediaTek Dimensity 900
DOOGEE N50 Pro (DOOGEE N50Pro) - Unisoc Tiger T606
ASUS Zenfone 9 (ASUS_AI2202) - Snapdragon 8+ Gen 1
Nothing Phone (2a) (Nothing A142) - MediaTek Dimensity 7200 Pro
Samsung Galaxy A55 5G (SM-A556E) - Exynos 1480
Samsung Galaxy S25 Edge (SM-S937N) - Snapdragon 8 Elite for Galaxy
Samsung Galaxy S25+ (SM-S936N) - Snapdragon 8 Elite for Galaxy

Assisted-by: Codex:gpt-5.6-sol