### PR TITLE
Power on the device for a new virtual display

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
+++ b/server/src/main/java/com/genymobile/scrcpy/control/Controller.java
@@ -227,9 +227,28 @@ public class Controller implements AsyncProcessor, VirtualDisplayListener {
     }
 
     private void control() throws IOException {
-        // on start, power on the device
-        if (!camera && powerOn && displayId == 0 && !Device.isScreenOn(displayId)) {
-            Device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, displayId, Device.INJECT_MODE_ASYNC);
+        // on start, power on the device (only for the main display, or for a new virtual display, which is not rendered while the device
+        // is asleep)
+        boolean mayPowerOn = !camera && powerOn && (displayId == 0 || displayId == Device.DISPLAY_ID_NONE);
+        int powerOnDisplayId = Device.DISPLAY_ID_NONE;
+        if (mayPowerOn) {
+            if (displayId != Device.DISPLAY_ID_NONE) {
+                powerOnDisplayId = displayId;
+            } else {
+                try {
+                    // Wait for at most 1 second until the virtual display id is known
+                    DisplayData data = waitDisplayData(1000);
+                    if (data != null) {
+                        powerOnDisplayId = data.virtualDisplayId;
+                    }
+                } catch (InterruptedException e) {
+                    // do nothing
+                }
+            }
+        }
+        // Consistent with pressBackOrTurnScreenOn(): check (and inject POWER on) the virtual display id
+        if (powerOnDisplayId != Device.DISPLAY_ID_NONE && !Device.isScreenOn(powerOnDisplayId)) {
+            Device.pressReleaseKeycode(KeyEvent.KEYCODE_POWER, powerOnDisplayId, Device.INJECT_MODE_ASYNC);
 
             // dirty hack
             // After POWER is injected, the device is powered on asynchronously.


### PR DESCRIPTION
Fixes #6974

## Problem

With `--new-display`, if the device is asleep when scrcpy starts, the virtual display is never rendered on Android 17: the client receives no video frame at all (a `--record` file stays empty) until the device is woken up manually.

On Android 16 (Pixel 7 Pro, CP1A.260305.018), creating the virtual display was enough to wake the device up by itself: `mWakefulness` went from `Dozing` to `Awake`, with the main screen staying off, and the virtual display was rendered. On Android 17 (same device, CP2A.260705.006), the device stays in `Dozing`, and a virtual display is not rendered in that state.

scrcpy never powered on the device for `--new-display`: the power-on on start only applies to the main display (`displayId == 0`), and a new virtual display has `displayId == DISPLAY_ID_NONE`. Nobody noticed because Android did it by itself until now.

`--keep-active` does not help here: `userActivity()` cannot wake up a dozing device (it does keep it awake once it is awake, see the tests below).

## Fix

Also power on the device on start when a new virtual display is requested, consistently with `pressBackOrTurnScreenOn()`: wait for the virtual display id (`waitDisplayData()`, as already done for UHID and `--start-app`), check `Device.isScreenOn()` on the virtual display id, and inject `POWER` on it only if it reports the screen off.

- On Android 17, the virtual display reports `isScreenOn() == false` while the device is dozing, so `POWER` is injected and the device wakes up (this is what right-clicking on the virtual display already does).
- On Android versions/devices where creating the virtual display wakes the device up by itself (Android 16 on my device), the virtual display is already interactive when checked, so nothing is injected and the behavior is unchanged.
- `--no-power-on` disables it, as for the main display.
- `--turn-screen-off` is handled after the wake up (existing 500 ms delay), so the physical screen is turned off right after (SurfaceFlinger reports `powerMode=Off` for the physical display while the virtual display keeps rendering), which is what the reporter of #6974 wants.
- Secondary physical displays (`--display-id=N`) are still excluded, as in f08a6d86.

## Tests

Pixel 7 Pro, scrcpy 4.1 client with a server built from this branch (`SCRCPY_SERVER_PATH`). Before each run the device is put to sleep (`adb shell input keyevent KEYCODE_SLEEP`), `mWakefulness` is read from `dumpsys power` during the session, and touch events are injected on the virtual display (`adb shell input -d <id> swipe ...`) so that the recording only contains frames if the display is actually rendered. `stay_on_while_plugged_in` was set to 0 for the 50 s runs (the device is on a wireless charger), and `screen_off_timeout` is 30 s.

Android 17 (CP2A.260705.006), current version of the PR:

| scenario | before | after |
|---|---|---|
| `--new-display=1280x720/200` from sleep | stays `Dozing`, no frame at all | `Awake`, rendered (14 s of frames with injected swipes) |
| `--new-display=1280x720/200 --turn-screen-off` from sleep | stays `Dozing`, no frame | `Awake`, physical display `powerMode=Off`, virtual display rendered |
| `--new-display=1280x720/200 --keep-active` from sleep | stays `Dozing`, no frame | `Awake`, rendered |
| `--new-display=1280x720/200 --no-power-on` from sleep | stays `Dozing`, no frame | unchanged (stays `Dozing`, no frame) |
| main display (no `--new-display`) from sleep | wakes up | wakes up (no regression) |

Longer sessions (50 s, no input between t+5 s and t+45 s) with the fix:

| scenario | result |
|---|---|
| `--new-display --turn-screen-off --keep-active` from sleep | `Awake` for the whole session, physical display off, still rendered at t+45 s (2 runs) |
| `--new-display --keep-active` from sleep | `Awake` for the whole session, still rendered at t+45 s (3 runs) |
| `--new-display --turn-screen-off` from sleep | falls back to `Dozing` after the 30 s screen timeout, virtual display frozen |
| `--new-display` from awake | same: `Dozing` after 30 s, virtual display frozen |

So the second symptom of #6974 (the virtual display goes black when the device goes to sleep) is Android behavior: a virtual display is not rendered while the device is dozing. The working recipe on Android 17 is `--new-display --turn-screen-off --keep-active` (with this fix), and this could be worth a note in `doc/virtual-display.md` if you agree.
