### PR TITLE
Stop the repeating capture request on camera stop

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
+++ b/server/src/main/java/com/genymobile/scrcpy/video/CameraCapture.java
@@ -357,6 +357,14 @@ public class CameraCapture extends SurfaceCapture {
     public void stop() {
         cameraHandler.post(() -> {
             assertCameraThread();
+            if (currentSession != null) {
+                try {
+                    currentSession.stopRepeating();
+                } catch (CameraAccessException | IllegalStateException e) {
+                    // The session may already be closed (for example if the camera has been disconnected)
+                    Ln.d("Could not stop repeating capture request: " + e.getMessage());
+                }
+            }
             currentSession = null;
             requestBuilder = null;
             started = false;


### PR DESCRIPTION
When the camera capture is stopped, the `CameraDevice` is closed while the repeating capture request is still active. This has two visible consequences.

**1. A spurious warning at the end of every camera session**

```
[server] DEBUG: Controller stopped
[server] WARN: Camera capture failed: frame 176
[server] DEBUG: Screen streaming stopped
```

The frames still in flight when the device is closed are reported through `CaptureCallback.onCaptureFailed()` with `REASON_ERROR`, one warning per in-flight frame (5 warnings in high speed mode on my device). Related to #7012 (this does not address the repeated failures reported there *during* streaming, only the ones printed when the capture stops).

**2. In high speed mode, the server is always killed instead of terminating properly**

```
[server] DEBUG: Controller stopped
WARN: Killing the server...
```

With `--camera-high-speed`, `CameraDevice.close()` does not return within the 1 second watchdog delay of the client (`WATCHDOG_DELAY` in `app/src/server.c`), so the client kills the server. I instrumented `release()`: "closing camera device" is logged, "camera device closed" never is.

## Fix

Stop the repeating request (on the camera thread, like every other access to `currentSession`) before the device is closed. `IllegalStateException` is caught because the session may already be closed (camera disconnected).

With this change, no capture failure is reported anymore, and `CameraDevice.close()` returns in less than 100 ms in both modes.

I also tried the alternatives before settling on this one:
- filtering `onCaptureFailed()` once the capture is stopped removes the warning but not the hang in high speed mode;
- `abortCaptures()` alone also makes the close fast, but still reports the in-flight frames as failed (`REASON_FLUSHED`);
- `stopRepeating()` alone fixes both, so it is the only change.

## Test

Pixel 7 Pro (Android 16, build CP1A.260305.018), scrcpy 4.1 client with a server built from this branch (`SCRCPY_SERVER_PATH`):

```
scrcpy --video-source=camera --camera-id=0 -m1024 --no-window --no-audio --record out.mkv --time-limit 5
scrcpy --video-source=camera --camera-id=0 --camera-high-speed --camera-size=1280x720 --camera-fps=120 --no-window --no-audio --record out.mkv --time-limit 5
```

- before (4.1 release server, and unmodified `dev` server): `Camera capture failed: frame N` at the end of every session (1 time in regular mode, 5 times in high speed mode), and `Killing the server...` in high speed mode;
- after: no warning, no kill, complete recordings (regular mode: 30 fps at 1024x768; high speed mode: 120 fps at 1280x720), on 2 consecutive sessions in each mode.

Only tested on this device, but the mechanism (closing the device with an active repeating request) is not device-specific.
