### PR TITLE
Request source refresh rate for mirrored displays

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/display/DisplayInfo.java
+++ b/server/src/main/java/com/genymobile/scrcpy/display/DisplayInfo.java
@@ -10,10 +10,12 @@ public final class DisplayInfo {
     private final int flags;
     private final int dpi;
     private final String uniqueId;
+    private final float refreshRate;
 
     public static final int FLAG_SUPPORTS_PROTECTED_BUFFERS = 0x00000001;
 
-    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags, int dpi, String uniqueId) {
+    @SuppressWarnings("checkstyle:ParameterNumber")
+    public DisplayInfo(int displayId, Size size, int rotation, int layerStack, int flags, int dpi, String uniqueId, float refreshRate) {
         this.displayId = displayId;
         this.size = size;
         this.rotation = rotation;
@@ -21,6 +23,7 @@ public final class DisplayInfo {
         this.flags = flags;
         this.dpi = dpi;
         this.uniqueId = uniqueId;
+        this.refreshRate = refreshRate;
     }
 
     public int getDisplayId() {
@@ -49,5 +52,9 @@ public final class DisplayInfo {
 
     public String getUniqueId() {
         return uniqueId;
+    }
+
+    public float getRefreshRate() {
+        return refreshRate;
     }
 }

--- a/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/ScreenCapture.java
@@ -131,7 +131,7 @@ public class ScreenCapture extends SurfaceCapture {
 
         try {
             virtualDisplay = ServiceManager.getDisplayManager()
-                    .createVirtualDisplay("scrcpy", inputSize.getWidth(), inputSize.getHeight(), displayId, surface);
+                    .createVirtualDisplay("scrcpy", inputSize.getWidth(), inputSize.getHeight(), displayId, surface, displayInfo.getRefreshRate());
             Ln.d("Display: using DisplayManager API");
         } catch (Exception displayManagerException) {
             if (Build.BRAND.equalsIgnoreCase("oculus") && Build.MODEL.toLowerCase(Locale.ROOT).startsWith("quest")) {

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayManager.java
@@ -11,6 +11,8 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.hardware.display.VirtualDisplay;
+import android.hardware.display.VirtualDisplayConfig;
+import android.os.Build;
 import android.os.Handler;
 import android.view.Display;
 import android.view.Surface;
@@ -82,7 +84,7 @@ public final class DisplayManager {
         int density = Integer.parseInt(m.group(5));
         int layerStack = Integer.parseInt(m.group(6));
 
-        return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, density, null);
+        return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, density, null, 0);
     }
 
     private static DisplayInfo getDisplayInfoFromDumpsysDisplay(int displayId) {
@@ -139,6 +141,12 @@ public final class DisplayManager {
             int layerStack = cls.getDeclaredField("layerStack").getInt(displayInfo);
             int flags = cls.getDeclaredField("flags").getInt(displayInfo);
             int dpi = cls.getDeclaredField("logicalDensityDpi").getInt(displayInfo);
+            float refreshRate;
+            try {
+                refreshRate = (float) cls.getMethod("getRefreshRate").invoke(displayInfo);
+            } catch (ReflectiveOperationException e) {
+                refreshRate = 0;
+            }
             String uniqueId;
             try {
                 uniqueId = (String) cls.getDeclaredField("uniqueId").get(displayInfo);
@@ -146,7 +154,7 @@ public final class DisplayManager {
                 // This field might not exist: <https://github.com/Genymobile/scrcpy/issues/6461>
                 uniqueId = null;
             }
-            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, dpi, uniqueId);
+            return new DisplayInfo(displayId, new Size(width, height), rotation, layerStack, flags, dpi, uniqueId, refreshRate);
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
@@ -168,7 +176,24 @@ public final class DisplayManager {
         return createVirtualDisplayMethod;
     }
 
-    public VirtualDisplay createVirtualDisplay(String name, int width, int height, int displayIdToMirror, Surface surface) throws Exception {
+    public VirtualDisplay createVirtualDisplay(String name, int width, int height, int displayIdToMirror, Surface surface, float sourceRefreshRate)
+            throws Exception {
+        // High-refresh mirrored virtual displays default to 60Hz if no refresh rate is requested.
+        if (Math.round(sourceRefreshRate) > 60 && Build.VERSION.SDK_INT >= AndroidVersions.API_34_ANDROID_14) {
+            Constructor<android.hardware.display.DisplayManager> ctor = android.hardware.display.DisplayManager.class.getDeclaredConstructor(
+                    Context.class);
+            ctor.setAccessible(true);
+            android.hardware.display.DisplayManager dm = ctor.newInstance(FakeContext.get());
+
+            VirtualDisplayConfig.Builder builder = new VirtualDisplayConfig.Builder(name, width, height, 1)
+                    .setFlags(android.hardware.display.DisplayManager.VIRTUAL_DISPLAY_FLAG_AUTO_MIRROR)
+                    .setSurface(surface)
+                    .setRequestedRefreshRate(sourceRefreshRate);
+            Method setDisplayIdToMirror = builder.getClass().getMethod("setDisplayIdToMirror", int.class);
+            setDisplayIdToMirror.invoke(builder, displayIdToMirror);
+            return dm.createVirtualDisplay(builder.build());
+        }
+
         Method method = getCreateVirtualDisplayMethod();
         return (VirtualDisplay) method.invoke(null, name, width, height, displayIdToMirror, surface);
     }


### PR DESCRIPTION
## Summary

On some Android 14+ devices, a mirrored virtual display created through the legacy `DisplayManager.createVirtualDisplay()` API defaults to 60Hz even when the physical display is currently running at a higher refresh rate.

This makes the encoder receive at most about 60 frames per second. Passing `--max-fps=120` does not help, because `--max-fps` is only an encoder-side limiter.

This change:

- reads the current refresh rate of the source display;
- requests that same rate through `VirtualDisplayConfig.setRequestedRefreshRate()` for mirrored displays above 60Hz on Android 14+;
- keeps the existing virtual-display creation path for Android versions below 14, 60Hz displays, and cases where the refresh rate cannot be read.

`--max-fps` keeps its existing semantics and is not used to select the virtual display refresh rate.

## Motivation

Test device:

- HONOR AAK-AN00
- Android 16
- physical display running at 120.00001Hz
- scrcpy 4.1 macOS arm64 client

Before this change, the mirrored scrcpy virtual display was created at 60Hz. After requesting the source refresh rate, `dumpsys display` reports:

```text
source renderFrameRate=120.00001
scrcpy renderFrameRate=120.00001
mRequestedRefreshRate=120.00001
```

Packet timestamps from a 15-second recording while scrolling showed a peak one-second bin of 116 frames, instead of being capped around 60.

## Compatibility and limiter behavior

The legacy path is preserved for a 60Hz source (reported as `60.000004` on the test device):

```text
source renderFrameRate=60.000004
scrcpy renderFrameRate=60.0
mRequestedRefreshRate=0.0
```

With a 120Hz source and `--max-fps=60`, the virtual display remains at 120Hz while the encoded recording is limited to a peak one-second bin of 60 frames:

```text
source renderFrameRate=120.00001
scrcpy renderFrameRate=120.00001
mRequestedRefreshRate=120.00001
```

## Difference from #5505

#5505 added an arbitrary refresh-rate setting for new displays and connected it to `max_fps`. This PR only affects mirroring, automatically uses the refresh rate reported by the source display, and does not add a user-facing option or change `--max-fps` behavior.

Related: #5622

## Tests

- `server/build_without_gradle.sh`
- `./gradlew -p server check`
- Android 16 device test with a 120Hz source display
- Android 16 device test with a 60Hz source display
- Android 16 device test with a 120Hz source and `--max-fps=60`
