### PR TITLE
Call `IContentProvider.call()` directly through a compile-only stub

### DIFF
--- a/server-hidden-api/build.gradle
+++ b/server-hidden-api/build.gradle
@@ -1,0 +1,9 @@
+apply plugin: 'com.android.library'
+
+android {
+    namespace = 'com.genymobile.scrcpy.hiddenapi'
+    compileSdk = 36
+    defaultConfig {
+        minSdkVersion 21
+    }
+}

--- a/server-hidden-api/src/main/AndroidManifest.xml
+++ b/server-hidden-api/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest />

--- a/server-hidden-api/src/main/java/android/content/IContentProvider.java
+++ b/server-hidden-api/src/main/java/android/content/IContentProvider.java
@@ -1,0 +1,17 @@
+package android.content;
+
+import android.os.Bundle;
+import android.os.IInterface;
+import android.os.RemoteException;
+
+// android.content.IContentProvider is hidden, this is a fake one to expose the type to the project
+public interface IContentProvider extends IInterface {
+
+    Bundle call(AttributionSource attributionSource, String authority, String method, String arg, Bundle extras) throws RemoteException;
+
+    Bundle call(String callingPackage, String attributionTag, String authority, String method, String arg, Bundle extras) throws RemoteException;
+
+    Bundle call(String callingPackage, String authority, String method, String arg, Bundle extras) throws RemoteException;
+
+    Bundle call(String callingPackage, String method, String arg, Bundle extras) throws RemoteException;
+}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -26,6 +26,7 @@ android {
 }
 
 dependencies {
+    compileOnly project(':server-hidden-api')
     testImplementation 'junit:junit:4.13.2'
 }
 

--- a/server/build_without_gradle.sh
+++ b/server/build_without_gradle.sh
@@ -21,8 +21,10 @@ BUILD_TOOLS_DIR="$ANDROID_HOME/build-tools/$BUILD_TOOLS"
 
 BUILD_DIR="$(realpath ${BUILD_DIR:-build_manual})"
 CLASSES_DIR="$BUILD_DIR/classes"
+HIDDEN_API_CLASSES_DIR="$BUILD_DIR/hidden-api-classes"
 GEN_DIR="$BUILD_DIR/gen"
-SERVER_DIR=$(dirname "$0")
+SERVER_DIR="$(cd "$(dirname "$0")" && pwd)"
+HIDDEN_API_SRC="$SERVER_DIR/../server-hidden-api/src/main/java"
 SERVER_BINARY=scrcpy-server
 ANDROID_JAR="$PLATFORM_TOOLS/android.jar"
 ANDROID_AIDL="$PLATFORM_TOOLS/framework.aidl"
@@ -32,8 +34,9 @@ echo "Platform: android-$PLATFORM"
 echo "Build-tools: $BUILD_TOOLS"
 echo "Build dir: $BUILD_DIR"
 
-rm -rf "$CLASSES_DIR" "$GEN_DIR" "$BUILD_DIR/$SERVER_BINARY" classes.dex
+rm -rf "$CLASSES_DIR" "$HIDDEN_API_CLASSES_DIR" "$GEN_DIR" "$BUILD_DIR/$SERVER_BINARY" classes.dex
 mkdir -p "$CLASSES_DIR"
+mkdir -p "$HIDDEN_API_CLASSES_DIR"
 mkdir -p "$GEN_DIR/com/genymobile/scrcpy"
 
 << EOF cat > "$GEN_DIR/com/genymobile/scrcpy/BuildConfig.java"
@@ -52,9 +55,10 @@ cd "$SERVER_DIR/src/main/aidl"
 "$BUILD_TOOLS_DIR/aidl" -o"$GEN_DIR" -I. -p "$ANDROID_AIDL" \
     android/view/IDisplayWindowListener.aidl
 
