### PR TITLE
Fix timeout startup race

### DIFF
--- a/app/src/util/timeout.c
+++ b/app/src/util/timeout.c
@@ -43,18 +43,18 @@ run_timeout(void *data) {
 bool
 sc_timeout_start(struct sc_timeout *timeout, sc_tick deadline,
                  const struct sc_timeout_callbacks *cbs, void *cbs_userdata) {
+    assert(cbs && cbs->on_timeout);
+
+    timeout->deadline = deadline;
+    timeout->cbs = cbs;
+    timeout->cbs_userdata = cbs_userdata;
+
     bool ok = sc_thread_create(&timeout->thread, run_timeout, "scrcpy-timeout",
                                timeout);
     if (!ok) {
         LOGE("Timeout: could not start thread");
         return false;
     }
-
-    timeout->deadline = deadline;
-
-    assert(cbs && cbs->on_timeout);
-    timeout->cbs = cbs;
-    timeout->cbs_userdata = cbs_userdata;
 
     return true;
 }


### PR DESCRIPTION


`sc_timeout_start()` created the timeout thread before initializing the data read by `run_timeout()`.

`SDL_CreateThread()` may start the worker before it returns, so `run_timeout()` could read `timeout->deadline` before it was assigned and access the callback fields before they were initialized. This creates a real startup race and could make `--time-limit` use an invalid deadline or callback state.



Validate the callback and initialize `deadline`, `cbs`, and `cbs_userdata` before creating the timeout thread.

This guarantees that the worker only starts after all data it needs has been initialized.

