### PR TITLE
Move codec opening from demuxer to decoder

### DIFF
--- a/app/src/decoder.c
+++ b/app/src/decoder.c
@@ -10,23 +10,42 @@
 #define DOWNCAST(SINK) container_of(SINK, struct sc_decoder, packet_sink)
 
 static bool
-sc_decoder_open(struct sc_decoder *decoder, AVCodecContext *ctx,
+sc_decoder_open(struct sc_decoder *decoder, const AVCodec *codec,
+                const AVCodecParameters *params,
                 const struct sc_stream_session *session) {
-    decoder->frame = av_frame_alloc();
-    if (!decoder->frame) {
+    // A video stream must have a session
+    assert(session || codec->type != AVMEDIA_TYPE_VIDEO);
+
+    decoder->ctx = avcodec_alloc_context3(codec);
+    if (!decoder->ctx) {
         LOG_OOM();
         return false;
     }
 
-    if (!sc_frame_source_sinks_open(&decoder->frame_source, ctx, session)) {
-        av_frame_free(&decoder->frame);
-        return false;
+    int r = avcodec_parameters_to_context(decoder->ctx, params);
+    if (r < 0) {
+        LOGE("Decoder '%s': could not set codec parameters", decoder->name);
+        goto error_free_context;
     }
 
-    decoder->ctx = ctx;
+    decoder->ctx->flags |= AV_CODEC_FLAG_LOW_DELAY;
 
-    // A video stream must have a session
-    assert(session || ctx->codec_type != AVMEDIA_TYPE_VIDEO);
+    r = avcodec_open2(decoder->ctx, codec, NULL);
+    if (r < 0) {
+        LOGE("Decoder '%s': could not open codec", decoder->name);
+        goto error_free_context;
+    }
+
+    decoder->frame = av_frame_alloc();
+    if (!decoder->frame) {
+        LOG_OOM();
+        goto error_free_context;
+    }
+
+    if (!sc_frame_source_sinks_open(&decoder->frame_source, decoder->ctx,
+                                    session)) {
+        goto error_free_frame;
+    }
 
     if (session) {
         decoder->session = *session;
@@ -35,12 +54,20 @@ sc_decoder_open(struct sc_decoder *decoder, AVCodecContext *ctx,
     memset(&decoder->frame_size, 0, sizeof(decoder->frame_size));
 
     return true;
+
+error_free_frame:
+    av_frame_free(&decoder->frame);
+error_free_context:
+    avcodec_free_context(&decoder->ctx);
+
+    return false;
 }
 
 static void
 sc_decoder_close(struct sc_decoder *decoder) {
     sc_frame_source_sinks_close(&decoder->frame_source);
     av_frame_free(&decoder->frame);
+    avcodec_free_context(&decoder->ctx);
 }
 
 static bool
@@ -117,10 +144,11 @@ sc_decoder_push_session(struct sc_decoder *decoder,
 }
 
 static bool
-sc_decoder_packet_sink_open(struct sc_packet_sink *sink, AVCodecContext *ctx,
+sc_decoder_packet_sink_open(struct sc_packet_sink *sink, const AVCodec *codec,
+                            const AVCodecParameters *params,
                             const struct sc_stream_session *session) {
     struct sc_decoder *decoder = DOWNCAST(sink);
-    return sc_decoder_open(decoder, ctx, session);
+    return sc_decoder_open(decoder, codec, params, session);
 }
 
 static void

--- a/app/src/demuxer.c
+++ b/app/src/demuxer.c
@@ -218,13 +218,14 @@ run_demuxer(void *data) {
         goto end;
     }
 
-    AVCodecContext *codec_ctx = avcodec_alloc_context3(codec);
-    if (!codec_ctx) {
+    AVCodecParameters *params = avcodec_parameters_alloc();
+    if (!params) {
         LOG_OOM();
         goto end;
     }
 
-    codec_ctx->flags |= AV_CODEC_FLAG_LOW_DELAY;
+    params->codec_type = codec->type;
+    params->codec_id = codec->id;
 
     uint8_t header[SC_PACKET_HEADER_SIZE];
     struct sc_stream_session session_data;
@@ -233,12 +234,12 @@ run_demuxer(void *data) {
     if (codec->type == AVMEDIA_TYPE_VIDEO) {
         bool ok = sc_demuxer_recv_header(demuxer, header);
         if (!ok) {
-            goto finally_free_context;
+            goto finally_free_params;
         }
 
         if (!sc_demuxer_is_session(header)) {
             LOGE("Unexpected packet (not a session header)");
-            goto finally_free_context;
+            goto finally_free_params;
         }
 
         session = &session_data;
@@ -247,37 +248,32 @@ run_demuxer(void *data) {
         if (!session_data.video.width || !session_data.video.height) {
             LOGE("Invalid session video size: %" PRIu32 "x%" PRIu32,
                  session_data.video.width, session_data.video.height);
-            goto finally_free_context;
+            goto finally_free_params;
         }
 
-        codec_ctx->width = session_data.video.width;
-        codec_ctx->height = session_data.video.height;
-        codec_ctx->pix_fmt = AV_PIX_FMT_YUV420P;
+        params->width = session_data.video.width;
+        params->height = session_data.video.height;
+        params->format = AV_PIX_FMT_YUV420P;
 
     } else {
         // Hardcoded audio properties
 #ifdef SCRCPY_LAVU_HAS_CHLAYOUT
-        codec_ctx->ch_layout = (AVChannelLayout) AV_CHANNEL_LAYOUT_STEREO;
+        params->ch_layout = (AVChannelLayout) AV_CHANNEL_LAYOUT_STEREO;
 #else
-        codec_ctx->channel_layout = AV_CH_LAYOUT_STEREO;
-        codec_ctx->channels = 2;
+        params->channel_layout = AV_CH_LAYOUT_STEREO;
+        params->channels = 2;
 #endif
-        codec_ctx->sample_rate = 48000;
+        params->sample_rate = 48000;
 
         if (raw_codec_id == SC_CODEC_ID_FLAC) {
             // The sample_fmt is not set by the FLAC decoder
-            codec_ctx->sample_fmt = AV_SAMPLE_FMT_S16;
+            params->format = AV_SAMPLE_FMT_S16;
         }
     }
 
-    if (avcodec_open2(codec_ctx, codec, NULL) < 0) {
-        LOGE("Demuxer '%s': could not open codec", demuxer->name);
-        goto finally_free_context;
-    }
-
-    if (!sc_packet_source_sinks_open(&demuxer->packet_source, codec_ctx,
+    if (!sc_packet_source_sinks_open(&demuxer->packet_source, codec, params,
                                      session)) {
-        goto finally_free_context;
+        goto finally_free_params;
     }
 
     // Config packets must be merged with the next non-config packet only for
@@ -346,8 +342,8 @@ run_demuxer(void *data) {
     av_packet_free(&packet);
 finally_close_sinks:
     sc_packet_source_sinks_close(&demuxer->packet_source);
-finally_free_context:
-    avcodec_free_context(&codec_ctx);
+finally_free_params:
+    avcodec_parameters_free(&params);
 end:
     demuxer->cbs->on_ended(demuxer, status, demuxer->cbs_userdata);
 

--- a/app/src/recorder.c
+++ b/app/src/recorder.c
@@ -543,7 +543,8 @@ sc_recorder_set_orientation(AVStream *stream, enum sc_orientation orientation) {
 
 static bool
 sc_recorder_video_packet_sink_open(struct sc_packet_sink *sink,
-                                   AVCodecContext *ctx,
+                                   const AVCodec *codec,
+                                   const AVCodecParameters *params,
                                    const struct sc_stream_session *session) {
     (void) session;
 
@@ -557,13 +558,13 @@ sc_recorder_video_packet_sink_open(struct sc_packet_sink *sink,
         return false;
     }
 
-    AVStream *stream = avformat_new_stream(recorder->ctx, ctx->codec);
+    AVStream *stream = avformat_new_stream(recorder->ctx, codec);
     if (!stream) {
         sc_mutex_unlock(&recorder->mutex);
         return false;
     }
 
-    int r = avcodec_parameters_from_context(stream->codecpar, ctx);
+    int r = avcodec_parameters_copy(stream->codecpar, params);
     if (r < 0) {
         sc_mutex_unlock(&recorder->mutex);
         return false;
@@ -582,8 +583,8 @@ sc_recorder_video_packet_sink_open(struct sc_packet_sink *sink,
     }
 
     // A config packet is provided for all supported formats except VPx
-    recorder->video_expects_config_packet = ctx->codec_id != AV_CODEC_ID_VP8
-                                         && ctx->codec_id != AV_CODEC_ID_VP9;
+    recorder->video_expects_config_packet = codec->id != AV_CODEC_ID_VP8
+                                         && codec->id != AV_CODEC_ID_VP9;
 
     recorder->video_init = true;
     sc_cond_signal(&recorder->cond);
@@ -644,7 +645,8 @@ sc_recorder_video_packet_sink_push(struct sc_packet_sink *sink,
 
 static bool
 sc_recorder_audio_packet_sink_open(struct sc_packet_sink *sink,
-                                   AVCodecContext *ctx,
+                                   const AVCodec *codec,
+                                   const AVCodecParameters *params,
                                    const struct sc_stream_session *session) {
     (void) session;
 
@@ -655,13 +657,13 @@ sc_recorder_audio_packet_sink_open(struct sc_packet_sink *sink,
 
     sc_mutex_lock(&recorder->mutex);
 
-    AVStream *stream = avformat_new_stream(recorder->ctx, ctx->codec);
+    AVStream *stream = avformat_new_stream(recorder->ctx, codec);
     if (!stream) {
         sc_mutex_unlock(&recorder->mutex);
         return false;
     }
 
-    int r = avcodec_parameters_from_context(stream->codecpar, ctx);
+    int r = avcodec_parameters_copy(stream->codecpar, params);
     if (r < 0) {
         sc_mutex_unlock(&recorder->mutex);
         return false;
@@ -671,7 +673,7 @@ sc_recorder_audio_packet_sink_open(struct sc_packet_sink *sink,
 
     // A config packet is provided for all supported formats except raw audio
     recorder->audio_expects_config_packet =
-        ctx->codec_id != AV_CODEC_ID_PCM_S16LE;
+        codec->id != AV_CODEC_ID_PCM_S16LE;
 
     recorder->audio_init = true;
     sc_cond_signal(&recorder->cond);

--- a/app/src/trait/packet_sink.h
+++ b/app/src/trait/packet_sink.h
@@ -26,8 +26,8 @@ struct sc_stream_session {
 };
 
 struct sc_packet_sink_ops {
-    /* The codec context is valid until the sink is closed */
-    bool (*open)(struct sc_packet_sink *sink, AVCodecContext *ctx,
+    bool (*open)(struct sc_packet_sink *sink, const AVCodec *codec,
+                 const AVCodecParameters *params,
                  const struct sc_stream_session *session);
     void (*close)(struct sc_packet_sink *sink);
     bool (*push)(struct sc_packet_sink *sink, const AVPacket *packet);

--- a/app/src/trait/packet_source.c
+++ b/app/src/trait/packet_source.c
@@ -27,12 +27,13 @@ sc_packet_source_sinks_close_firsts(struct sc_packet_source *source,
 
 bool
 sc_packet_source_sinks_open(struct sc_packet_source *source,
-                            AVCodecContext *ctx,
+                            const AVCodec *codec,
+                            const AVCodecParameters *params,
                             const struct sc_stream_session *session) {
     assert(source->sink_count);
     for (unsigned i = 0; i < source->sink_count; ++i) {
         struct sc_packet_sink *sink = source->sinks[i];
-        if (!sink->ops->open(sink, ctx, session)) {
+        if (!sink->ops->open(sink, codec, params, session)) {
             sc_packet_source_sinks_close_firsts(source, i);
             return false;
         }

--- a/app/src/trait/packet_source.h
+++ b/app/src/trait/packet_source.h
@@ -28,7 +28,8 @@ sc_packet_source_add_sink(struct sc_packet_source *source,
 
 bool
 sc_packet_source_sinks_open(struct sc_packet_source *source,
-                            AVCodecContext *ctx,
+                            const AVCodec *codec,
+                            const AVCodecParameters *params,
                             const struct sc_stream_session *session);
 
 void


### PR DESCRIPTION
The `AVCodecContext` is a decoder concern. The codec was previously opened by the demuxer, even when no decoder existed (in recording-only mode).

Instead, make the demuxer only pass the codec and the stream parameters to its sinks. The decoder opens its own codec context from them, and the recorder copies them to its output streams.

(preliminary step for implementing hardware decoding properly from #7001)