### PR TITLE
Mention VP8 and VP9 in doc/video.md

### DIFF
--- a/doc/video.md
+++ b/doc/video.md
@@ -79,12 +79,14 @@ your device, you should not get more than 24 frames per second in scrcpy.
 ## Codec
 
 The video codec can be selected. The possible values are `h264` (default),
-`h265` and `av1`:
+`h265`, `av1`, `vp8` and `vp9`:
 
 ```bash
 scrcpy --video-codec=h264  # default
 scrcpy --video-codec=h265
 scrcpy --video-codec=av1
+scrcpy --video-codec=vp8
+scrcpy --video-codec=vp9
 ```
 
 H265 may provide better quality, but H264 should provide lower latency.


### PR DESCRIPTION
Fixes #7009

VP8 and VP9 video codecs are supported since scrcpy 4.1 (8ced1325), and are already documented in the manpage, in `scrcpy --help` and in `doc/develop.md`, but the *Codec* section of `doc/video.md` still only listed `h264`, `h265` and `av1`.

This adds both codecs to the list and to the examples.

Verified with scrcpy 4.1 on a TCL Smart TV Pro (Android 12): `--list-encoders` reports `c2.android.vp8.encoder` and `c2.android.vp9.encoder`, and `scrcpy --video-codec=vp8 --record out.mkv` / `--video-codec=vp9` produce valid VP8 / VP9 recordings.