-# Fake sources to expose hidden Android types to the project
-FAKE_SRC=( \
-    android/content/*java \
+GEN_SRC=( \
+    "$GEN_DIR/com/genymobile/scrcpy/BuildConfig.java" \
+    "$GEN_DIR/android/content/IOnPrimaryClipChangedListener.java" \
+    "$GEN_DIR/android/view/IDisplayWindowListener.java" \
 )
 
 SRC=( \
@@ -76,13 +80,19 @@ do
     CLASSES+=("${src%.java}.class")
 done
 
+echo "Compiling hidden API stubs..."
+javac -encoding UTF-8 -bootclasspath "$ANDROID_JAR" \
+    -d "$HIDDEN_API_CLASSES_DIR" \
+    -source 1.8 -target 1.8 \
+    "$HIDDEN_API_SRC/android/content/IContentProvider.java"
+
 echo "Compiling java sources..."
 cd ../java
 javac -encoding UTF-8 -bootclasspath "$ANDROID_JAR" \
-    -cp "$LAMBDA_JAR:$GEN_DIR" \
+    -cp "$LAMBDA_JAR:$GEN_DIR:$HIDDEN_API_CLASSES_DIR" \
     -d "$CLASSES_DIR" \
     -source 1.8 -target 1.8 \
-    ${FAKE_SRC[@]} \
+    "${GEN_SRC[@]}" \
     ${SRC[@]}
 
 echo "Dexing..."
@@ -93,7 +103,7 @@ then
     # use dx
     "$BUILD_TOOLS_DIR/dx" --dex --output "$BUILD_DIR/classes.dex" \
         android/view/*.class \
-        android/content/*.class \
+        android/content/IOnPrimaryClipChangedListener*.class \
         ${CLASSES[@]}
 
     echo "Archiving..."
@@ -103,15 +113,16 @@ then
 else
     # use d8
     "$BUILD_TOOLS_DIR/d8" --classpath "$ANDROID_JAR" \
+        --classpath "$HIDDEN_API_CLASSES_DIR" \
         --output "$BUILD_DIR/classes.zip" \
         android/view/*.class \
-        android/content/*.class \
+        android/content/IOnPrimaryClipChangedListener*.class \
         ${CLASSES[@]}
 
     cd "$BUILD_DIR"
     mv classes.zip "$SERVER_BINARY"
 fi
 
-rm -rf "$GEN_DIR" "$CLASSES_DIR"
+rm -rf "$GEN_DIR" "$CLASSES_DIR" "$HIDDEN_API_CLASSES_DIR"
 
 echo "Server generated in $BUILD_DIR/$SERVER_BINARY"

--- a/server/src/main/java/android/content/IContentProvider.java
+++ b/server/src/main/java/android/content/IContentProvider.java
@@ -1,5 +1,0 @@
-package android.content;
-
-public interface IContentProvider {
-    // android.content.IContentProvider is hidden, this is a fake one to expose the type to the project
-}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/ContentProvider.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/ContentProvider.java
@@ -6,13 +6,13 @@ import com.genymobile.scrcpy.util.Ln;
 import com.genymobile.scrcpy.util.SettingsException;
 
 import android.annotation.SuppressLint;
-import android.content.AttributionSource;
+import android.content.IContentProvider;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
+import android.os.RemoteException;
 
 import java.io.Closeable;
-import java.lang.reflect.Method;
 
 public final class ContentProvider implements Closeable {
 
@@ -33,16 +33,20 @@ public final class ContentProvider implements Closeable {
 
     private static final String NAME_VALUE_TABLE_VALUE = "value";
 
+    private static final int CALL_METHOD_VERSION_UNKNOWN = -1;
+    private static final int CALL_METHOD_VERSION_ATTRIBUTION_SOURCE = 0;
+    private static final int CALL_METHOD_VERSION_ATTRIBUTION_TAG = 1;
+    private static final int CALL_METHOD_VERSION_AUTHORITY = 2;
+    private static final int CALL_METHOD_VERSION_LEGACY = 3;
+
     private final ActivityManager manager;
-    // android.content.IContentProvider
-    private final Object provider;
+    private final IContentProvider provider;
     private final String name;
     private final IBinder token;
 
-    private Method callMethod;
-    private int callMethodVersion;
+    private int callMethodVersion = CALL_METHOD_VERSION_UNKNOWN;
 
-    ContentProvider(ActivityManager manager, Object provider, String name, IBinder token) {
+    ContentProvider(ActivityManager manager, IContentProvider provider, String name, IBinder token) {
         this.manager = manager;
         this.provider = provider;
         this.name = name;
@@ -50,54 +54,44 @@ public final class ContentProvider implements Closeable {
     }
 
     @SuppressLint("PrivateApi")
-    private Method getCallMethod() throws NoSuchMethodException {
-        if (callMethod == null) {
-            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12) {
-                callMethod = provider.getClass().getMethod("call", AttributionSource.class, String.class, String.class, String.class, Bundle.class);
-                callMethodVersion = 0;
-            } else {
-                // old versions
-                try {
-                    callMethod = provider.getClass()
-                            .getMethod("call", String.class, String.class, String.class, String.class, String.class, Bundle.class);
-                    callMethodVersion = 1;
-                } catch (NoSuchMethodException e1) {
-                    try {
-                        callMethod = provider.getClass().getMethod("call", String.class, String.class, String.class, String.class, Bundle.class);
-                        callMethodVersion = 2;
-                    } catch (NoSuchMethodException e2) {
-                        callMethod = provider.getClass().getMethod("call", String.class, String.class, String.class, Bundle.class);
-                        callMethodVersion = 3;
-                    }
-                }
-            }
-        }
-        return callMethod;
-    }
-
-    private Bundle call(String callMethod, String arg, Bundle extras) throws ReflectiveOperationException {
+    private Bundle call(String callMethod, String arg, Bundle extras) throws RemoteException {
         try {
-            Method method = getCallMethod();
-            Object[] args;
+            switch (callMethodVersion) {
+                case CALL_METHOD_VERSION_ATTRIBUTION_SOURCE:
+                    return provider.call(FakeContext.get().getAttributionSource(), "settings", callMethod, arg, extras);
+                case CALL_METHOD_VERSION_ATTRIBUTION_TAG:
+                    return provider.call(FakeContext.PACKAGE_NAME, null, "settings", callMethod, arg, extras);
+                case CALL_METHOD_VERSION_AUTHORITY:
+                    return provider.call(FakeContext.PACKAGE_NAME, "settings", callMethod, arg, extras);
+                case CALL_METHOD_VERSION_LEGACY:
+                    return provider.call(FakeContext.PACKAGE_NAME, callMethod, arg, extras);
+                default:
+                    break;
+            }
 
-            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12 && callMethodVersion == 0) {
-                args = new Object[]{FakeContext.get().getAttributionSource(), "settings", callMethod, arg, extras};
-            } else {
-                switch (callMethodVersion) {
-                    case 1:
-                        args = new Object[]{FakeContext.PACKAGE_NAME, null, "settings", callMethod, arg, extras};
-                        break;
-                    case 2:
-                        args = new Object[]{FakeContext.PACKAGE_NAME, "settings", callMethod, arg, extras};
-                        break;
-                    default:
-                        args = new Object[]{FakeContext.PACKAGE_NAME, callMethod, arg, extras};
-                        break;
+            if (Build.VERSION.SDK_INT >= AndroidVersions.API_31_ANDROID_12) {
+                Bundle result = provider.call(FakeContext.get().getAttributionSource(), "settings", callMethod, arg, extras);
+                callMethodVersion = CALL_METHOD_VERSION_ATTRIBUTION_SOURCE;
+                return result;
+            }
+
+            try {
+                Bundle result = provider.call(FakeContext.PACKAGE_NAME, null, "settings", callMethod, arg, extras);
+                callMethodVersion = CALL_METHOD_VERSION_ATTRIBUTION_TAG;
+                return result;
+            } catch (NoSuchMethodError e) {
+                try {
+                    Bundle result = provider.call(FakeContext.PACKAGE_NAME, "settings", callMethod, arg, extras);
+                    callMethodVersion = CALL_METHOD_VERSION_AUTHORITY;
+                    return result;
+                } catch (NoSuchMethodError e2) {
+                    Bundle result = provider.call(FakeContext.PACKAGE_NAME, callMethod, arg, extras);
+                    callMethodVersion = CALL_METHOD_VERSION_LEGACY;
+                    return result;
                 }
             }
-            return (Bundle) method.invoke(provider, args);
-        } catch (ReflectiveOperationException e) {
-            Ln.e("Could not invoke method", e);
+        } catch (RemoteException | RuntimeException | LinkageError e) {
+            Ln.e("Could not call content provider", e);
             throw e;
         }
     }
@@ -142,7 +136,7 @@ public final class ContentProvider implements Closeable {
                 return null;
             }
             return bundle.getString("value");
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             throw new SettingsException(table, "get", key, null, e);
         }
 
@@ -155,7 +149,7 @@ public final class ContentProvider implements Closeable {
         arg.putString(NAME_VALUE_TABLE_VALUE, value);
         try {
             call(method, key, arg);
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             throw new SettingsException(table, "put", key, value, e);
         }
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include ':server'
+include ':server-hidden-api'


### PR DESCRIPTION
Closes #7010  
Related to [#6492](https://github.com/Genymobile/scrcpy/issues/6492)

## Summary

This change replaces reflection in the settings `ContentProvider` wrapper with typed calls to the hidden framework interface `android.content.IContentProvider`.

The local framework declaration is moved to a new `server-hidden-api` module and referenced by the server with `compileOnly`. It is therefore available during compilation but is not defined in the final server DEX. The non-Gradle build follows the same rule by compiling hidden API stubs into a separate classpath directory.

This PR is intentionally limited to one hidden interface and one call site. Reflection used for private framework members and unrelated wrappers is unchanged.

## Implementation

`ActivityManager` already returned an `IContentProvider`, but `ContentProvider` stored it as `Object`, found one of four `call()` overloads with `getMethod()`, assembled an `Object[]`, and invoked the selected `Method` reflectively.

The provider now remains strongly typed:

```java
private final IContentProvider provider;
```

The compile-only stub declares the same four overloads that the reflection code previously searched for. Android 12 and later use the `AttributionSource` signature. Older systems preserve the existing runtime fallback order:

```text
calling package + attribution tag + authority
    -> calling package + authority
        -> calling package only
```

This is intentionally capability-based rather than a strict `SDK_INT` mapping so that the existing behavior remains available for older or vendor-modified frameworks. Once an overload succeeds, its version is cached on the `ContentProvider` instance and subsequent calls on that provider reuse it.

Representative definitions in the official Android source:

- Android 12: [`AttributionSource` signature, lines 123-124](https://cs.android.com/android/platform/superproject/+/android-12.0.0_r1:frameworks/base/core/java/android/content/IContentProvider.java;drc=cebf5c06997b64f4e47a1611edb5f97044509d76;l=123)
- Android 11: [attribution-tag signature, lines 118-119](https://cs.android.com/android/platform/superproject/+/android-11.0.0_r1:frameworks/base/core/java/android/content/IContentProvider.java;drc=34a1b9c951c38537ab96b69bc308f6e0884823f5;l=118)
- Android 10: [authority signature, lines 82-83](https://cs.android.com/android/platform/superproject/+/android-10.0.0_r1:frameworks/base/core/java/android/content/IContentProvider.java;drc=57bb140be9e48cf08acba131f7463e461777bb8e;l=82)
- Android 9: [legacy signature, lines 60-62](https://cs.android.com/android/platform/superproject/+/android-9.0.0_r1:frameworks/base/core/java/android/content/IContentProvider.java;drc=6549309f6c473b792ec62d1aebadec62bcf07827;l=60)

## Compile-only packaging

The stub is needed to compile direct method references, but its runtime definition must be supplied by the Android framework:

```gradle
compileOnly project(':server-hidden-api')
```

The resulting DEX contains references to `IContentProvider` and its `call()` methods, but no `android.content.IContentProvider` class definition. `app_process` resolves those references against the framework class from the boot class path.

For `build_without_gradle.sh`, hidden API stubs are compiled into `hidden-api-classes`. That directory is used only on the javac and D8 classpaths, while actual server and generated AIDL classes remain in the program classes directory passed to D8.

## Exception handling

Removing reflection changes which failures are visible. The new catches preserve the old public behavior while retaining the real direct-call cause:

| Failure | Purpose and behavior |
| --- | --- |
| `NoSuchMethodError` | A missing intermediate pre-Android 12 overload selects the next historical signature. A missing final overload is not recovered. |
| `RemoteException` | Represents the checked Binder communication failure declared by `IContentProvider.call()`. |
| `RuntimeException` | Preserves framework failures such as `SecurityException`, which are exposed directly instead of being wrapped by `Method.invoke()`. |
| `LinkageError` | Reports a final incompatibility between the compile-time stub and runtime framework, such as `NoSuchMethodError`, `IllegalAccessError`, or `IncompatibleClassChangeError`. |

Only `NoSuchMethodError` around the two intermediate old-signature calls triggers fallback. Other linkage failures are logged and propagated without being treated as an Android-version difference.

The private wrapper logs direct invocation failures without changing their type:

```java
catch (RemoteException | RuntimeException | LinkageError e) {
    Ln.e("Could not call content provider", e);
    throw e;
}
```

At the public boundary, `getValue()` and `putValue()` continue to report `SettingsException`, with the direct failure retained as the cause. `LinkageError` is listed separately because it is an `Error`, not an `Exception`:

```java
catch (Exception | LinkageError e) {
    throw new SettingsException(..., e);
}
```

## Verification

Completed locally:

- [x] `git diff --check`
- [x] `./gradlew :server-hidden-api:check`
- [x] `./gradlew :server:check`
- [x] `./gradlew :server:assembleDebug`
- [x] `./gradlew :server:assembleRelease`
- [x] Debug build through `server/scripts/build-wrapper.sh`
- [x] Manual build through `server/build_without_gradle.sh` with Android platform 36 and build-tools 36.0.0
- [x] Unit tests, checkstyle, and Android lint
- [x] Debug and Release duplicate-class checks
- [x] D8 packaging
- [x] Release DEX contains `IContentProvider` references but no `IContentProvider` class definition

### Runtime compatibility

The settings `ContentProvider` path was tested against these Android Emulator system images:

- Android 5.0.2 (API 21), 5.1.1 (API 22), 6 (API 23), 7 (API 24), 7.1.1 (API 25), 8 (API 26), 8.1 (API 27), and 9 (API 28);
- Android 10 (API 29) and Android 11 (API 30);
- Android 12 (API 31), 12L (API 32), 13 (API 33), 14 (API 34), 15 (API 35), 16 (API 36), and 17 (API 37).

| Runtime API | Successful `IContentProvider.call()` signature |
| --- | --- |
| API 21-28 | calling package only |
| API 29 | calling package + authority |
| API 30 | calling package + attribution tag + authority |
| API 31-37 | `AttributionSource` |

For every image, the GET and PUT operations used by `--show-touches`, `--stay-awake`, and `--screen-off-timeout` completed successfully and the settings were restored after exit. No uncaught `NoSuchMethodError`, `LinkageError`, `RemoteException`, or `Could not call content provider` failure was observed.

After restoring the per-provider signature cache, signature selection and subsequent cache reuse were revalidated on Android 9, 10, 11, and 12, covering all four overload branches.

This matrix covers Android Emulator images only. Vendor-modified ROMs may change this part of the framework, so affected physical devices will still need observation. The runtime fallback for older signatures is retained for that reason.

## AI assistance

AI assistance was used for the runtime testing workflow and for drafting this PR description. The test procedure, test results, and final PR text were manually reviewed and verified.
