### PR TITLE
Add --vsync option

### DIFF
--- a/app/data/bash-completion/scrcpy
+++ b/app/data/bash-completion/scrcpy
@@ -107,6 +107,7 @@ _scrcpy() {
         --video-codec-options=
         --video-encoder=
         --video-source=
+        --vsync
         -w --stay-awake
         --window-borderless
         --window-title=

--- a/app/data/zsh-completion/_scrcpy
+++ b/app/data/zsh-completion/_scrcpy
@@ -111,6 +111,7 @@ arguments=(
     '--video-codec-options=[Set a list of comma-separated key\:type=value options for the device video encoder]'
     '--video-encoder=[Use a specific MediaCodec video encoder]'
     '--video-source=[Select the video source]:source:(display camera)'
+    '--vsync[Enable vertical synchronization for the display renderer]'
     {-w,--stay-awake}'[Keep the device on while scrcpy is running, when the device is plugged in]'
     '--window-borderless[Disable window decorations \(display borderless window\)]'
     '--window-title=[Set a custom window title]'

--- a/app/scrcpy.1
+++ b/app/scrcpy.1
@@ -693,6 +693,12 @@ Camera mirroring requires Android 12+.
 Default is display.
 
 .TP
+.B \-\-vsync
+Enable vertical synchronization for the display renderer.
+
+This may increase latency.
+
+.TP
 .B \-w, \-\-stay-awake
 Keep the device on while scrcpy is running, when the device is plugged in.
 

--- a/app/src/cli.c
+++ b/app/src/cli.c
@@ -110,6 +110,7 @@ enum {
     OPT_BACKGROUND_COLOR,
     OPT_RENDER_FIT,
     OPT_IGNORE_VIDEO_ENCODER_CONSTRAINTS,
+    OPT_VSYNC,
     OPT_NO_TERMINAL_TITLE,
 };
 
@@ -1012,6 +1013,12 @@ static const struct sc_option options[] = {
         .text = "Select the video source (display or camera).\n"
                 "Camera mirroring requires Android 12+.\n"
                 "Default is display.",
+    },
+    {
+        .longopt_id = OPT_VSYNC,
+        .longopt = "vsync",
+        .text = "Enable vertical synchronization for the display renderer.\n"
+                "This may increase latency.",
     },
     {
         .shortopt = 'w',
@@ -2689,6 +2696,9 @@ parse_args_with_getopt(struct scrcpy_cli_args *args, int argc, char *argv[],
             }
             case OPT_RENDER_DRIVER:
                 opts->render_driver = optarg;
+                break;
+            case OPT_VSYNC:
+                opts->vsync = true;
                 break;
             case OPT_NO_MIPMAPS:
                 opts->mipmaps = false;

--- a/app/src/options.c
+++ b/app/src/options.c
@@ -89,6 +89,7 @@ const struct scrcpy_options scrcpy_options_default = {
     .window_aspect_ratio_lock = true,
     .window_borderless = false,
     .mipmaps = true,
+    .vsync = false,
     .stay_awake = false,
     .force_adb_forward = false,
     .disable_screensaver = false,

--- a/app/src/options.h
+++ b/app/src/options.h
@@ -308,6 +308,7 @@ struct scrcpy_options {
     bool window_aspect_ratio_lock;
     bool window_borderless;
     bool mipmaps;
+    bool vsync;
     bool stay_awake;
     bool force_adb_forward;
     bool disable_screensaver;

--- a/app/src/scrcpy.c
+++ b/app/src/scrcpy.c
@@ -780,6 +780,7 @@ aoa_complete:
             .render_fit = options->render_fit,
             .orientation = options->display_orientation,
             .mipmaps = options->mipmaps,
+            .vsync = options->vsync,
             .fullscreen = options->fullscreen,
             .start_fps_counter = options->start_fps_counter,
         };

--- a/app/src/screen.c
+++ b/app/src/screen.c
@@ -585,6 +585,10 @@ sc_screen_init(struct sc_screen *screen,
         goto error_destroy_window;
     }
 
+    if (params->vsync && !SDL_SetRenderVSync(screen->renderer, 1)) {
+        LOGW("Could not enable VSync: %s", SDL_GetError());
+    }
+
 #ifdef SC_DISPLAY_FORCE_OPENGL_CORE_PROFILE
     screen->gl_context = NULL;
 

--- a/app/src/screen.h
+++ b/app/src/screen.h
@@ -141,6 +141,7 @@ struct sc_screen_params {
     enum sc_render_fit render_fit;
     enum sc_orientation orientation;
     bool mipmaps;
+    bool vsync;
 
     bool fullscreen;
     bool start_fps_counter;

--- a/app/tests/test_cli.c
+++ b/app/tests/test_cli.c
@@ -67,6 +67,7 @@ static void test_options(void) {
         "--window-width", "600",
         "--window-height", "0",
         "--window-borderless",
+        "--vsync",
     };
 
     bool ok = scrcpy_parse_args(&args, ARRAY_LEN(argv), argv);
@@ -94,6 +95,7 @@ static void test_options(void) {
     assert(opts->window_width == 600);
     assert(opts->window_height == 0);
     assert(opts->window_borderless);
+    assert(opts->vsync);
 }
 
 static void test_options2(void) {


### PR DESCRIPTION
## Summary

Add a `--vsync` option to enable vertical synchronization for the SDL display renderer.

VSync remains disabled by default so the existing low-latency behavior is unchanged.

When `--vsync` is provided, scrcpy calls `SDL_SetRenderVSync()` after creating the renderer. If the renderer does not support enabling VSync, scrcpy logs a warning and continues.

The option is included in:

- CLI help and parsing
- bash completion
- zsh completion
- man page
- CLI parser tests

Fixes #7028

## Validation

Tested on macOS:

- scrcpy C client builds successfully with Meson/Ninja
- all 12 client unit tests pass
- built `scrcpy --help` exposes `--vsync`
- `git diff --check` passes
- no competing open PR for #7028 was found
