### PR TITLE
deps: limit build threads to processor count instead

### DIFF
--- a/app/deps/_init
+++ b/app/deps/_init
@@ -42,6 +42,8 @@ process_args() {
     fi
 }
 
+NPROC=$(getconf _NPROCESSORS_ONLN)
+
 DEPS_DIR=$(dirname ${BASH_SOURCE[0]})
 cd "$DEPS_DIR"
 

--- a/app/deps/ffmpeg.sh
+++ b/app/deps/ffmpeg.sh
@@ -141,5 +141,5 @@ else
     "$SOURCES_DIR/$PROJECT_DIR"/configure "${conf[@]}"
 fi
 
-make -j
+make -j"$NPROC"
 make install

--- a/app/deps/libusb.sh
+++ b/app/deps/libusb.sh
@@ -62,5 +62,5 @@ else
     "$SOURCES_DIR/$PROJECT_DIR"/configure "${conf[@]}"
 fi
 
-make -j
+make -j"$NPROC"
 make install-strip

--- a/app/deps/sdl.sh
+++ b/app/deps/sdl.sh
@@ -81,5 +81,5 @@ else
     cmake "$SOURCES_DIR/$PROJECT_DIR" "${conf[@]}"
 fi
 
-cmake --build . -j
+cmake --build . -j"$NPROC"
 cmake --install .


### PR DESCRIPTION
Plain "-j" unbounds process creation.

This was hit in build-macos-aarch64 GitHub workflow: clang: error: unable to execute command: posix_spawn failed: Resource temporarily unavailable